### PR TITLE
fix: keep typing indicator active until response is fully sent

### DIFF
--- a/crates/hive/src/daemon/mod.rs
+++ b/crates/hive/src/daemon/mod.rs
@@ -1716,9 +1716,6 @@ impl DaemonRunner {
             )
             .await;
 
-            // Stop typing indicator.
-            typing_cancel.cancel();
-
             let outcome = match result {
                 Ok((final_text, session_id, turn_dispatches)) => {
                     // Extract buttons and dispatch blocks from the response.
@@ -1782,6 +1779,9 @@ impl DaemonRunner {
                     }
                 }
             };
+
+            // Stop typing indicator now that all messages have been sent.
+            typing_cancel.cancel();
 
             // Send result back to the main loop for state mutations.
             let _ = msg_done_tx.send(MessageResult {


### PR DESCRIPTION
## Summary
- The Telegram typing indicator was being cancelled right after the coordinator turn completed, but **before** the final response was sent to the user and dispatch blocks were processed
- Moved `typing_cancel.cancel()` to after all messages and dispatches are sent, so the typing indicator covers the full duration from message receipt to final response delivery
- The 👀 reaction on incoming messages was already implemented and working correctly

## Test plan
- [ ] Send a message to the bot via Telegram and verify the typing indicator persists until the full response appears
- [ ] Verify the 👀 reaction still appears immediately on incoming messages
- [ ] `cargo check -p hive` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)