### PR TITLE
fix: add --force to reinstall command template

### DIFF
--- a/crates/apiari/src/init.rs
+++ b/crates/apiari/src/init.rs
@@ -48,6 +48,12 @@ prompt = """
 # token = "sntrys_..."
 # interval_secs = 120
 
+# [[commands]]
+# name = "reinstall"
+# script = "cargo install --force --path {root_str}/cli/crates/apiari 2>&1 && cargo install --force --path {root_str}/swarm 2>&1"
+# description = "Rebuild and install apiari and swarm binaries"
+# restart = true
+
 # [watchers.swarm]
 # state_path = "{swarm_state}"
 # interval_secs = 15


### PR DESCRIPTION
## Summary
- Added `--force` flag to the commented-out `[[commands]]` reinstall template in `apiari init` scaffolding, so new workspaces get the correct default
- Also applied the fix to the live `~/.config/apiari/workspaces/apiari.toml` config (out-of-repo, not in this PR)

## Context
The reinstall `[[commands]]` script completes in ~2 seconds because `cargo install` skips recompilation when the installed version number matches, even if source has changed. Adding `--force` ensures it always rebuilds from source.

## Changes
- `crates/apiari/src/init.rs` — Added a commented-out `[[commands]]` reinstall block with `--force` to the workspace template

## Test plan
- [ ] Run `cargo build -p apiari` to verify compilation
- [ ] Run `apiari init` in a temp directory and verify the generated TOML includes the `--force` reinstall command template

🤖 Generated with [Claude Code](https://claude.com/claude-code)