### PR TITLE
feat: conversation persistence and session resumption

### DIFF
--- a/crates/apiari/src/buzz/conversation.rs
+++ b/crates/apiari/src/buzz/conversation.rs
@@ -60,7 +60,7 @@ impl<'a> ConversationStore<'a> {
         self.conn.execute(
             "INSERT INTO conversations (workspace, role, content, source, provider, session_id, created_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            params![self.workspace, role, content, source, provider, session_id, now],
+            params![&self.workspace, role, content, source, provider, session_id, now],
         )?;
         Ok(self.conn.last_insert_rowid())
     }
@@ -75,7 +75,7 @@ impl<'a> ConversationStore<'a> {
              LIMIT ?2",
         )?;
         let mut rows: Vec<ConversationRow> = stmt
-            .query_map(params![self.workspace, limit as i64], |row| {
+            .query_map(params![&self.workspace, limit as i64], |row| {
                 Ok(ConversationRow {
                     id: row.get(0)?,
                     workspace: row.get(1)?,
@@ -100,7 +100,7 @@ impl<'a> ConversationStore<'a> {
              WHERE workspace = ?1 AND provider IS NOT NULL AND session_id IS NOT NULL
              ORDER BY created_at DESC, id DESC
              LIMIT 1",
-            params![self.workspace],
+            params![&self.workspace],
             |row| {
                 Ok(SessionToken {
                     provider: row.get(0)?,

--- a/crates/apiari/src/buzz/conversation.rs
+++ b/crates/apiari/src/buzz/conversation.rs
@@ -1,0 +1,239 @@
+//! Conversation persistence — SQLite-backed chat history and session tokens.
+//!
+//! Stores user/assistant messages and provider-specific session tokens
+//! for session resumption across daemon restarts.
+//! All queries are scoped to a workspace.
+
+use chrono::Utc;
+use color_eyre::eyre::Result;
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
+
+/// A provider-agnostic session token for resuming conversations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionToken {
+    /// Provider name: "claude", "codex", "gemini", etc.
+    pub provider: String,
+    /// The provider-specific resume token/ID.
+    pub token: String,
+}
+
+/// A row from the conversations table.
+#[derive(Debug, Clone)]
+pub struct ConversationRow {
+    pub id: i64,
+    pub workspace: String,
+    pub role: String,
+    pub content: String,
+    pub source: Option<String>,
+    pub provider: Option<String>,
+    pub session_id: Option<String>,
+    pub created_at: String,
+}
+
+/// SQLite-backed conversation store, scoped to a workspace.
+pub struct ConversationStore<'a> {
+    conn: &'a Connection,
+    workspace: String,
+}
+
+impl<'a> ConversationStore<'a> {
+    /// Create a ConversationStore backed by the given connection, scoped to a workspace.
+    /// Assumes the `conversations` table already exists (created by SignalStore::init_schema).
+    pub fn new(conn: &'a Connection, workspace: &str) -> Self {
+        Self {
+            conn,
+            workspace: workspace.to_string(),
+        }
+    }
+
+    /// Insert a conversation message.
+    pub fn save_message(
+        &self,
+        role: &str,
+        content: &str,
+        source: Option<&str>,
+        provider: Option<&str>,
+        session_id: Option<&str>,
+    ) -> Result<i64> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "INSERT INTO conversations (workspace, role, content, source, provider, session_id, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![self.workspace, role, content, source, provider, session_id, now],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Load the last N messages ordered by created_at.
+    pub fn load_history(&self, limit: usize) -> Result<Vec<ConversationRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, workspace, role, content, source, provider, session_id, created_at
+             FROM conversations
+             WHERE workspace = ?1
+             ORDER BY created_at DESC, id DESC
+             LIMIT ?2",
+        )?;
+        let mut rows: Vec<ConversationRow> = stmt
+            .query_map(params![self.workspace, limit as i64], |row| {
+                Ok(ConversationRow {
+                    id: row.get(0)?,
+                    workspace: row.get(1)?,
+                    role: row.get(2)?,
+                    content: row.get(3)?,
+                    source: row.get(4)?,
+                    provider: row.get(5)?,
+                    session_id: row.get(6)?,
+                    created_at: row.get(7)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        // Reverse so oldest first
+        rows.reverse();
+        Ok(rows)
+    }
+
+    /// Get the most recent (provider, session_id) pair for session resumption.
+    pub fn last_session(&self) -> Result<Option<SessionToken>> {
+        let result = self.conn.query_row(
+            "SELECT provider, session_id FROM conversations
+             WHERE workspace = ?1 AND provider IS NOT NULL AND session_id IS NOT NULL
+             ORDER BY created_at DESC, id DESC
+             LIMIT 1",
+            params![self.workspace],
+            |row| {
+                Ok(SessionToken {
+                    provider: row.get(0)?,
+                    token: row.get(1)?,
+                })
+            },
+        );
+
+        match result {
+            Ok(token) => Ok(Some(token)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn test_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE conversations (
+                id          INTEGER PRIMARY KEY,
+                workspace   TEXT NOT NULL,
+                role        TEXT NOT NULL,
+                content     TEXT NOT NULL,
+                source      TEXT,
+                provider    TEXT,
+                session_id  TEXT,
+                created_at  TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_conversations_workspace
+                ON conversations(workspace, created_at);",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_save_and_load() {
+        let conn = test_conn();
+        let store = ConversationStore::new(&conn, "test");
+
+        store
+            .save_message("user", "hello", Some("telegram"), None, None)
+            .unwrap();
+        store
+            .save_message(
+                "assistant",
+                "hi there",
+                Some("system"),
+                Some("claude"),
+                Some("sess-123"),
+            )
+            .unwrap();
+
+        let history = store.load_history(10).unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].role, "user");
+        assert_eq!(history[0].content, "hello");
+        assert_eq!(history[1].role, "assistant");
+        assert_eq!(history[1].provider.as_deref(), Some("claude"));
+        assert_eq!(history[1].session_id.as_deref(), Some("sess-123"));
+    }
+
+    #[test]
+    fn test_last_session() {
+        let conn = test_conn();
+        let store = ConversationStore::new(&conn, "test");
+
+        // No session yet
+        assert!(store.last_session().unwrap().is_none());
+
+        store
+            .save_message("user", "msg1", None, None, None)
+            .unwrap();
+        // Still no session (user messages have no provider)
+        assert!(store.last_session().unwrap().is_none());
+
+        store
+            .save_message("assistant", "resp1", None, Some("claude"), Some("sess-abc"))
+            .unwrap();
+        let token = store.last_session().unwrap().unwrap();
+        assert_eq!(token.provider, "claude");
+        assert_eq!(token.token, "sess-abc");
+
+        // Newer session replaces
+        store
+            .save_message("assistant", "resp2", None, Some("claude"), Some("sess-xyz"))
+            .unwrap();
+        let token = store.last_session().unwrap().unwrap();
+        assert_eq!(token.token, "sess-xyz");
+    }
+
+    #[test]
+    fn test_workspace_isolation() {
+        let conn = test_conn();
+        let store_a = ConversationStore::new(&conn, "ws-a");
+        let store_b = ConversationStore::new(&conn, "ws-b");
+
+        store_a
+            .save_message("user", "from A", None, None, None)
+            .unwrap();
+        store_b
+            .save_message("user", "from B", None, None, None)
+            .unwrap();
+
+        let a_history = store_a.load_history(10).unwrap();
+        assert_eq!(a_history.len(), 1);
+        assert_eq!(a_history[0].content, "from A");
+
+        let b_history = store_b.load_history(10).unwrap();
+        assert_eq!(b_history.len(), 1);
+        assert_eq!(b_history[0].content, "from B");
+    }
+
+    #[test]
+    fn test_load_history_limit() {
+        let conn = test_conn();
+        let store = ConversationStore::new(&conn, "test");
+
+        for i in 0..10 {
+            store
+                .save_message("user", &format!("msg {i}"), None, None, None)
+                .unwrap();
+        }
+
+        let recent = store.load_history(3).unwrap();
+        assert_eq!(recent.len(), 3);
+        // Should be the last 3 messages, in chronological order
+        assert!(recent[2].content.contains("msg 9"));
+    }
+}

--- a/crates/apiari/src/buzz/coordinator/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/mod.rs
@@ -17,6 +17,7 @@ use tracing::{info, warn};
 use apiari_claude_sdk::types::ContentBlock;
 use apiari_claude_sdk::{ClaudeClient, Event, SessionOptions};
 
+use crate::buzz::conversation::SessionToken;
 use crate::buzz::signal::store::SignalStore;
 
 /// Structured events emitted by the coordinator during a turn.
@@ -49,8 +50,10 @@ pub trait SafetyHooks: Send {
 pub struct Coordinator {
     name: String,
     model: String,
+    provider: String,
     max_turns: u32,
     session_id: Option<String>,
+    session_token: Option<SessionToken>,
     extra_context: Option<String>,
     prompt_preamble: Option<String>,
     allowed_tools: Vec<String>,
@@ -65,8 +68,10 @@ impl Coordinator {
         Self {
             name: "Bee".to_string(),
             model: model.to_string(),
+            provider: "claude".to_string(),
             max_turns,
             session_id: None,
+            session_token: None,
             extra_context: None,
             prompt_preamble: None,
             allowed_tools: Vec::new(),
@@ -120,6 +125,27 @@ impl Coordinator {
     /// Whether the coordinator has been used (has a persistent session).
     pub fn has_session(&self) -> bool {
         self.session_id.is_some()
+    }
+
+    /// Get the current session token (provider + resume token).
+    pub fn session_token(&self) -> Option<&SessionToken> {
+        self.session_token.as_ref()
+    }
+
+    /// Get the provider name (e.g. "claude").
+    pub fn provider(&self) -> &str {
+        &self.provider
+    }
+
+    /// Restore a session from a persisted token.
+    pub fn restore_session(&mut self, token: SessionToken) {
+        info!(
+            "restoring {} session (token: {}...)",
+            token.provider,
+            &token.token[..token.token.len().min(12)]
+        );
+        self.session_id = Some(token.token.clone());
+        self.session_token = Some(token);
     }
 
     /// Get current max turns.
@@ -215,6 +241,10 @@ impl Coordinator {
             }
             Event::Result(result) => {
                 self.session_id = Some(result.session_id.clone());
+                self.session_token = Some(SessionToken {
+                    provider: self.provider.clone(),
+                    token: result.session_id.clone(),
+                });
             }
             _ => {}
         }
@@ -304,6 +334,7 @@ impl Coordinator {
     pub fn reset_session(&mut self) {
         info!("coordinator session reset");
         self.session_id = None;
+        self.session_token = None;
     }
 }
 

--- a/crates/apiari/src/buzz/coordinator/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/mod.rs
@@ -142,7 +142,7 @@ impl Coordinator {
         info!(
             "restoring {} session (token: {}...)",
             token.provider,
-            &token.token[..token.token.len().min(12)]
+            token.token.get(..12).unwrap_or(&token.token)
         );
         self.session_id = Some(token.token.clone());
         self.session_token = Some(token);

--- a/crates/apiari/src/buzz/mod.rs
+++ b/crates/apiari/src/buzz/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod channel;
 pub mod config;
+pub mod conversation;
 pub mod coordinator;
 pub mod daemon;
 pub mod pipeline;

--- a/crates/apiari/src/buzz/signal/store.rs
+++ b/crates/apiari/src/buzz/signal/store.rs
@@ -83,6 +83,19 @@ impl SignalStore {
                 content TEXT NOT NULL,
                 created_at TEXT NOT NULL
             );
+
+            CREATE TABLE IF NOT EXISTS conversations (
+                id          INTEGER PRIMARY KEY,
+                workspace   TEXT NOT NULL,
+                role        TEXT NOT NULL,
+                content     TEXT NOT NULL,
+                source      TEXT,
+                provider    TEXT,
+                session_id  TEXT,
+                created_at  TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_conversations_workspace
+                ON conversations(workspace, created_at);
             ",
         )?;
         Ok(())

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -16,6 +16,7 @@ use crate::git_safety::GitSafetyHooks;
 
 use crate::buzz::channel::telegram::TelegramChannel;
 use crate::buzz::channel::{Channel, ChannelEvent, OutboundMessage};
+use crate::buzz::conversation::ConversationStore;
 use crate::buzz::coordinator::prompt::format_signal_summary;
 use crate::buzz::coordinator::skills::{
     SkillContext, build_skills_prompt, default_coordinator_disallowed_tools,
@@ -185,6 +186,27 @@ async fn run_coordinator_task(
                 // Stop typing indicator
                 typing_cancel.cancel();
 
+                // Persist messages to DB (scoped to drop before await)
+                {
+                    let conv = ConversationStore::new(store.conn(), store.workspace());
+                    if let Err(e) = conv.save_message("user", &text, Some("telegram"), None, None) {
+                        warn!("[{slot_name}] failed to save user message: {e}");
+                    }
+                    if let Ok(ref response) = result {
+                        let session_id = coordinator.session_token().map(|t| t.token.as_str());
+                        let provider = Some(coordinator.provider());
+                        if let Err(e) = conv.save_message(
+                            "assistant",
+                            response,
+                            Some("system"),
+                            provider,
+                            session_id,
+                        ) {
+                            warn!("[{slot_name}] failed to save assistant message: {e}");
+                        }
+                    }
+                }
+
                 match result {
                     Ok(response) => {
                         if let Some(ref server) = socket_server {
@@ -226,6 +248,13 @@ async fn run_coordinator_task(
                     }
                     Err(e) => {
                         error!("[{slot_name}] coordinator error: {e}");
+                        // If session resume failed, reset and try fresh next time
+                        if coordinator.has_session() {
+                            warn!(
+                                "[{slot_name}] resetting session after error (possible expired resume token)"
+                            );
+                            coordinator.reset_session();
+                        }
                         let msg = OutboundMessage {
                             chat_id,
                             text: format!("Error: {e}"),
@@ -283,6 +312,27 @@ async fn run_coordinator_task(
                     })
                     .await;
 
+                // Persist messages to DB (scoped to drop before any further borrows)
+                {
+                    let conv = ConversationStore::new(store.conn(), store.workspace());
+                    if let Err(e) = conv.save_message("user", &text, Some("tui"), None, None) {
+                        warn!("[{ws_name}] failed to save user message: {e}");
+                    }
+                    if let Ok(ref response) = result {
+                        let session_id = coordinator.session_token().map(|t| t.token.as_str());
+                        let provider = Some(coordinator.provider());
+                        if let Err(e) = conv.save_message(
+                            "assistant",
+                            response,
+                            Some("system"),
+                            provider,
+                            session_id,
+                        ) {
+                            warn!("[{ws_name}] failed to save assistant message: {e}");
+                        }
+                    }
+                }
+
                 match result {
                     Ok(response) => {
                         let _ = responder.send(socket::DaemonResponse::Done);
@@ -296,6 +346,13 @@ async fn run_coordinator_task(
                         }
                     }
                     Err(e) => {
+                        // If session resume failed, reset and try fresh next time
+                        if coordinator.has_session() {
+                            warn!(
+                                "[{ws_name}] resetting session after error (possible expired resume token)"
+                            );
+                            coordinator.reset_session();
+                        }
                         let _ = responder.send(socket::DaemonResponse::Error {
                             text: format!("{e}"),
                         });
@@ -529,6 +586,31 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
 
         let pipeline_rules = to_pipeline_rules(&ws.config.pipeline);
         let pipeline = Pipeline::new(pipeline_rules, ws.config.pipeline.batch_window_secs);
+
+        // Restore session from DB if available
+        {
+            let conv = ConversationStore::new(store.conn(), &ws.name);
+            match conv.last_session() {
+                Ok(Some(token)) if token.provider == coordinator.provider() => {
+                    info!("[{}] restoring {} session from DB", ws.name, token.provider);
+                    coordinator.restore_session(token);
+                }
+                Ok(Some(token)) => {
+                    info!(
+                        "[{}] skipping session restore: provider mismatch (db={}, current={})",
+                        ws.name,
+                        token.provider,
+                        coordinator.provider()
+                    );
+                }
+                Ok(None) => {
+                    info!("[{}] no previous session to restore", ws.name);
+                }
+                Err(e) => {
+                    warn!("[{}] failed to query last session: {e}", ws.name);
+                }
+            }
+        }
 
         // Spawn dedicated coordinator task for this workspace
         let coord_store = match SignalStore::open(&db, &ws.name) {

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 
 use apiari_tui::scroll::ScrollState;
 
+use crate::buzz::conversation::ConversationStore;
 use crate::config::{self, Workspace};
 
 // ── Constants ─────────────────────────────────────────────
@@ -232,26 +233,37 @@ pub struct App {
 impl App {
     /// Create app from discovered workspaces, focusing the given tab.
     pub fn new(workspaces: Vec<Workspace>, focus_workspace: Option<&str>) -> Self {
+        let db = config::db_path();
         let ws_states: Vec<WorkspaceState> = workspaces
             .into_iter()
             .map(|ws| {
-                // Load chat history
-                let history = super::history::load_history(&ws.name, 200);
-                let chat_history: Vec<ChatLine> = history
-                    .into_iter()
-                    .map(|msg| {
-                        let ts = msg.ts.format("%H:%M").to_string();
-                        let source = msg.source.as_deref().map(|s| match s {
-                            "telegram" => MessageSource::Telegram,
-                            "system" => MessageSource::System,
-                            _ => MessageSource::Tui,
-                        });
-                        match msg.role.as_str() {
-                            "user" => ChatLine::User(msg.content, ts, source),
-                            _ => ChatLine::Assistant(msg.content, ts, source),
+                // Load chat history from DB (primary), falling back to JSONL (legacy)
+                let chat_history: Vec<ChatLine> =
+                    if let Ok(store) = SignalStore::open(&db, &ws.name) {
+                        let conv = ConversationStore::new(store.conn(), &ws.name);
+                        match conv.load_history(200) {
+                            Ok(rows) if !rows.is_empty() => rows
+                                .into_iter()
+                                .map(|row| {
+                                    let ts = chrono::DateTime::parse_from_rfc3339(&row.created_at)
+                                        .map(|dt| dt.format("%H:%M").to_string())
+                                        .unwrap_or_default();
+                                    let source = row.source.as_deref().map(|s| match s {
+                                        "telegram" => MessageSource::Telegram,
+                                        "system" => MessageSource::System,
+                                        _ => MessageSource::Tui,
+                                    });
+                                    match row.role.as_str() {
+                                        "user" => ChatLine::User(row.content, ts, source),
+                                        _ => ChatLine::Assistant(row.content, ts, source),
+                                    }
+                                })
+                                .collect(),
+                            _ => load_history_from_jsonl(&ws.name),
                         }
-                    })
-                    .collect();
+                    } else {
+                        load_history_from_jsonl(&ws.name)
+                    };
 
                 // Extract coordinator preview from last assistant message
                 let coordinator_preview = chat_history.iter().rev().find_map(|msg| {
@@ -1216,6 +1228,26 @@ impl App {
 }
 
 // ── Free functions ────────────────────────────────────────
+
+/// Legacy fallback: load chat history from JSONL file.
+fn load_history_from_jsonl(workspace: &str) -> Vec<ChatLine> {
+    let history = super::history::load_history(workspace, 200);
+    history
+        .into_iter()
+        .map(|msg| {
+            let ts = msg.ts.format("%H:%M").to_string();
+            let source = msg.source.as_deref().map(|s| match s {
+                "telegram" => MessageSource::Telegram,
+                "system" => MessageSource::System,
+                _ => MessageSource::Tui,
+            });
+            match msg.role.as_str() {
+                "user" => ChatLine::User(msg.content, ts, source),
+                _ => ChatLine::Assistant(msg.content, ts, source),
+            }
+        })
+        .collect()
+}
 
 pub fn now_ts() -> String {
     chrono::Local::now().format("%H:%M").to_string()


### PR DESCRIPTION
## Summary
- Add `conversations` SQLite table for persistent message storage in the daemon
- Create `ConversationStore` with `save_message`, `load_history`, and `last_session` methods
- Add provider-agnostic `SessionToken` type to Coordinator for session resume across restarts
- Daemon now saves user/assistant messages directly to DB after each coordinator turn
- On daemon startup, restore last session token per workspace (with graceful fallback on failure)
- TUI loads chat history from DB, falling back to legacy JSONL files

## Test plan
- [x] All 181 existing tests pass
- [x] New `ConversationStore` unit tests cover save/load, last_session, workspace isolation, and limit
- [ ] Manual: verify messages persist across daemon restarts
- [ ] Manual: verify session resume works (coordinator uses `--resume` on restart)
- [ ] Manual: verify TUI shows DB-sourced history on connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)