### PR TITLE
feat: implement GitHub review queue watcher with TUI lens

### DIFF
--- a/crates/apiari/src/buzz/config.rs
+++ b/crates/apiari/src/buzz/config.rs
@@ -61,6 +61,16 @@ pub struct GithubWatcherConfig {
     pub repos: Vec<String>,
     #[serde(default)]
     pub watch_labels: Vec<String>,
+    /// Named priority queries for the review queue.
+    #[serde(default)]
+    pub review_queue: Vec<ReviewQueueEntry>,
+}
+
+/// A named review queue query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewQueueEntry {
+    pub name: String,
+    pub query: String,
 }
 
 /// Sentry watcher configuration.

--- a/crates/apiari/src/buzz/coordinator/skills/github.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/github.rs
@@ -9,7 +9,7 @@ pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
 
     let repos_list = ctx.repos.join(", ");
 
-    Some(format!(
+    let mut prompt = format!(
         "## GitHub\n\
          Repos: {repos_list}\n\
          Use the `gh` CLI (already authenticated):\n\
@@ -19,5 +19,20 @@ pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
          - List issues: `gh issue list --repo {{repo}}`\n\
          - Issue detail: `gh issue view {{number}} --repo {{repo}}`\n\
          - Create issue: `gh issue create --repo {{repo}} --title \"...\" --body \"...\"`\n",
-    ))
+    );
+
+    if ctx.has_review_queue && !ctx.review_queue_names.is_empty() {
+        let names = ctx.review_queue_names.join(", ");
+        prompt.push_str(&format!(
+            "\n### Review Queue\n\
+             This workspace has a review queue with {count} named quer{plural}: {names}.\n\
+             Review queue signals appear in the signal store with source `github_review_queue`.\n\
+             Each signal's metadata includes `query_name` and `priority` (lower = higher priority).\n\
+             When summarizing pending reviews, group by query name and mention priority order.\n",
+            count = ctx.review_queue_names.len(),
+            plural = if ctx.review_queue_names.len() == 1 { "y" } else { "ies" },
+        ));
+    }
+
+    Some(prompt)
 }

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -19,6 +19,8 @@ pub struct SkillContext {
     pub repos: Vec<String>,
     pub has_sentry: bool,
     pub has_swarm: bool,
+    pub has_review_queue: bool,
+    pub review_queue_names: Vec<String>,
     /// Custom prompt preamble loaded from prompt_file.
     /// If set, replaces the default identity/role sections in the system prompt.
     pub prompt_preamble: Option<String>,
@@ -108,6 +110,8 @@ mod tests {
             repos: vec!["org/repo".to_string()],
             has_sentry: true,
             has_swarm: true,
+            has_review_queue: false,
+            review_queue_names: vec![],
             prompt_preamble: None,
         }
     }

--- a/crates/apiari/src/buzz/daemon/config.rs
+++ b/crates/apiari/src/buzz/daemon/config.rs
@@ -72,6 +72,7 @@ mod tests {
             interval_secs: 60,
             repos: vec!["org/repo".into()],
             watch_labels: vec![],
+            review_queue: vec![],
         });
         assert!(has_watchers(&config));
     }
@@ -84,6 +85,7 @@ mod tests {
             interval_secs: 60,
             repos: vec![],
             watch_labels: vec![],
+            review_queue: vec![],
         });
         assert!(!has_watchers(&config));
     }
