### PR TITLE
docs: update examples to show multiple repos in GitHub watcher config

### DIFF
--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -45,7 +45,7 @@ pub struct WorkspaceConfig {
     /// Absolute path to the workspace root.
     pub root: PathBuf,
 
-    /// Repository slugs (e.g. ["ApiariTools/swarm"]).
+    /// Repository slugs (e.g. ["ApiariTools/swarm", "ApiariTools/apiari"]).
     #[serde(default)]
     pub repos: Vec<String>,
 

--- a/crates/apiari/src/init.rs
+++ b/crates/apiari/src/init.rs
@@ -39,7 +39,7 @@ prompt = """
 {prompt_lines}"""
 
 # [watchers.github]
-# repos = ["owner/repo"]
+# repos = ["owner/repo1", "owner/repo2"]
 # interval_secs = 120
 
 # [watchers.sentry]


### PR DESCRIPTION
## Summary
- Updated doc comment in `config.rs` and init template in `init.rs` to show multiple repos in `[watchers.github]` examples
- Reflects that workspaces can watch more than one repository (e.g. both `ApiariTools/swarm` and `ApiariTools/apiari`)

## Notes
The main config change (`~/.config/apiari/workspaces/apiari.toml`) was applied directly outside the repo. This PR updates the in-repo documentation and template to match.

## Test plan
- [x] `cargo test -p apiari -- config::tests` passes (all 20 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)