### PR TITLE
fix: auto-discover repos for github watcher when none configured

### DIFF
--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -311,7 +311,11 @@ pub fn to_buzz_config(ws: &WorkspaceConfig) -> buzz::config::BuzzConfig {
                 .map(|g| buzz::config::GithubWatcherConfig {
                     enabled: true,
                     interval_secs: g.interval_secs,
-                    repos: g.repos.clone(),
+                    repos: if g.repos.is_empty() {
+                        discover_repos(&ws.root)
+                    } else {
+                        g.repos.clone()
+                    },
                     watch_labels: vec![],
                 }),
             sentry: ws

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -152,9 +152,10 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             && gh_config.enabled
         {
             info!(
-                "[{}] enabling github watcher ({} repo(s))",
+                "[{}] github watcher: watching {} repo(s): {}",
                 ws.name,
-                gh_config.repos.len()
+                gh_config.repos.len(),
+                gh_config.repos.join(", ")
             );
             registry.add(Box::new(GithubWatcher::new(gh_config.clone())));
         }


### PR DESCRIPTION
## Summary
- When `repos = []` or the `repos` field is omitted in `[watchers.github]`, the GitHub watcher now auto-discovers all GitHub repos from the workspace root using the existing `discover_repos()` function
- Improved startup log to show exactly which repos are being watched (e.g. `[workspace] github watcher: watching 7 repo(s): ApiariTools/swarm, ApiariTools/apiari, ...`)
- Explicit `repos` config continues to work as before

## Test plan
- [ ] Configure `[watchers.github]` with `repos = []` and verify all workspace repos are discovered
- [ ] Configure `[watchers.github]` without a `repos` field and verify auto-discovery
- [ ] Configure `[watchers.github]` with explicit repos and verify only those are watched
- [ ] Verify startup log lists watched repos
- [ ] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)