@@ -96,6 +98,7 @@ mod tests {
             interval_secs: 120,
             repos: vec![],
             watch_labels: vec![],
+            review_queue: vec![],
         });
         config.watchers.swarm = Some(SwarmWatcherConfig {
             enabled: true,

--- a/crates/apiari/src/buzz/watcher/mod.rs
+++ b/crates/apiari/src/buzz/watcher/mod.rs
@@ -4,6 +4,7 @@
 //! get upserted into the SQLite signal store.
 
 pub mod github;
+pub mod review_queue;
 pub mod sentry;
 pub mod swarm;
 

--- a/crates/apiari/src/buzz/watcher/review_queue.rs
+++ b/crates/apiari/src/buzz/watcher/review_queue.rs
@@ -1,0 +1,236 @@
+//! Review Queue watcher — polls GitHub for PRs matching named priority queries.
+//!
+//! Uses `gh search prs --json ...` to query each configured review queue entry.
+//! Deduplicates across queries: lowest index (highest priority) wins.
+//! Source: `github_review_queue`.
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use color_eyre::Result;
+use tracing::{info, warn};
+
+use super::Watcher;
+use crate::buzz::config::{GithubWatcherConfig, ReviewQueueEntry};
+use crate::buzz::signal::store::SignalStore;
+use crate::buzz::signal::{Severity, SignalUpdate};
+
+const SOURCE: &str = "github_review_queue";
+
+/// Watches GitHub for PRs matching named priority queries.
+pub struct ReviewQueueWatcher {
+    queries: Vec<ReviewQueueEntry>,
+    gh_available: Option<bool>,
+}
+
+impl ReviewQueueWatcher {
+    pub fn new(config: &GithubWatcherConfig) -> Self {
+        Self {
+            queries: config.review_queue.clone(),
+            gh_available: None,
+        }
+    }
+
+    async fn ensure_gh_available(&mut self) -> bool {
+        if let Some(available) = self.gh_available {
+            return available;
+        }
+
+        let auth_result = tokio::process::Command::new("gh")
+            .args(["auth", "status"])
+            .output()
+            .await;
+
+        match auth_result {
+            Ok(output) if output.status.success() => {
+                self.gh_available = Some(true);
+                true
+            }
+            _ => {
+                warn!("gh CLI not available for review queue watcher");
+                self.gh_available = Some(false);
+                false
+            }
+        }
+    }
+
+    /// Run a single query and return parsed PR results.
+    async fn search_prs(&self, query: &str) -> Vec<PrResult> {
+        let output = match tokio::process::Command::new("gh")
+            .args([
+                "search",
+                "prs",
+                "--json",
+                "number,title,url,repository,author,updatedAt",
+                "--limit",
+                "30",
+                "--",
+                query,
+            ])
+            .output()
+            .await
+        {
+            Ok(output) => output,
+            Err(e) => {
+                warn!("failed to run `gh search prs`: {e}");
+                return Vec::new();
+            }
+        };
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            warn!("`gh search prs` failed: {}", stderr.trim());
+            return Vec::new();
+        }
+
+        let body = String::from_utf8_lossy(&output.stdout);
+        match serde_json::from_str::<Vec<serde_json::Value>>(&body) {
+            Ok(items) => items.into_iter().filter_map(parse_pr_result).collect(),
+            Err(e) => {
+                warn!("failed to parse `gh search prs` JSON: {e}");
+                Vec::new()
+            }
+        }
+    }
+}
+
+/// Parsed PR from `gh search prs` output.
+struct PrResult {
+    number: u64,
+    title: String,
+    url: String,
+    repo: String,
+    author: String,
+}
+
+fn parse_pr_result(val: serde_json::Value) -> Option<PrResult> {
+    let number = val.get("number")?.as_u64()?;
+    let title = val.get("title")?.as_str()?.to_string();
+    let url = val.get("url")?.as_str()?.to_string();
+    let repo = val
+        .get("repository")
+        .and_then(|r| r.get("nameWithOwner"))
+        .and_then(|n| n.as_str())
+        .unwrap_or("")
+        .to_string();
+    let author = val
+        .get("author")
+        .and_then(|a| a.get("login"))
+        .and_then(|l| l.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    Some(PrResult {
+        number,
+        title,
+        url,
+        repo,
+        author,
+    })
+}
+
+/// Build the external ID for a review queue signal.
+fn external_id(repo: &str, number: u64) -> String {
+    format!("rq-{repo}-{number}")
+}
+
+#[async_trait]
+impl Watcher for ReviewQueueWatcher {
+    fn name(&self) -> &str {
+        "review_queue"
+    }
+
+    async fn poll(&mut self, _store: &SignalStore) -> Result<Vec<SignalUpdate>> {
+        if self.queries.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        if !self.ensure_gh_available().await {
+            return Ok(Vec::new());
+        }
+
+        let mut all_signals = Vec::new();
+        // Track seen PR keys across queries for dedup (lowest index wins).
+        let mut seen_keys: HashSet<String> = HashSet::new();
+
+        for (priority, entry) in self.queries.iter().enumerate() {
+            let prs = self.search_prs(&entry.query).await;
+            for pr in prs {
+                let key = external_id(&pr.repo, pr.number);
+                if seen_keys.contains(&key) {
+                    continue; // Already emitted by a higher-priority query.
+                }
+                seen_keys.insert(key.clone());
+
+                let metadata = serde_json::json!({
+                    "query_name": entry.name,
+                    "priority": priority,
+                    "author": pr.author,
+                    "repo": pr.repo,
+                });
+
+                let signal = SignalUpdate::new(SOURCE, &key, pr.title, Severity::Info)
+                    .with_body(format!("{} — {} by {}", entry.name, pr.repo, pr.author))
+                    .with_url(&pr.url)
+                    .with_metadata(metadata.to_string());
+
+                all_signals.push(signal);
+            }
+        }
+
+        if !all_signals.is_empty() {
+            info!("review_queue: {} signal(s)", all_signals.len());
+        }
+
+        Ok(all_signals)
+    }
+
+    fn reconcile(&self, store: &SignalStore) -> Result<usize> {
+        // The poll already emits the full set of current PRs.
+        // We don't track current_ids here because poll is stateless;
+        // the daemon calls resolve_missing_signals after each poll cycle.
+        // We'd need the IDs from the last poll. For now, let the daemon
+        // handle this via the standard pattern.
+        //
+        // Actually, since we return all current signals every poll, we can
+        // use the store's resolve_missing_signals with the current external IDs.
+        // But we don't have them here (poll already finished). The simplest
+        // approach: skip reconcile and let signals be updated on each poll.
+        // They'll get updated_at refreshed, keeping them alive.
+        let _ = store;
+        Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_external_id() {
+        assert_eq!(external_id("org/repo", 42), "rq-org/repo-42");
+    }
+
+    #[test]
+    fn test_parse_pr_result() {
+        let val = serde_json::json!({
+            "number": 42,
+            "title": "Add feature X",
+            "url": "https://github.com/org/repo/pull/42",
+            "repository": {"nameWithOwner": "org/repo"},
+            "author": {"login": "user1"},
+            "updatedAt": "2025-01-01T00:00:00Z",
+        });
+        let pr = parse_pr_result(val).unwrap();
+        assert_eq!(pr.number, 42);
+        assert_eq!(pr.title, "Add feature X");
+        assert_eq!(pr.repo, "org/repo");
+        assert_eq!(pr.author, "user1");
+    }
+
+    #[test]
+    fn test_parse_pr_result_missing_fields() {
+        let val = serde_json::json!({"title": "No number"});
+        assert!(parse_pr_result(val).is_none());
+    }
+}

--- a/crates/apiari/src/buzz/watcher/review_queue.rs
+++ b/crates/apiari/src/buzz/watcher/review_queue.rs
@@ -21,6 +21,9 @@ const SOURCE: &str = "github_review_queue";
 pub struct ReviewQueueWatcher {
     queries: Vec<ReviewQueueEntry>,
     gh_available: Option<bool>,
+    /// External IDs from the last successful poll, for reconciliation.
+    /// `None` = never polled, `Some(vec![])` = polled and got zero.
+    last_poll_ids: Option<Vec<String>>,
 }
 
 impl ReviewQueueWatcher {
@@ -28,6 +31,7 @@ impl ReviewQueueWatcher {
         Self {
             queries: config.review_queue.clone(),
             gh_available: None,
+            last_poll_ids: None,
         }
     }
 
@@ -169,7 +173,14 @@ impl Watcher for ReviewQueueWatcher {
                     "repo": pr.repo,
                 });
 
-                let signal = SignalUpdate::new(SOURCE, &key, pr.title, Severity::Info)
+                // First query (priority 0) = Warning, others = Info
+                let severity = if priority == 0 {
+                    Severity::Warning
+                } else {
+                    Severity::Info
+                };
+
+                let signal = SignalUpdate::new(SOURCE, &key, pr.title, severity)
                     .with_body(format!("{} — {} by {}", entry.name, pr.repo, pr.author))
                     .with_url(&pr.url)
                     .with_metadata(metadata.to_string());
@@ -177,6 +188,9 @@ impl Watcher for ReviewQueueWatcher {
                 all_signals.push(signal);
             }
         }
+
+        // Store current IDs for reconciliation
+        self.last_poll_ids = Some(seen_keys.into_iter().collect());
 
         if !all_signals.is_empty() {
             info!("review_queue: {} signal(s)", all_signals.len());
@@ -186,19 +200,14 @@ impl Watcher for ReviewQueueWatcher {
     }
 
     fn reconcile(&self, store: &SignalStore) -> Result<usize> {
-        // The poll already emits the full set of current PRs.
-        // We don't track current_ids here because poll is stateless;
-        // the daemon calls resolve_missing_signals after each poll cycle.
-        // We'd need the IDs from the last poll. For now, let the daemon
-        // handle this via the standard pattern.
-        //
-        // Actually, since we return all current signals every poll, we can
-        // use the store's resolve_missing_signals with the current external IDs.
-        // But we don't have them here (poll already finished). The simplest
-        // approach: skip reconcile and let signals be updated on each poll.
-        // They'll get updated_at refreshed, keeping them alive.
-        let _ = store;
-        Ok(0)
+        let Some(ref ids) = self.last_poll_ids else {
+            return Ok(0); // Never polled yet — skip
+        };
+        let resolved = store.resolve_missing_signals(SOURCE, ids)?;
+        if resolved > 0 {
+            info!("review_queue: reconciled {resolved} resolved signal(s)");
+        }
+        Ok(resolved)
     }
 }
 

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -125,6 +125,19 @@ pub struct GithubWatcherConfig {
     pub repos: Vec<String>,
     #[serde(default = "default_watcher_interval")]
     pub interval_secs: u64,
+    /// Named priority queries for the review queue.
+    /// Order = priority order (first entry is highest priority).
+    #[serde(default)]
+    pub review_queue: Vec<ReviewQueueEntry>,
+}
+
+/// A named review queue query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewQueueEntry {
+    /// Human-readable name for this query (e.g. "My PRs", "Team Reviews").
+    pub name: String,
+    /// GitHub search query (e.g. "is:pr is:open review-requested:@me").
+    pub query: String,
 }
 
 /// Sentry watcher configuration.
@@ -287,6 +300,12 @@ pub fn build_skill_context(
     config: &WorkspaceConfig,
 ) -> crate::buzz::coordinator::skills::SkillContext {
     let repos = resolve_repos(config);
+    let review_queue_names: Vec<String> = config
+        .watchers
+        .github
+        .as_ref()
+        .map(|g| g.review_queue.iter().map(|e| e.name.clone()).collect())
+        .unwrap_or_default();
     crate::buzz::coordinator::skills::SkillContext {
         workspace_name: workspace_name.to_string(),
         workspace_root: config.root.clone(),
@@ -294,6 +313,8 @@ pub fn build_skill_context(
         repos,
         has_sentry: config.watchers.sentry.is_some(),
         has_swarm: config.watchers.swarm.is_some(),
+        has_review_queue: !review_queue_names.is_empty(),
+        review_queue_names,
         prompt_preamble: config.coordinator.prompt.clone(),
     }
 }
@@ -324,6 +345,14 @@ pub fn to_buzz_config(ws: &WorkspaceConfig) -> crate::buzz::config::BuzzConfig {
                         g.repos.clone()
                     },
                     watch_labels: vec![],
+                    review_queue: g
+                        .review_queue
+                        .iter()
+                        .map(|e| crate::buzz::config::ReviewQueueEntry {
+                            name: e.name.clone(),
+                            query: e.query.clone(),
+                        })
+                        .collect(),
                 }),
             sentry: ws
                 .watchers

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -27,6 +27,7 @@ use crate::buzz::pipeline::Pipeline;
 use crate::buzz::signal::store::SignalStore;
 use crate::buzz::watcher::WatcherRegistry;
 use crate::buzz::watcher::github::GithubWatcher;
