### PR TITLE
fix: use valid Telegram reaction emoji and parse API errors

### DIFF
--- a/crates/apiari/src/buzz/channel/telegram.rs
+++ b/crates/apiari/src/buzz/channel/telegram.rs
@@ -158,11 +158,9 @@ impl TelegramChannel {
                 warn!("setMessageReaction failed: {e}");
             }
             Ok(resp) => {
-                if let Ok(body) = resp.json::<TgResponse<serde_json::Value>>().await {
-                    if !body.ok {
-                        let desc = body.description.unwrap_or_default();
-                        warn!("setMessageReaction failed: {desc}");
-                    }
+                if let Ok(body) = resp.json::<TgResponse<serde_json::Value>>().await && !body.ok {
+                    let desc = body.description.unwrap_or_default();
+                    warn!("setMessageReaction failed: {desc}");
                 }
             }
         }

--- a/crates/apiari/src/buzz/channel/telegram.rs
+++ b/crates/apiari/src/buzz/channel/telegram.rs
@@ -153,8 +153,18 @@ impl TelegramChannel {
             .send()
             .await;
 
-        if let Err(e) = resp {
-            warn!("setMessageReaction failed: {e}");
+        match resp {
+            Err(e) => {
+                warn!("setMessageReaction failed: {e}");
+            }
+            Ok(resp) => {
+                if let Ok(body) = resp.json::<TgResponse<serde_json::Value>>().await {
+                    if !body.ok {
+                        let desc = body.description.unwrap_or_default();
+                        warn!("setMessageReaction failed: {desc}");
+                    }
+                }
+            }
         }
     }
 

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -522,7 +522,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                             }
 
                             if let Some(channel) = get_channel(slot, &telegram_channels) {
-                                channel.send_reaction(chat_id, message_id, "🧠").await;
+                                channel.send_reaction(chat_id, message_id, "👀").await;
 
                                 // Start typing indicator loop (expires after ~5s, so resend every 4s).
                                 let typing_cancel = CancellationToken::new();


### PR DESCRIPTION
## Summary
- Change reaction emoji from 🧠 to 👀 — the brain emoji is not in Telegram's allowed set for `setMessageReaction`, causing silent failures.
- Add response body parsing to `send_reaction` so API-level rejections (`ok: false`) are logged via `warn!()`, matching the error handling pattern used by other methods in the file.

## Test plan
- [x] `cargo check -p apiari` passes
- [ ] Deploy and verify reactions appear on incoming Telegram messages
- [ ] Trigger an invalid reaction to confirm warning is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)