### PR TITLE
feat: mirror Telegram conversations to TUI chat panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/crates/apiari/src/buzz/channel/telegram.rs
+++ b/crates/apiari/src/buzz/channel/telegram.rs
@@ -158,7 +158,9 @@ impl TelegramChannel {
                 warn!("setMessageReaction failed: {e}");
             }
             Ok(resp) => {
-                if let Ok(body) = resp.json::<TgResponse<serde_json::Value>>().await && !body.ok {
+                if let Ok(body) = resp.json::<TgResponse<serde_json::Value>>().await
+                    && !body.ok
+                {
                     let desc = body.description.unwrap_or_default();
                     warn!("setMessageReaction failed: {desc}");
                 }

--- a/crates/apiari/src/buzz/signal/store.rs
+++ b/crates/apiari/src/buzz/signal/store.rs
@@ -357,9 +357,9 @@ impl SignalStore {
         let now = Utc::now();
         let cutoff = (now - chrono::Duration::hours(24)).to_rfc3339();
 
-        let mut stmt = self.conn.prepare(
-            "SELECT created_at FROM signals WHERE workspace = ?1 AND created_at >= ?2",
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT created_at FROM signals WHERE workspace = ?1 AND created_at >= ?2")?;
         let timestamps: Vec<DateTime<Utc>> = stmt
             .query_map(params![self.workspace, cutoff], |row| {
                 let s: String = row.get(0)?;
@@ -412,9 +412,9 @@ impl SignalStore {
 
     /// Get watcher cursor timestamps for health checking.
     pub fn get_watcher_cursors(&self) -> Result<Vec<(String, String)>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT watcher, updated_at FROM watcher_cursors WHERE workspace = ?1",
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT watcher, updated_at FROM watcher_cursors WHERE workspace = ?1")?;
         let cursors = stmt
             .query_map(params![self.workspace], |row| {
                 Ok((row.get(0)?, row.get(1)?))
@@ -427,7 +427,11 @@ impl SignalStore {
     /// Returns `num_buckets` counts, each covering `bucket_minutes` minutes.
     /// Index 0 = oldest bucket, last index = most recent.
     /// Counts both created and updated signals (any event = activity).
-    pub fn count_signal_activity(&self, bucket_minutes: i64, num_buckets: usize) -> Result<Vec<u64>> {
+    pub fn count_signal_activity(
+        &self,
+        bucket_minutes: i64,
+        num_buckets: usize,
+    ) -> Result<Vec<u64>> {
         let now = Utc::now();
         let total_minutes = bucket_minutes * num_buckets as i64;
         let cutoff = (now - chrono::Duration::minutes(total_minutes)).to_rfc3339();
@@ -770,7 +774,12 @@ mod tests {
             .upsert_signal(&make_update("sentry", "sentry-1", "Bug 1", Severity::Error))
             .unwrap();
         store
-            .upsert_signal(&make_update("sentry", "sentry-2", "Bug 2", Severity::Warning))
+            .upsert_signal(&make_update(
+                "sentry",
+                "sentry-2",
+                "Bug 2",
+                Severity::Warning,
+            ))
             .unwrap();
         store
             .upsert_signal(&make_update("sentry", "sentry-3", "Bug 3", Severity::Info))
@@ -816,7 +825,12 @@ mod tests {
             .upsert_signal(&make_update("sentry", "sentry-1", "Bug 1", Severity::Error))
             .unwrap();
         store
-            .upsert_signal(&make_update("sentry", "sentry-2", "Bug 2", Severity::Warning))
+            .upsert_signal(&make_update(
+                "sentry",
+                "sentry-2",
+                "Bug 2",
+                Severity::Warning,
+            ))
             .unwrap();
 
         let current = vec!["sentry-1".to_string(), "sentry-2".to_string()];
@@ -853,7 +867,8 @@ mod tests {
             .unwrap();
         store
             .upsert_signal(
-                &make_update("a", "2", "second", Severity::Info).with_status(SignalStatus::Resolved),
+                &make_update("a", "2", "second", Severity::Info)
+                    .with_status(SignalStatus::Resolved),
             )
             .unwrap();
         store

--- a/crates/apiari/src/buzz/watcher/swarm.rs
+++ b/crates/apiari/src/buzz/watcher/swarm.rs
@@ -431,6 +431,9 @@ mod tests {
         )
         .unwrap();
         let signals = watcher.poll(&store).await.unwrap();
-        assert!(signals.is_empty(), "claude-tui waiting should be suppressed");
+        assert!(
+            signals.is_empty(),
+            "claude-tui waiting should be suppressed"
+        );
     }
 }

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -301,12 +301,15 @@ pub fn build_skill_context(
 /// Convert a WorkspaceConfig into a buzz BuzzConfig for watcher/coordinator use.
 pub fn to_buzz_config(ws: &WorkspaceConfig) -> crate::buzz::config::BuzzConfig {
     crate::buzz::config::BuzzConfig {
-        telegram: ws.telegram.as_ref().map(|t| crate::buzz::config::TelegramConfig {
-            bot_token: t.bot_token.clone(),
-            chat_id: t.chat_id,
-            topic_id: t.topic_id,
-            allowed_user_ids: t.allowed_user_ids.clone(),
-        }),
+        telegram: ws
+            .telegram
+            .as_ref()
+            .map(|t| crate::buzz::config::TelegramConfig {
+                bot_token: t.bot_token.clone(),
+                chat_id: t.chat_id,
+                topic_id: t.topic_id,
+                allowed_user_ids: t.allowed_user_ids.clone(),
+            }),
         watchers: crate::buzz::config::WatchersConfig {
             github: ws
                 .watchers
@@ -401,7 +404,9 @@ pub struct PipelineRuleConfig {
 }
 
 /// Convert pipeline config rules into buzz pipeline rules.
-pub fn to_pipeline_rules(config: &PipelineConfig) -> Vec<crate::buzz::pipeline::rule::PipelineRule> {
+pub fn to_pipeline_rules(
+    config: &PipelineConfig,
+) -> Vec<crate::buzz::pipeline::rule::PipelineRule> {
     use crate::buzz::pipeline::rule::{PipelineAction, PipelineRule};
     use crate::buzz::signal::Severity;
 

--- a/crates/apiari/src/daemon/socket.rs
+++ b/crates/apiari/src/daemon/socket.rs
@@ -114,13 +114,7 @@ impl DaemonSocketServer {
     }
 
     /// Broadcast an activity event to all connected TUI clients.
-    pub fn broadcast_activity(
-        &self,
-        source: &str,
-        workspace: &str,
-        kind: &str,
-        text: &str,
-    ) {
+    pub fn broadcast_activity(&self, source: &str, workspace: &str, kind: &str, text: &str) {
         let msg = DaemonResponse::Activity {
             source: source.to_string(),
             workspace: workspace.to_string(),

--- a/crates/apiari/src/git_safety.rs
+++ b/crates/apiari/src/git_safety.rs
@@ -114,9 +114,7 @@ mod tests {
         let mut after = BTreeSet::new();
         after.insert(("repo".to_string(), "existing.rs".to_string()));
         after.insert(("repo".to_string(), "new_file.rs".to_string()));
-        let b = GitSnapshot {
-            dirty_files: after,
-        };
+        let b = GitSnapshot { dirty_files: after };
 
         let diff = b.diff(&a);
         assert_eq!(diff.len(), 1);

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1,9 +1,9 @@
 //! App state machine for the apiari TUI.
 
-use apiari_tui::conversation::ConversationEntry;
 use crate::buzz::coordinator::memory::MemoryStore;
 use crate::buzz::signal::store::SignalStore;
 use crate::buzz::signal::{Severity, SignalRecord};
+use apiari_tui::conversation::ConversationEntry;
 use chrono::{DateTime, Local, Utc};
 use serde::Deserialize;
 use std::io::{BufRead, Seek, SeekFrom};

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -19,10 +19,10 @@ use std::io::stdout;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
-use crate::buzz::coordinator::{Coordinator, CoordinatorEvent};
 use crate::buzz::coordinator::skills::{
     build_skills_prompt, default_coordinator_disallowed_tools, default_coordinator_tools,
 };
+use crate::buzz::coordinator::{Coordinator, CoordinatorEvent};
 use crate::buzz::signal::store::SignalStore;
 
 use crate::config;
@@ -997,34 +997,32 @@ async fn coordinator_task(
 
                 let token_tx = coord_tx.clone();
                 match coordinator
-                    .handle_message(&text, &store, move |event| {
-                        match event {
-                            CoordinatorEvent::Token(t) => {
-                                let _ = token_tx.try_send(CoordResponse::Token(t));
-                            }
-                            CoordinatorEvent::FilesModified { files } => {
-                                let file_list: Vec<String> = files
+                    .handle_message(&text, &store, move |event| match event {
+                        CoordinatorEvent::Token(t) => {
+                            let _ = token_tx.try_send(CoordResponse::Token(t));
+                        }
+                        CoordinatorEvent::FilesModified { files } => {
+                            let file_list: Vec<String> = files
+                                .iter()
+                                .map(|(repo, file)| format!("{repo}/{file}"))
+                                .collect();
+                            let alert = format!(
+                                "Warning: coordinator modified workspace files:\n{}",
+                                file_list
                                     .iter()
-                                    .map(|(repo, file)| format!("{repo}/{file}"))
-                                    .collect();
-                                let alert = format!(
-                                    "Warning: coordinator modified workspace files:\n{}",
-                                    file_list
-                                        .iter()
-                                        .map(|f| format!("  - {f}"))
-                                        .collect::<Vec<_>>()
-                                        .join("\n")
-                                );
-                                let _ = token_tx.try_send(CoordResponse::Error(alert));
-                            }
-                            CoordinatorEvent::BashAudit {
-                                command,
-                                matched_pattern,
-                            } => {
-                                let _ = token_tx.try_send(CoordResponse::Error(format!(
-                                    "Bash audit ({matched_pattern}): {command}"
-                                )));
-                            }
+                                    .map(|f| format!("  - {f}"))
+                                    .collect::<Vec<_>>()
+                                    .join("\n")
+                            );
+                            let _ = token_tx.try_send(CoordResponse::Error(alert));
+                        }
+                        CoordinatorEvent::BashAudit {
+                            command,
+                            matched_pattern,
+                        } => {
+                            let _ = token_tx.try_send(CoordResponse::Error(format!(
+                                "Bash audit ({matched_pattern}): {command}"
+                            )));
                         }
                     })
                     .await
@@ -1069,4 +1067,3 @@ fn build_coordinator(workspace_name: &str) -> Option<Coordinator> {
 
     Some(coordinator)
 }
-

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -132,9 +132,9 @@ fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
         .constraints([
             Constraint::Length(kpi_h),      // KPI cards (Watchers + Today)
             Constraint::Length(action_h),   // Action banner
-            Constraint::Percentage(55),    // Workers + Signals/Feed
+            Constraint::Percentage(55),     // Workers + Signals/Feed
             Constraint::Length(thoughts_h), // Thoughts strip
-            Constraint::Min(5),            // Chat
+            Constraint::Min(5),             // Chat
         ])
         .split(area);
 
@@ -204,9 +204,9 @@ fn draw_home_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area:
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(4),              // KPI cards (fill)
-            Constraint::Length(action_h),     // Action banner
-            Constraint::Length(thoughts_h),   // Thoughts
+            Constraint::Min(4),             // KPI cards (fill)
+            Constraint::Length(action_h),   // Action banner
+            Constraint::Length(thoughts_h), // Thoughts
         ])
         .split(area);
 
@@ -384,10 +384,7 @@ fn draw_kpi_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, area:
                 Style::default().fg(theme::FROST),
             ),
             if crit > 0 {
-                Span::styled(
-                    format!("  !!{crit}"),
-                    theme::error(),
-                )
+                Span::styled(format!("  !!{crit}"), theme::error())
             } else {
                 Span::styled("  all clear", Style::default().fg(theme::SMOKE))
             },
@@ -404,15 +401,13 @@ fn draw_kpi_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, area:
                     format!("  \u{27f3}{open_prs} open"),
                     Style::default().fg(theme::MINT),
                 ),
-                Span::styled(
-                    format!(" \u{2713}{merged_prs}"),
-                    theme::status_done(),
-                ),
+                Span::styled(format!(" \u{2713}{merged_prs}"), theme::status_done()),
             ]));
         } else {
-            lines.push(Line::from(vec![
-                Span::styled(" 0 PRs", Style::default().fg(theme::FROST)),
-            ]));
+            lines.push(Line::from(vec![Span::styled(
+                " 0 PRs",
+                Style::default().fg(theme::FROST),
+            )]));
         }
 
         frame.render_widget(Paragraph::new(lines), inner);
@@ -432,7 +427,9 @@ fn build_action_summary(_app: &App, ws: &app::WorkspaceState) -> Vec<(Style, Str
     for sig in &ws.signals {
         let entry = by_source.entry(sig.source.as_str()).or_default();
         match sig.severity {
-            crate::buzz::signal::Severity::Critical | crate::buzz::signal::Severity::Error => entry.0 += 1,
+            crate::buzz::signal::Severity::Critical | crate::buzz::signal::Severity::Error => {
+                entry.0 += 1
+            }
             crate::buzz::signal::Severity::Warning => entry.1 += 1,
             crate::buzz::signal::Severity::Info => entry.2 += 1,
         }
@@ -443,12 +440,18 @@ fn build_action_summary(_app: &App, ws: &app::WorkspaceState) -> Vec<(Style, Str
         if *crit_err > 0 {
             items.push((
                 theme::error(),
-                format!("{crit_err} {source} error{}", if *crit_err > 1 { "s" } else { "" }),
+                format!(
+                    "{crit_err} {source} error{}",
+                    if *crit_err > 1 { "s" } else { "" }
+                ),
             ));
         } else if *warn > 0 {
             items.push((
                 Style::default().fg(theme::POLLEN),
-                format!("{warn} {source} warning{}", if *warn > 1 { "s" } else { "" }),
+                format!(
+                    "{warn} {source} warning{}",
+                    if *warn > 1 { "s" } else { "" }
+                ),
             ));
         }
     }
@@ -656,10 +659,7 @@ fn bee_status(app: &App, ws: &app::WorkspaceState) -> (String, String) {
             2 => "~(*?*)~",
             _ => " (*?*) ",
         };
-        return (
-            face.into(),
-            format!("{waiting} waiting"),
-        );
+        return (face.into(), format!("{waiting} waiting"));
     }
 
     // Unread response: bee winks to get your attention
@@ -707,10 +707,7 @@ fn bee_status(app: &App, ws: &app::WorkspaceState) -> (String, String) {
     };
     let pad = " ".repeat(patrol_pos);
     let trail = if patrol_pos > 0 { "\u{00b7}" } else { " " };
-    let face = format!(
-        "{trail}{pad}{}(*v*){}",
-        wings.0, wings.1
-    );
+    let face = format!("{trail}{pad}{}(*v*){}", wings.0, wings.1);
     (face, mood.into())
 }
 
@@ -755,9 +752,10 @@ fn draw_chat_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area:
         let lines = vec![
             Line::from(""),
             Line::from(""),
-            Line::from(vec![
-                Span::styled("        ~(*v*)~", Style::default().fg(theme::HONEY)),
-            ]),
+            Line::from(vec![Span::styled(
+                "        ~(*v*)~",
+                Style::default().fg(theme::HONEY),
+            )]),
             Line::from(""),
             Line::from(vec![
                 Span::raw("    "),
@@ -779,12 +777,11 @@ fn draw_chat_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area:
             .iter()
             .map(|msg| match msg {
                 ChatLine::User(text, ts, source) => {
-                    let display_text =
-                        if matches!(source, Some(app::MessageSource::Telegram)) {
-                            format!("[TG] {text}")
-                        } else {
-                            text.clone()
-                        };
+                    let display_text = if matches!(source, Some(app::MessageSource::Telegram)) {
+                        format!("[TG] {text}")
+                    } else {
+                        text.clone()
+                    };
                     conversation::ConversationEntry::User {
                         text: display_text,
                         timestamp: ts.clone(),
@@ -796,14 +793,19 @@ fn draw_chat_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area:
                         timestamp: ts.clone(),
                     }
                 }
-                ChatLine::System(text) => conversation::ConversationEntry::Status {
-                    text: text.clone(),
-                },
+                ChatLine::System(text) => {
+                    conversation::ConversationEntry::Status { text: text.clone() }
+                }
             })
             .collect();
 
         let mut all_lines: Vec<Line> = Vec::new();
-        conversation::render_conversation(&mut all_lines, &entries, None, Some(&ws.config.coordinator.name));
+        conversation::render_conversation(
+            &mut all_lines,
+            &entries,
+            None,
+            Some(&ws.config.coordinator.name),
+        );
 
         if ws.streaming {
             let spin = SPINNER[app.spinner_tick % SPINNER.len()];
@@ -1112,10 +1114,10 @@ fn draw_thoughts_strip(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, a
 
     let category_icon = |cat: &str| -> &str {
         match cat {
-            "observation" => "\u{25cb}",  // ○
-            "decision" => "\u{2713}",     // ✓
-            "preference" => "\u{2605}",   // ★
-            _ => "\u{00b7}",              // ·
+            "observation" => "\u{25cb}", // ○
+            "decision" => "\u{2713}",    // ✓
+            "preference" => "\u{2605}",  // ★
+            _ => "\u{00b7}",             // ·
         }
     };
 
@@ -1135,10 +1137,16 @@ fn draw_thoughts_strip(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, a
             break;
         }
         if used > 1 {
-            spans.push(Span::styled("  \u{00b7}  ", Style::default().fg(theme::WAX)));
+            spans.push(Span::styled(
+                "  \u{00b7}  ",
+                Style::default().fg(theme::WAX),
+            ));
             used += 5;
         }
-        spans.push(Span::styled(icon.to_string(), Style::default().fg(theme::POLLEN)));
+        spans.push(Span::styled(
+            icon.to_string(),
+            Style::default().fg(theme::POLLEN),
+        ));
         spans.push(Span::raw(" "));
         spans.push(Span::styled(
             content.clone(),
@@ -1252,7 +1260,9 @@ fn render_signal_line(
 
     // Severity-colored bar
     let sev_color = match signal.severity {
-        crate::buzz::signal::Severity::Critical | crate::buzz::signal::Severity::Error => theme::EMBER,
+        crate::buzz::signal::Severity::Critical | crate::buzz::signal::Severity::Error => {
+            theme::EMBER
+        }
         crate::buzz::signal::Severity::Warning => theme::NECTAR,
         crate::buzz::signal::Severity::Info => theme::SMOKE,
     };
@@ -1670,7 +1680,12 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                 };
                 vec![
                     Span::raw(" "),
-                    Span::styled(panel_name, Style::default().fg(theme::HONEY).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        panel_name,
+                        Style::default()
+                            .fg(theme::HONEY)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                     Span::styled("  ", theme::key_desc()),
                     Span::styled("h/l", theme::key_hint()),
                     Span::styled(":prev/next  ", theme::key_desc()),
@@ -1767,7 +1782,9 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 
     // Right-aligned daemon status with ECG heartbeat trace
     let cur_ws = app.current_ws();
-    let healthy_w = cur_ws.map_or(0, |ws| ws.watcher_health.iter().filter(|w| w.healthy).count());
+    let healthy_w = cur_ws.map_or(0, |ws| {
+        ws.watcher_health.iter().filter(|w| w.healthy).count()
+    });
     let total_w = cur_ws.map_or(0, |ws| ws.watcher_health.len());
     let ecg = activity_graph(&app.activity_buf);
     // ECG color reflects signal severity
@@ -1780,9 +1797,10 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                 crate::buzz::signal::Severity::Critical | crate::buzz::signal::Severity::Error
             )
         });
-        let has_warn = ws.signals.iter().any(|s| {
-            s.severity == crate::buzz::signal::Severity::Warning
-        });
+        let has_warn = ws
+            .signals
+            .iter()
+            .any(|s| s.severity == crate::buzz::signal::Severity::Warning);
         if has_crit {
             theme::EMBER
         } else if has_warn {
@@ -1798,7 +1816,11 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         "\u{25cb}" // ○ local fallback
     };
-    let conn_label = if app.daemon_connected { "daemon" } else { "local" };
+    let conn_label = if app.daemon_connected {
+        "daemon"
+    } else {
+        "local"
+    };
     let daemon_spans: Vec<Span> = if app.daemon_alive {
         let uptime_str = match app.daemon_uptime_secs {
             Some(s) if s >= 3600 => format!("{}h{}m", s / 3600, (s % 3600) / 60),
@@ -1829,7 +1851,11 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     };
 
     // On narrow terminals (mobile), skip key hints — just show daemon status
-    let hints = if area.width < 120 { vec![Span::raw(" ")] } else { hints };
+    let hints = if area.width < 120 {
+        vec![Span::raw(" ")]
+    } else {
+        hints
+    };
 
     // Calculate padding for right-alignment
     let hints_len: usize = hints.iter().map(|s| s.content.len()).sum();
@@ -2053,12 +2079,10 @@ fn severity_style(severity: &crate::buzz::signal::Severity) -> Style {
 /// Data is pushed in from the left and scrolls right. The buffer IS the graph.
 fn activity_graph(buf: &[u8]) -> String {
     const BLOCKS: &[char] = &[
-        '\u{2581}', '\u{2582}', '\u{2583}', '\u{2584}',
-        '\u{2585}', '\u{2586}', '\u{2587}', '\u{2588}',
+        '\u{2581}', '\u{2582}', '\u{2583}', '\u{2584}', '\u{2585}', '\u{2586}', '\u{2587}',
+        '\u{2588}',
     ];
-    buf.iter()
-        .map(|&v| BLOCKS[(v as usize).min(7)])
-        .collect()
+    buf.iter().map(|&v| BLOCKS[(v as usize).min(7)]).collect()
 }
 
 /// Truncate a string to `max` chars, appending "..." if truncated.

--- a/crates/hive/src/daemon/mod.rs
+++ b/crates/hive/src/daemon/mod.rs
@@ -1712,6 +1712,10 @@ impl DaemonRunner {
             .clone();
         let text = text.to_owned();
 
+        // Clone broadcast sender for mirroring to TUI clients.
+        let tui_broadcast_tx = self.tui_socket.as_ref().map(|s| s.broadcast_tx());
+        let user_name = user_name.to_owned();
+
         // -- Phase B: spawn the long-running coordinator work --
         tokio::spawn(async move {
             // React immediately so the user knows we received their message.
@@ -1719,6 +1723,15 @@ impl DaemonRunner {
             // message_id == 0 for synthetic callback messages — skip the reaction.
             if message_id != 0 {
                 channel.send_reaction(chat_id, message_id, "👀").await;
+            }
+
+            // Mirror the incoming user message to TUI clients.
+            if let Some(ref tx) = tui_broadcast_tx {
+                let _ = tx.send(TuiResponse::IncomingMessage {
+                    source: "telegram".into(),
+                    user_name: user_name.clone(),
+                    text: text.clone(),
+                });
             }
 
             // Start typing indicator loop (expires after 5s, so we resend every 4s).
@@ -1737,11 +1750,17 @@ impl DaemonRunner {
                 });
             }
 
-            // Build a callback that sends intermediate text blocks to Telegram.
+            // Build a callback that sends intermediate text blocks to Telegram + TUI.
             let send_channel = channel.clone();
+            let tui_tx_for_send = tui_broadcast_tx.clone();
             let send_fn = move |text: String| {
                 let channel = send_channel.clone();
+                let tui_tx = tui_tx_for_send.clone();
                 async move {
+                    // Mirror intermediate tokens to TUI clients.
+                    if let Some(ref tx) = tui_tx {
+                        let _ = tx.send(TuiResponse::Token { text: text.clone() });
+                    }
                     for chunk in split_message(&text, 4000) {
                         channel
                             .send_message(&OutboundMessage {
@@ -1777,13 +1796,19 @@ impl DaemonRunner {
                     let mut dispatches = turn_dispatches;
                     dispatches.extend(final_dispatches);
 
-                    // Send the final response to Telegram.
+                    // Send the final response to Telegram + mirror to TUI.
                     if !clean_response.is_empty() {
                         tracing::debug!(
                             chars = clean_response.len(),
                             text = %truncate(&clean_response, 80),
                             "Responding",
                         );
+                        // Mirror final text to TUI clients.
+                        if let Some(ref tx) = tui_broadcast_tx {
+                            let _ = tx.send(TuiResponse::Token {
+                                text: clean_response.clone(),
+                            });
+                        }
                         if buttons.is_empty() {
                             let _ = send_to_telegram(&channel, chat_id, &clean_response, topic_id)
                                 .await;
@@ -1797,6 +1822,10 @@ impl DaemonRunner {
                             )
                             .await;
                         }
+                    }
+                    // Signal TUI that the coordinator response is complete.
+                    if let Some(ref tx) = tui_broadcast_tx {
+                        let _ = tx.send(TuiResponse::Done);
                     }
 
                     // Process dispatch blocks after sending the text response.

--- a/crates/hive/src/daemon/tui_socket.rs
+++ b/crates/hive/src/daemon/tui_socket.rs
@@ -76,6 +76,12 @@ pub enum TuiResponse {
     },
     /// Dispatch was executed or cancelled — no longer active.
     DispatchCleared,
+    /// A message received from an external channel (e.g. Telegram) — mirrored to TUI.
+    IncomingMessage {
+        source: String,
+        user_name: String,
+        text: String,
+    },
 }
 
 /// A handle to a connected TUI client's write channel.
@@ -142,6 +148,11 @@ impl TuiSocketServer {
     /// Push an arbitrary response to all connected TUI clients.
     pub fn push_response(&self, response: TuiResponse) {
         let _ = self.notify_tx.send(response);
+    }
+
+    /// Get a clone of the broadcast sender for use in spawned tasks.
+    pub fn broadcast_tx(&self) -> broadcast::Sender<TuiResponse> {
+        self.notify_tx.clone()
     }
 
     /// Check if any TUI clients are connected.

--- a/crates/hive/src/ui/mod.rs
+++ b/crates/hive/src/ui/mod.rs
@@ -60,6 +60,12 @@ enum CoordResponse {
     },
     /// Dispatch cleared by daemon.
     DispatchCleared,
+    /// An incoming message from an external channel (e.g. Telegram), mirrored to the TUI.
+    IncomingMessage {
+        source: String,
+        user_name: String,
+        text: String,
+    },
 }
 
 /// Async action results sent back to the event loop.
@@ -268,6 +274,15 @@ async fn daemon_client_task(
                                 per_repo,
                             },
                             TuiResponse::DispatchCleared => CoordResponse::DispatchCleared,
+                            TuiResponse::IncomingMessage {
+                                source,
+                                user_name,
+                                text,
+                            } => CoordResponse::IncomingMessage {
+                                source,
+                                user_name,
+                                text,
+                            },
                         };
                         if coord_tx.send(coord_msg).await.is_err() {
                             break;
@@ -414,6 +429,17 @@ async fn event_loop(
                     app.active_dispatch = None;
                     app.clamp_sidebar_selection();
                     app.streaming = false;
+                }
+                CoordResponse::IncomingMessage {
+                    source,
+                    user_name,
+                    text,
+                } => {
+                    let label = format!("[{source}] {user_name}");
+                    app.chat_history
+                        .push(ChatLine::User(format!("{label}: {text}"), app::now_ts()));
+                    app.streaming = true;
+                    app.chat_scroll = 0;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Adds real-time mirroring of Telegram → coordinator conversations to the TUI chat panel
- When a Telegram user sends a message, the TUI now shows the incoming message (with `[telegram] username:` prefix) and streams the coordinator's response
- Uses the existing `TuiSocketServer` broadcast channel — no new infrastructure needed

## Changes
- **`tui_socket.rs`**: Added `IncomingMessage { source, user_name, text }` variant to `TuiResponse`, and `broadcast_tx()` method on `TuiSocketServer` to expose the broadcast sender for spawned tasks
- **`daemon/mod.rs`**: In `handle_message` (Telegram path), clones the broadcast sender and mirrors: incoming user message → intermediate tokens → final response text → Done signal
- **`ui/mod.rs`**: Added `IncomingMessage` to `CoordResponse` enum, wired it through `daemon_client_task`, and handled it in the event loop to display as a `ChatLine::User` with streaming enabled

## Test plan
- [ ] Start daemon with Telegram bot configured
- [ ] Open `hive ui` in a separate terminal
- [ ] Send a message via Telegram
- [ ] Verify the TUI shows `[telegram] <username>: <message>` followed by the streamed coordinator response
- [ ] Verify TUI-originated messages still work as before
- [ ] `cargo check -p hive` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)