+use crate::buzz::watcher::review_queue::ReviewQueueWatcher;
 use crate::buzz::watcher::sentry::SentryWatcher;
 use crate::buzz::watcher::swarm::SwarmWatcher;
 
@@ -475,6 +476,26 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 gh_config.repos.join(", ")
             );
             registry.add(Box::new(GithubWatcher::new(gh_config.clone())));
+
+            if !gh_config.review_queue.is_empty() {
+                let query_names: Vec<&str> = gh_config
+                    .review_queue
+                    .iter()
+                    .map(|q| q.name.as_str())
+                    .collect();
+                info!(
+                    "[{}] review queue watcher: {} quer{}: {}",
+                    ws.name,
+                    gh_config.review_queue.len(),
+                    if gh_config.review_queue.len() == 1 {
+                        "y"
+                    } else {
+                        "ies"
+                    },
+                    query_names.join(", ")
+                );
+                registry.add(Box::new(ReviewQueueWatcher::new(gh_config)));
+            }
         }
 
         if let Some(sentry_config) = &buzz_config.watchers.sentry

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -38,6 +38,15 @@ pub enum Panel {
     Chat,
 }
 
+/// Lens filter for the Signals panel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LensKind {
+    /// Show all signals.
+    All,
+    /// Show only review queue signals (source = "github_review_queue").
+    ReviewQueue,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
     Normal,
