### PR TITLE
feat: add self-memory-update capability to coordinator

### DIFF
--- a/crates/apiari/src/buzz/coordinator/audit.rs
+++ b/crates/apiari/src/buzz/coordinator/audit.rs
@@ -62,7 +62,7 @@ pub fn classify_bash_command(command: &str) -> BashClassification {
 
     // Check each pattern
     for &pattern in WRITE_PATTERNS {
-        if contains_pattern(trimmed, pattern) && !all_targets_tmp(trimmed, pattern) {
+        if contains_pattern(trimmed, pattern) && !all_targets_allowed(trimmed, pattern) {
             return BashClassification::PotentiallyMutating {
                 matched_pattern: pattern.to_string(),
             };
@@ -80,14 +80,14 @@ pub fn classify_bash_command(command: &str) -> BashClassification {
 
     // Output redirects: > and >> (but not 2> which is stderr)
     // Check for echo/cat/printf writing to files
-    if has_file_redirect(trimmed) && !redirect_targets_tmp(trimmed) {
+    if has_file_redirect(trimmed) && !redirect_targets_allowed(trimmed) {
         return BashClassification::PotentiallyMutating {
             matched_pattern: "output redirect".to_string(),
         };
     }
 
     // tee (writes to files)
-    if contains_pattern(trimmed, "tee ") && !all_targets_tmp(trimmed, "tee ") {
+    if contains_pattern(trimmed, "tee ") && !all_targets_allowed(trimmed, "tee ") {
         return BashClassification::PotentiallyMutating {
             matched_pattern: "tee".to_string(),
         };
@@ -96,7 +96,7 @@ pub fn classify_bash_command(command: &str) -> BashClassification {
     // curl -o / -O / --output (downloads to file)
     if (contains_pattern(trimmed, "curl ") || contains_pattern(trimmed, "curl\t"))
         && has_curl_output_flag(trimmed)
-        && !curl_output_targets_tmp(trimmed)
+        && !curl_output_targets_allowed(trimmed)
     {
         return BashClassification::PotentiallyMutating {
             matched_pattern: "curl download".to_string(),
@@ -124,11 +124,28 @@ fn contains_pattern(command: &str, pattern: &str) -> bool {
     false
 }
 
-/// Check if the destination/target of a write command is under /tmp/.
+/// Check if a path is an allowed write target.
+///
+/// Allowed targets:
+/// - `/tmp/` — the coordinator needs this for swarm `--prompt-file`.
+/// - Claude Code project memory paths (`~/.claude/.../memory/`) — the
+///   coordinator is allowed to update its own persistent memory.
+fn is_allowed_write_target(path: &str) -> bool {
+    if path.starts_with("/tmp/") || path == "/tmp" {
+        return true;
+    }
+    // Claude Code project memory files.
+    // Matches: ~/.claude/.../memory/..., /Users/.../. claude/.../memory/..., $HOME/.claude/.../memory/...
+    let has_claude =
+        path.contains("/.claude/") || path.starts_with("~/.claude/") || path.contains("$HOME/.claude/");
+    has_claude && (path.contains("/memory/") || path.ends_with("/memory"))
+}
+
+/// Check if the destination/target of a write command is an allowed path.
 ///
 /// For commands like `cp`, `mv`, `tee`, the last non-flag argument is the destination.
-/// For others we check if any argument points to /tmp/.
-fn all_targets_tmp(command: &str, pattern: &str) -> bool {
+/// For others we check if any argument points to an allowed path.
+fn all_targets_allowed(command: &str, pattern: &str) -> bool {
     // Find the subcommand portion that matched
     let relevant = find_relevant_part(command, pattern);
     let parts: Vec<&str> = relevant.split_whitespace().collect();
@@ -145,15 +162,13 @@ fn all_targets_tmp(command: &str, pattern: &str) -> bool {
     // For cp/mv: destination is the last argument
     if pattern.starts_with("cp ") || pattern.starts_with("mv ") {
         if let Some(dest) = non_flag_args.last() {
-            return dest.starts_with("/tmp/") || *dest == "/tmp";
+            return is_allowed_write_target(dest);
         }
         return false;
     }
 
-    // For tee/touch/mkdir/chmod/etc: all targets must be /tmp/
-    non_flag_args
-        .iter()
-        .all(|p| p.starts_with("/tmp/") || *p == "/tmp")
+    // For tee/touch/mkdir/chmod/etc: all targets must be allowed
+    non_flag_args.iter().all(|p| is_allowed_write_target(p))
 }
 
 /// Find the relevant subcommand in a pipeline that matches the pattern.
@@ -186,14 +201,14 @@ fn has_file_redirect(command: &str) -> bool {
     false
 }
 
-/// Check if redirect targets are under /tmp/.
-fn redirect_targets_tmp(command: &str) -> bool {
+/// Check if redirect targets are allowed write paths.
+fn redirect_targets_allowed(command: &str) -> bool {
     // Find the part after > or >>
     if let Some(idx) = command.find('>') {
         let after = &command[idx..];
         // Skip > or >>
         let after = after.trim_start_matches('>').trim();
-        after.starts_with("/tmp/") || after.starts_with("/tmp")
+        is_allowed_write_target(after)
     } else {
         false
     }
@@ -207,12 +222,12 @@ fn has_curl_output_flag(command: &str) -> bool {
         .any(|p| *p == "-o" || *p == "-O" || *p == "--output" || p.starts_with("-o"))
 }
 
-/// Check if curl output target is /tmp/.
-fn curl_output_targets_tmp(command: &str) -> bool {
+/// Check if curl output target is an allowed write path.
+fn curl_output_targets_allowed(command: &str) -> bool {
     let parts: Vec<&str> = command.split_whitespace().collect();
     for (i, part) in parts.iter().enumerate() {
         if (*part == "-o" || *part == "--output") && i + 1 < parts.len() {
-            return parts[i + 1].starts_with("/tmp/");
+            return is_allowed_write_target(parts[i + 1]);
         }
     }
     false
@@ -385,6 +400,67 @@ mod tests {
             result,
             BashClassification::ReadOnly,
             "2> stderr redirect should not be flagged"
+        );
+    }
+
+    #[test]
+    fn test_claude_memory_exception_redirect() {
+        // Writing to Claude project memory is allowed (coordinator self-memory).
+        let result = classify_bash_command(
+            "echo '- New fact' >> /Users/josh/.claude/projects/-Users-josh-Developer-apiari/memory/MEMORY.md",
+        );
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "redirect to Claude memory should be ReadOnly"
+        );
+    }
+
+    #[test]
+    fn test_claude_memory_exception_tee() {
+        let result = classify_bash_command(
+            "echo 'fact' | tee -a /Users/josh/.claude/projects/-proj/memory/MEMORY.md",
+        );
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "tee to Claude memory should be ReadOnly"
+        );
+    }
+
+    #[test]
+    fn test_claude_memory_exception_tilde() {
+        let result = classify_bash_command(
+            "echo 'fact' >> ~/.claude/projects/-proj/memory/MEMORY.md",
+        );
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "redirect to ~/.claude memory should be ReadOnly"
+        );
+    }
+
+    #[test]
+    fn test_claude_memory_exception_mkdir() {
+        let result = classify_bash_command(
+            "mkdir -p /Users/josh/.claude/projects/-proj/memory",
+        );
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "mkdir for Claude memory dir should be ReadOnly"
+        );
+    }
+
+    #[test]
+    fn test_non_memory_claude_path_still_blocked() {
+        // Writing to other .claude paths (not /memory/) should still be blocked.
+        let result = classify_bash_command(
+            "echo 'bad' >> /Users/josh/.claude/projects/-proj/settings.json",
+        );
+        assert!(
+            result.is_mutating(),
+            "writing to non-memory .claude path should be mutating"
         );
     }
 }

--- a/crates/apiari/src/buzz/coordinator/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/mod.rs
@@ -176,26 +176,19 @@ impl Coordinator {
         let mut events = Vec::new();
 
         match event {
-            Event::Assistant {
-                message,
-                tool_uses,
-            } => {
+            Event::Assistant { message, tool_uses } => {
                 // Audit Bash tool uses
                 for tool_use in tool_uses {
                     if tool_use.name == "Bash"
-                        && let Some(command) = tool_use.input.get("command").and_then(|v| v.as_str())
+                        && let Some(command) =
+                            tool_use.input.get("command").and_then(|v| v.as_str())
                     {
                         let classification = audit::classify_bash_command(command);
                         match &classification {
                             audit::BashClassification::ReadOnly => {
-                                info!(
-                                    "[coordinator] bash (read-only): {}",
-                                    truncate_cmd(command)
-                                );
+                                info!("[coordinator] bash (read-only): {}", truncate_cmd(command));
                             }
-                            audit::BashClassification::PotentiallyMutating {
-                                matched_pattern,
-                            } => {
+                            audit::BashClassification::PotentiallyMutating { matched_pattern } => {
                                 warn!(
                                     "[coordinator] bash MUTATING ({}): {}",
                                     matched_pattern,
@@ -298,9 +291,6 @@ impl Coordinator {
 
 /// Truncate a command string for logging.
 fn truncate_cmd(cmd: &str) -> &str {
-    let end = cmd
-        .char_indices()
-        .nth(120)
-        .map_or(cmd.len(), |(i, _)| i);
+    let end = cmd.char_indices().nth(120).map_or(cmd.len(), |(i, _)| i);
     &cmd[..end]
 }

--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -26,7 +26,8 @@ pub fn default_preamble(name: &str) -> String {
            swarm status, curl APIs, sqlite3, ls, etc.).\n\
          - You must NEVER use Bash to modify the workspace: no creating/editing/deleting files, \
            no git add/commit/push, no curl -o/wget into repos, no echo/cat/sed writing to files. \
-           The ONLY write allowed is to /tmp/ (for swarm --prompt-file).\n\
+           The ONLY writes allowed are to /tmp/ (for swarm --prompt-file) and your persistent \
+           memory file (see Persistent Memory section if present).\n\
          - You CAN read code, investigate issues, check PR status, query signals, \
            and answer questions about the codebase.\n\
          - You already know your workspace context from this prompt. Do NOT use tools \
@@ -271,7 +272,7 @@ mod tests {
             "preamble missing 'no git add/commit/push'"
         );
         assert!(
-            preamble.contains("ONLY write allowed is to /tmp/"),
+            preamble.contains("ONLY writes allowed are to /tmp/"),
             "preamble missing '/tmp/ exception'"
         );
     }

--- a/crates/hive/src/daemon/mod.rs
+++ b/crates/hive/src/daemon/mod.rs
@@ -83,6 +83,25 @@ pub(crate) fn is_process_alive(pid: u32) -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// Claude Code project memory path
+// ---------------------------------------------------------------------------
+
+/// Compute the Claude Code project memory file path for a workspace.
+///
+/// Claude Code stores per-project memory at:
+///   `~/.claude/projects/<sanitized-path>/memory/MEMORY.md`
+/// where `<sanitized-path>` is the absolute workspace path with `/` replaced by `-`.
+fn claude_memory_path(workspace_root: &Path) -> PathBuf {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let sanitized = workspace_root
+        .to_string_lossy()
+        .replace('/', "-");
+    home.join(".claude/projects")
+        .join(sanitized)
+        .join("memory/MEMORY.md")
+}
+
+// ---------------------------------------------------------------------------
 // Public API: start / stop
 // ---------------------------------------------------------------------------
 
@@ -758,6 +777,30 @@ fn build_coordinator_prompt(workspace_root: &Path, bot_username: Option<&str>) -
         "When the user asks about Sentry issues or triage, check `.hive/last_sweep.md` for the latest sweep results. \
          This file is updated after each `/sweep` command and contains issue titles, severity, event counts, and links.\n",
     );
+
+    // Memory update instructions
+    let memory_path = claude_memory_path(workspace_root);
+    let memory_path_str = memory_path.display();
+    prompt.push_str("\n## Persistent Memory\n\n");
+    prompt.push_str(&format!(
+        "You have a persistent memory file at:\n  {memory_path_str}\n\n"
+    ));
+    prompt.push_str(&format!(
+        "You can read it with `cat` and update it using Bash, e.g.:\n\
+         ```\n\
+         echo '- New fact to remember' >> {memory_path_str}\n\
+         ```\n\n\
+         Update your memory when you learn something worth remembering across sessions:\n\
+         - User preferences and communication style\n\
+         - Project conventions or architectural decisions\n\
+         - Recurring patterns or solutions\n\
+         - Important context about repos, workflows, or team practices\n\n\
+         The file uses markdown. Append new entries as `- ` bullet points.\n\
+         Keep entries concise — this file is included in future system prompts.\n\
+         Read the file before writing to avoid duplicates.\n\
+         The user can also save notes directly via the /remember command.\n",
+    ));
+
     Ok(prompt)
 }
 
@@ -1500,6 +1543,7 @@ impl DaemonRunner {
             "remind" => self.handle_remind_command(chat_id, args).await,
             "reminders" => self.handle_reminders_command(chat_id, args).await,
             "sweep" => self.handle_sweep_command(chat_id).await,
+            "remember" => self.handle_remember_command(chat_id, args).await,
             "help" => {
                 let mut text = String::from(
                     "Commands:\n\
@@ -1512,6 +1556,7 @@ impl DaemonRunner {
                      /reminders — List pending reminders\n\
                      /reminders cancel <id> — Cancel a reminder\n\
                      /sweep — Run a Sentry sweep now\n\
+                     /remember <text> — Save a note to memory\n\
                      /help — Show this message",
                 );
                 // Append custom commands.
@@ -2674,6 +2719,49 @@ impl DaemonRunner {
     }
 
     /// Handle `/sweep` Telegram command — run a sweep on demand for the active workspace.
+    /// Handle /remember — append a note to the Claude Code project memory file.
+    async fn handle_remember_command(&mut self, chat_id: i64, args: &str) -> Result<()> {
+        let text = args.trim();
+        if text.is_empty() {
+            return self
+                .send(chat_id, "Usage: /remember <text to save>")
+                .await;
+        }
+
+        let memory_path = claude_memory_path(&self.active_ws().workspace_root);
+
+        // Ensure the memory directory exists.
+        if let Some(parent) = memory_path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                return self
+                    .send(chat_id, &format!("Failed to create memory directory: {e}"))
+                    .await;
+            }
+        }
+
+        // Append the entry (with a blank line before for clean markdown).
+        let entry = format!("\n- {text}\n");
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&memory_path)
+        {
+            Ok(mut f) => {
+                use std::io::Write;
+                if let Err(e) = f.write_all(entry.as_bytes()) {
+                    return self
+                        .send(chat_id, &format!("Failed to write to memory: {e}"))
+                        .await;
+                }
+                self.send(chat_id, &format!("Remembered: {text}")).await
+            }
+            Err(e) => {
+                self.send(chat_id, &format!("Failed to open memory file: {e}"))
+                    .await
+            }
+        }
+    }
+
     async fn handle_sweep_command(&mut self, chat_id: i64) -> Result<()> {
         let has_buzz = self.workspaces.iter().any(|ws| ws.buzz_slot.is_some());
 

--- a/crates/hive/src/daemon/mod.rs
+++ b/crates/hive/src/daemon/mod.rs
@@ -93,9 +93,7 @@ pub(crate) fn is_process_alive(pid: u32) -> bool {
 /// where `<sanitized-path>` is the absolute workspace path with `/` replaced by `-`.
 fn claude_memory_path(workspace_root: &Path) -> PathBuf {
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    let sanitized = workspace_root
-        .to_string_lossy()
-        .replace('/', "-");
+    let sanitized = workspace_root.to_string_lossy().replace('/', "-");
     home.join(".claude/projects")
         .join(sanitized)
         .join("memory/MEMORY.md")
@@ -2723,20 +2721,18 @@ impl DaemonRunner {
     async fn handle_remember_command(&mut self, chat_id: i64, args: &str) -> Result<()> {
         let text = args.trim();
         if text.is_empty() {
-            return self
-                .send(chat_id, "Usage: /remember <text to save>")
-                .await;
+            return self.send(chat_id, "Usage: /remember <text to save>").await;
         }
 
         let memory_path = claude_memory_path(&self.active_ws().workspace_root);
 
         // Ensure the memory directory exists.
-        if let Some(parent) = memory_path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                return self
-                    .send(chat_id, &format!("Failed to create memory directory: {e}"))
-                    .await;
-            }
+        if let Some(parent) = memory_path.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            return self
+                .send(chat_id, &format!("Failed to create memory directory: {e}"))
+                .await;
         }
 
         // Append the entry (with a blank line before for clean markdown).


### PR DESCRIPTION
## Summary
- Extends the bash audit validator to allow writes to Claude Code project memory paths (`~/.claude/.../memory/`) alongside the existing `/tmp/` exception
- Adds `/remember <text>` built-in Telegram command that directly appends to the memory file
- Adds a "Persistent Memory" section to the coordinator's system prompt with the computed memory file path and usage instructions
- Updates the default preamble to mention the memory write exception

## How it works
The coordinator can now update its memory in two ways:
1. **Autonomously** — via Bash (e.g. `echo '- fact' >> ~/.claude/.../memory/MEMORY.md`), enabled by the bash audit whitelist
2. **Explicitly** — user sends `/remember <text>` in Telegram, which appends directly to the file

## Test plan
- [x] All 608 existing tests pass (171 apiari + 437 hive)
- [x] New audit tests verify memory path exceptions for redirect, tee, tilde, mkdir
- [x] Non-memory `.claude/` paths still blocked (test_non_memory_claude_path_still_blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)