### PR TITLE
feat: validate Telegram bot tokens on daemon startup

### DIFF
--- a/crates/apiari/src/buzz/channel/telegram.rs
+++ b/crates/apiari/src/buzz/channel/telegram.rs
@@ -79,6 +79,36 @@ impl TelegramChannel {
         format!("https://api.telegram.org/bot{}/{method}", self.bot_token)
     }
 
+    /// Validate the bot token by calling the Telegram `getMe` endpoint.
+    ///
+    /// Returns `Ok(username)` on success or `Err(description)` on failure.
+    pub async fn validate(&self) -> std::result::Result<String, String> {
+        let resp = self
+            .client
+            .get(self.api_url("getMe"))
+            .send()
+            .await
+            .map_err(|e| format!("HTTP error: {e}"))?;
+
+        let body: TgResponse<TgUser> = resp
+            .json()
+            .await
+            .map_err(|e| format!("failed to parse response: {e}"))?;
+
+        if body.ok {
+            if let Some(user) = body.result {
+                let username = user.username.unwrap_or(user.first_name);
+                Ok(username)
+            } else {
+                Err("ok=true but no result".to_string())
+            }
+        } else {
+            Err(body
+                .description
+                .unwrap_or_else(|| "unknown error".to_string()))
+        }
+    }
+
     fn parse_message(msg: &TgMessage) -> Option<ChannelEvent> {
         let text = msg.text.as_deref()?.trim();
         if text.is_empty() {

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -587,6 +587,29 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
         }
     }
 
+    // Validate Telegram bot tokens at startup
+    for slot in &slots {
+        if let Some(tg) = &slot.config.telegram {
+            if let Some(channel) = telegram_channels.get(&tg.bot_token) {
+                let channel = channel.clone();
+                let ws_name = slot.name.clone();
+                tokio::spawn(async move {
+                    match channel.validate().await {
+                        Ok(username) => {
+                            info!("[{ws_name}] Telegram bot @{username} connected");
+                        }
+                        Err(description) => {
+                            warn!(
+                                "[{ws_name}] Telegram bot token appears invalid (getMe failed: {description}). \
+                                 Notifications will not be delivered. Check your bot_token in ~/.config/apiari/workspaces/{ws_name}.toml"
+                            );
+                        }
+                    }
+                });
+            }
+        }
+    }
+
     // Compute min poll interval across all workspaces
     let min_interval = slots
         .iter()

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -589,24 +589,24 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
 
     // Validate Telegram bot tokens at startup
     for slot in &slots {
-        if let Some(tg) = &slot.config.telegram {
-            if let Some(channel) = telegram_channels.get(&tg.bot_token) {
-                let channel = channel.clone();
-                let ws_name = slot.name.clone();
-                tokio::spawn(async move {
-                    match channel.validate().await {
-                        Ok(username) => {
-                            info!("[{ws_name}] Telegram bot @{username} connected");
-                        }
-                        Err(description) => {
-                            warn!(
-                                "[{ws_name}] Telegram bot token appears invalid (getMe failed: {description}). \
-                                 Notifications will not be delivered. Check your bot_token in ~/.config/apiari/workspaces/{ws_name}.toml"
-                            );
-                        }
+        if let Some(tg) = &slot.config.telegram
+            && let Some(channel) = telegram_channels.get(&tg.bot_token)
+        {
+            let channel = channel.clone();
+            let ws_name = slot.name.clone();
+            tokio::spawn(async move {
+                match channel.validate().await {
+                    Ok(username) => {
+                        info!("[{ws_name}] Telegram bot @{username} connected");
                     }
-                });
-            }
+                    Err(description) => {
+                        warn!(
+                            "[{ws_name}] Telegram bot token appears invalid (getMe failed: {description}). \
+                             Notifications will not be delivered. Check your bot_token in ~/.config/apiari/workspaces/{ws_name}.toml"
+                        );
+                    }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `TelegramChannel::validate()` method that calls the Telegram `getMe` API to verify bot tokens
- On daemon startup, spawns non-blocking validation for each workspace with Telegram config
- Logs `INFO` with bot username on success, or `WARN` with actionable config path on failure
- Daemon continues running regardless of validation result

## Test plan
- [ ] Start daemon with a valid bot token — verify INFO log shows `@botname connected`
- [ ] Start daemon with an invalid/expired token — verify WARN log with config path hint
- [ ] Confirm daemon continues running and processing other workspaces after a failed validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)