### PR TITLE
fix: keep Telegram typing indicator active for full coordinator processing

### DIFF
--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -28,6 +28,7 @@ crossterm.workspace = true
 futures = "0.3"
 reqwest.workspace = true
 async-trait.workspace = true
+tokio-util = { version = "0.7", features = ["rt"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/apiari/src/buzz/channel/telegram.rs
+++ b/crates/apiari/src/buzz/channel/telegram.rs
@@ -13,6 +13,7 @@ use tracing::warn;
 const MAX_MESSAGE_LEN: usize = 4000;
 
 /// Telegram Bot API client.
+#[derive(Clone)]
 pub struct TelegramChannel {
     bot_token: String,
     client: reqwest::Client,

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -8,6 +8,7 @@ pub mod socket;
 use color_eyre::eyre::{Result, WrapErr};
 use std::collections::HashMap;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::git_safety::GitSafetyHooks;
@@ -521,8 +522,23 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                             }
 
                             if let Some(channel) = get_channel(slot, &telegram_channels) {
-                                channel.send_typing(chat_id, topic_id).await;
                                 channel.send_reaction(chat_id, message_id, "🧠").await;
+
+                                // Start typing indicator loop (expires after ~5s, so resend every 4s).
+                                let typing_cancel = CancellationToken::new();
+                                {
+                                    let typing_token = typing_cancel.clone();
+                                    let typing_channel = channel.clone();
+                                    tokio::spawn(async move {
+                                        loop {
+                                            typing_channel.send_typing(chat_id, topic_id).await;
+                                            tokio::select! {
+                                                _ = typing_token.cancelled() => break,
+                                                _ = tokio::time::sleep(std::time::Duration::from_secs(4)) => {}
+                                            }
+                                        }
+                                    });
+                                }
 
                                 let slot_name = slot.name.clone();
                                 let mut alerts: Vec<String> = Vec::new();
@@ -596,6 +612,9 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                         let _ = channel.send_message(&msg).await;
                                     }
                                 }
+
+                                // Stop typing indicator after all messages are sent.
+                                typing_cancel.cancel();
                             }
                         } else {
                             warn!("no workspace route for chat_id={chat_id} topic_id={topic_id:?}");


### PR DESCRIPTION
## Summary
- Telegram's typing indicator expires after ~5 seconds, but coordinator responses often take longer
- Ported the typing loop pattern from `hive/src/daemon/mod.rs`: spawns a background task that re-sends `sendChatAction(typing)` every 4 seconds using a `CancellationToken`
- The token is cancelled only after all response messages (alerts + final reply) are sent

## Changes
- `crates/apiari/Cargo.toml` — added `tokio-util` dependency
- `crates/apiari/src/buzz/channel/telegram.rs` — derived `Clone` on `TelegramChannel` (needed for the spawned typing task)
- `crates/apiari/src/daemon/mod.rs` — replaced single `send_typing` call with a cancellable loop

## Test plan
- [ ] Send a message to the bot that triggers a long coordinator response (>5s)
- [ ] Verify the typing indicator persists until the response arrives
- [ ] Verify short responses still show the indicator briefly and respond normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)