@@ -202,6 +211,7 @@ pub struct App {
     pub zoomed_panel: Option<Panel>,
     pub worker_selection: usize,
     pub signal_selection: usize,
+    pub signal_lens: LensKind,
     pub feed_selection: usize,
     pub chat_focused: bool,
     // Worker detail
@@ -301,6 +311,7 @@ impl App {
             zoomed_panel: None,
             worker_selection: 0,
             signal_selection: 0,
+            signal_lens: LensKind::All,
             feed_selection: 0,
             chat_focused: false,
             worker_input: String::new(),
@@ -469,7 +480,8 @@ impl App {
     }
 
     fn signal_selectable_count(&self) -> usize {
-        self.current_ws().map_or(0, |ws| ws.signals.len())
+        self.current_ws()
+            .map_or(0, |ws| self.lensed_signals(&ws.signals).len())
     }
 
     /// Clamp selections after data refresh.
@@ -521,6 +533,38 @@ impl App {
         self.signal_list_selection = 0;
         self.content_scroll = 0;
         self.needs_redraw = true;
+    }
+
+    /// Cycle the signal lens through available lenses.
+    /// Only includes ReviewQueue if the workspace has review queue signals.
+    pub fn cycle_signal_lens(&mut self) {
+        let has_rq = self.current_ws().map_or(false, |ws| {
+            ws.signals.iter().any(|s| s.source == "github_review_queue")
+        });
+
+        self.signal_lens = match self.signal_lens {
+            LensKind::All => {
+                if has_rq {
+                    LensKind::ReviewQueue
+                } else {
+                    LensKind::All
+                }
+            }
+            LensKind::ReviewQueue => LensKind::All,
+        };
+        self.signal_selection = 0;
+        self.needs_redraw = true;
+    }
+
+    /// Return signals filtered by the current lens.
+    pub fn lensed_signals<'a>(&self, signals: &'a [SignalRecord]) -> Vec<&'a SignalRecord> {
+        match self.signal_lens {
+            LensKind::All => signals.iter().collect(),
+            LensKind::ReviewQueue => signals
+                .iter()
+                .filter(|s| s.source == "github_review_queue")
+                .collect(),
+        }
     }
 
     pub fn back_to_dashboard(&mut self) {

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -45,6 +45,8 @@ pub enum LensKind {
     All,
     /// Show only review queue signals (source = "github_review_queue").
     ReviewQueue,
+    /// Placeholder for the upcoming Linear integration.
+    Linear,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -541,16 +543,28 @@ impl App {
         let has_rq = self
             .current_ws()
             .is_some_and(|ws| ws.signals.iter().any(|s| s.source == "github_review_queue"));
+        let has_linear = self
+            .current_ws()
+            .is_some_and(|ws| ws.signals.iter().any(|s| s.source == "linear"));
 
         self.signal_lens = match self.signal_lens {
             LensKind::All => {
                 if has_rq {
                     LensKind::ReviewQueue
+                } else if has_linear {
+                    LensKind::Linear
                 } else {
                     LensKind::All
                 }
             }
-            LensKind::ReviewQueue => LensKind::All,
+            LensKind::ReviewQueue => {
+                if has_linear {
+                    LensKind::Linear
+                } else {
+                    LensKind::All
+                }
+            }
+            LensKind::Linear => LensKind::All,
         };
         self.signal_selection = 0;
         self.needs_redraw = true;
@@ -564,6 +578,7 @@ impl App {
                 .iter()
                 .filter(|s| s.source == "github_review_queue")
                 .collect(),
+            LensKind::Linear => signals.iter().filter(|s| s.source == "linear").collect(),
         }
     }
 

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -14,10 +14,6 @@ use apiari_tui::scroll::ScrollState;
 
 use crate::config::{self, Workspace};
 
-// ── Constants ─────────────────────────────────────────────
-
-pub const MAX_VISIBLE_SIGNALS: usize = 5;
-
 // ── Types ─────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -489,7 +485,11 @@ impl App {
     /// Clamp selections after data refresh.
     pub fn clamp_selections(&mut self) {
         let (worker_count, sig_count, feed_count) = if let Some(ws) = self.current_ws() {
-            (ws.workers.len(), ws.signals.len(), ws.feed.len())
+            (
+                ws.workers.len(),
+                self.lensed_signals(&ws.signals).len(),
+                ws.feed.len(),
+            )
         } else {
             return;
         };
@@ -1246,12 +1246,8 @@ impl App {
         match &self.view {
             View::Dashboard => {
                 if self.focused_panel == Panel::Signals {
-                    let visible = self.current_ws()?.signals.len().min(MAX_VISIBLE_SIGNALS);
-                    if self.signal_selection < visible {
-                        self.current_ws()?.signals.get(self.signal_selection)
-                    } else {
-                        None // "more" item
-                    }
+                    let filtered = self.lensed_signals(&self.current_ws()?.signals);
+                    filtered.get(self.signal_selection).copied()
                 } else {
                     None
                 }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -538,9 +538,9 @@ impl App {
     /// Cycle the signal lens through available lenses.
     /// Only includes ReviewQueue if the workspace has review queue signals.
     pub fn cycle_signal_lens(&mut self) {
-        let has_rq = self.current_ws().map_or(false, |ws| {
-            ws.signals.iter().any(|s| s.source == "github_review_queue")
-        });
+        let has_rq = self
+            .current_ws()
+            .is_some_and(|ws| ws.signals.iter().any(|s| s.source == "github_review_queue"));
 
         self.signal_lens = match self.signal_lens {
             LensKind::All => {

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -415,7 +415,8 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
             }
         }
         KeyCode::Char('p') => app.enter_pr_list(),
-        KeyCode::Char('s') => app.enter_signal_list(),
+        KeyCode::Char('s') => app.cycle_signal_lens(),
+        KeyCode::Char('S') => app.enter_signal_list(),
         KeyCode::Char('o') => {
             if let Some(url) = app.selected_url() {
                 return KeyAction::OpenUrl(url);

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -893,27 +893,39 @@ fn draw_workers_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, ar
 fn draw_signals_card(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area: Rect) {
     let panel_focused = app.focused_panel == Panel::Signals;
 
-    let total = ws.signals.len();
+    let filtered: Vec<&crate::buzz::signal::SignalRecord> = app.lensed_signals(&ws.signals);
+    let total = filtered.len();
+
+    // Lens label for title
+    let lens_label = match app.signal_lens {
+        app::LensKind::All => "Signals",
+        app::LensKind::ReviewQueue => "Review Queue",
+    };
 
     // Title with navigation indicator
     let title = if total == 0 {
-        format!("Signals ({})", total)
+        format!("{lens_label} ({total})")
     } else {
         let idx = app.signal_selection.min(total.saturating_sub(1));
-        let signal = &ws.signals[idx];
+        let signal = filtered[idx];
         let icon = app::severity_icon(&signal.severity);
         if panel_focused {
             format!(
-                "Signals ({total})  {icon} \u{25c0} {}/{} \u{25b6}",
+                "{lens_label} ({total})  {icon} \u{25c0} {}/{} \u{25b6}",
                 idx + 1,
                 total
             )
         } else {
-            format!("Signals ({total})  {icon} {}/{}", idx + 1, total)
+            format!("{lens_label} ({total})  {icon} {}/{}", idx + 1, total)
         }
     };
 
-    let block = panel_block(&title, panel_focused, None);
+    let lens_hint = if app.signal_lens != app::LensKind::All {
+        Some("s:lens")
+    } else {
+        None
+    };
+    let block = panel_block(&title, panel_focused, lens_hint);
     let content_area = block.inner(area);
     frame.render_widget(block, area);
 
@@ -923,16 +935,20 @@ fn draw_signals_card(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
     }
 
     if total == 0 {
+        let empty_msg = match app.signal_lens {
+            app::LensKind::All => "No open signals",
+            app::LensKind::ReviewQueue => "No review queue items",
+        };
         let lines = vec![Line::from(vec![
             Span::raw(" "),
-            Span::styled("No open signals", theme::muted()),
+            Span::styled(empty_msg, theme::muted()),
         ])];
         frame.render_widget(Paragraph::new(lines), content_area);
         return;
     }
 
     let idx = app.signal_selection.min(total.saturating_sub(1));
-    let signal = &ws.signals[idx];
+    let signal = filtered[idx];
     let icon = app::severity_icon(&signal.severity);
     let sev_style = severity_style(&signal.severity);
     let ago = time_ago(&signal.updated_at);
@@ -940,6 +956,25 @@ fn draw_signals_card(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
     let content_lines = content_h;
 
     let mut lines: Vec<Line> = Vec::new();
+
+    // For ReviewQueue lens, show the query name from metadata
+    if app.signal_lens == app::LensKind::ReviewQueue {
+        if let Some(ref meta) = signal.metadata {
+            if let Ok(meta_val) = serde_json::from_str::<serde_json::Value>(meta) {
+                if let Some(qname) = meta_val.get("query_name").and_then(|v| v.as_str()) {
+                    lines.push(Line::from(vec![
+                        Span::raw("  "),
+                        Span::styled(
+                            qname.to_string(),
+                            Style::default()
+                                .fg(theme::POLLEN)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]));
+                }
+            }
+        }
+    }
 
     // Line 1: severity icon + title
     lines.push(Line::from(vec![
@@ -1709,6 +1744,8 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                     Span::styled(":chat  ", theme::key_desc()),
                     Span::styled("z", theme::key_hint()),
                     Span::styled(":zoom  ", theme::key_desc()),
+                    Span::styled("s", theme::key_hint()),
+                    Span::styled(":lens  ", theme::key_desc()),
                     Span::styled("p", theme::key_hint()),
                     Span::styled(":prs  ", theme::key_desc()),
                     Span::styled("?", theme::key_hint()),
@@ -1879,7 +1916,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 
 fn draw_help_overlay(frame: &mut Frame, area: Rect) {
     let w = 54u16.min(area.width.saturating_sub(4));
-    let h = 28u16.min(area.height.saturating_sub(4));
+    let h = 30u16.min(area.height.saturating_sub(4));
     let x = (area.width.saturating_sub(w)) / 2;
     let y = (area.height.saturating_sub(h)) / 2;
     let popup = Rect::new(x, y, w, h);
@@ -1919,6 +1956,14 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect) {
         Line::from(vec![
             Span::styled("  z             ", theme::key_hint()),
             Span::styled("Zoom focused panel", theme::key_desc()),
+        ]),
+        Line::from(vec![
+            Span::styled("  s             ", theme::key_hint()),
+            Span::styled("Cycle signal lens", theme::key_desc()),
+        ]),
+        Line::from(vec![
+            Span::styled("  S             ", theme::key_hint()),
+            Span::styled("Signal list (all)", theme::key_desc()),
         ]),
         Line::from(vec![
             Span::styled("  p             ", theme::key_hint()),

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -958,22 +958,20 @@ fn draw_signals_card(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
     let mut lines: Vec<Line> = Vec::new();
 
     // For ReviewQueue lens, show the query name from metadata
-    if app.signal_lens == app::LensKind::ReviewQueue {
-        if let Some(ref meta) = signal.metadata {
-            if let Ok(meta_val) = serde_json::from_str::<serde_json::Value>(meta) {
-                if let Some(qname) = meta_val.get("query_name").and_then(|v| v.as_str()) {
-                    lines.push(Line::from(vec![
-                        Span::raw("  "),
-                        Span::styled(
-                            qname.to_string(),
-                            Style::default()
-                                .fg(theme::POLLEN)
-                                .add_modifier(Modifier::BOLD),
-                        ),
-                    ]));
-                }
-            }
-        }
+    if app.signal_lens == app::LensKind::ReviewQueue
+        && let Some(ref meta) = signal.metadata
+        && let Ok(meta_val) = serde_json::from_str::<serde_json::Value>(meta)
+        && let Some(qname) = meta_val.get("query_name").and_then(|v| v.as_str())
+    {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                qname.to_string(),
+                Style::default()
+                    .fg(theme::POLLEN)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
     }
 
     // Line 1: severity icon + title

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -900,6 +900,7 @@ fn draw_signals_card(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
     let lens_label = match app.signal_lens {
         app::LensKind::All => "Signals",
         app::LensKind::ReviewQueue => "Review Queue",
+        app::LensKind::Linear => "Linear",
     };
 
     // Title with navigation indicator
@@ -938,6 +939,7 @@ fn draw_signals_card(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
         let empty_msg = match app.signal_lens {
             app::LensKind::All => "No open signals",
             app::LensKind::ReviewQueue => "No review queue items",
+            app::LensKind::Linear => "No Linear items",
         };
         let lines = vec![Line::from(vec![
             Span::raw(" "),


### PR DESCRIPTION
## Summary
- **Config**: Add `[[watchers.github.review_queue]]` support with `name` and `query` fields for named priority queries. Order in config determines priority (lowest index = highest priority).
- **Watcher**: New `ReviewQueueWatcher` polls each query via `gh search prs --json ...`, deduplicates across queries (highest priority wins), emits signals with source `github_review_queue` and metadata including query_name/priority/author/repo.
- **TUI Lens**: Add `LensKind` enum (`All` / `ReviewQueue`) to the signals panel. Press `s` to cycle lenses (ReviewQueue only appears when review queue signals exist). `S` opens the full signal list. ReviewQueue lens shows query name from metadata.
- **Coordinator Skill**: Extend GitHub skill to teach the coordinator about review queue signals, query names, and priority ordering when review queue is configured.

## Test plan
- [x] All 437 existing tests pass (`cargo test`)
- [x] `cargo check` and `cargo fmt` clean
- [ ] Manual: configure `[[watchers.github.review_queue]]` entries in a workspace TOML, run daemon, verify signals appear
- [ ] Manual: press `s` in TUI dashboard to cycle between All and ReviewQueue lens
- [ ] Manual: verify `S` opens full signal list view

🤖 Generated with [Claude Code](https://claude.com/claude-code)