### PR TITLE
feat: add quick approve/comment actions to review queue

### DIFF
--- a/crates/apiari/src/buzz/watcher/review_queue.rs
+++ b/crates/apiari/src/buzz/watcher/review_queue.rs
@@ -199,6 +199,7 @@ impl Watcher for ReviewQueueWatcher {
                     "priority": priority,
                     "author": pr.author,
                     "repo": pr.repo,
+                    "pr_number": pr.number,
                 });
 
                 // First query (priority 0) = Warning, others = Info

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1500,15 +1500,14 @@ pub fn review_signal_target(signal: &SignalRecord) -> Option<(String, u64)> {
     }
 
     // Try metadata first
-    if let Some(ref meta) = signal.metadata {
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(meta) {
-            if let (Some(repo), Some(pr)) = (
-                val.get("repo").and_then(|v| v.as_str()),
-                val.get("pr_number").and_then(|v| v.as_u64()),
-            ) {
-                return Some((repo.to_string(), pr));
-            }
-        }
+    if let Some(ref meta) = signal.metadata
+        && let Ok(val) = serde_json::from_str::<serde_json::Value>(meta)
+        && let (Some(repo), Some(pr)) = (
+            val.get("repo").and_then(|v| v.as_str()),
+            val.get("pr_number").and_then(|v| v.as_u64()),
+        )
+    {
+        return Some((repo.to_string(), pr));
     }
 
     // Fallback: parse from external_id (format: rq-{owner/repo}-{number})

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -63,6 +63,7 @@ pub enum ChatLine {
 pub enum PendingAction {
     CloseWorker(String), // worktree id
     ResolveSignal(i64),  // signal db id
+    ApproveReview { repo: String, pr_number: u64 },
 }
 
 #[derive(Debug, Clone)]
@@ -207,6 +208,11 @@ pub struct App {
     // Worker detail
     pub worker_input: String,
     pub worker_input_active: bool,
+    // Review comment input
+    pub review_comment_active: bool,
+    pub review_comment_input: String,
+    pub review_comment_repo: String,
+    pub review_comment_pr: u64,
     // Detail/list views
     pub content_scroll: u16,
     pub signal_list_selection: usize,
@@ -318,6 +324,10 @@ impl App {
             chat_focused: false,
             worker_input: String::new(),
             worker_input_active: false,
+            review_comment_active: false,
+            review_comment_input: String::new(),
+            review_comment_repo: String::new(),
+            review_comment_pr: 0,
             content_scroll: 0,
             signal_list_selection: 0,
             review_list_selection: 0,
@@ -1481,6 +1491,34 @@ fn truncate_preview(s: &str, max_chars: usize) -> String {
     }
 }
 
+/// Extract (repo, pr_number) from a review queue signal.
+/// Prefers metadata fields; falls back to parsing `external_id` (`rq-{repo}-{number}`).
+/// Returns `None` for non-GitHub review signals (e.g. Linear).
+pub fn review_signal_target(signal: &SignalRecord) -> Option<(String, u64)> {
+    if signal.source != "github_review_queue" {
+        return None;
+    }
+
+    // Try metadata first
+    if let Some(ref meta) = signal.metadata {
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(meta) {
+            if let (Some(repo), Some(pr)) = (
+                val.get("repo").and_then(|v| v.as_str()),
+                val.get("pr_number").and_then(|v| v.as_u64()),
+            ) {
+                return Some((repo.to_string(), pr));
+            }
+        }
+    }
+
+    // Fallback: parse from external_id (format: rq-{owner/repo}-{number})
+    let rest = signal.external_id.strip_prefix("rq-")?;
+    let last_dash = rest.rfind('-')?;
+    let repo = &rest[..last_dash];
+    let number: u64 = rest[last_dash + 1..].parse().ok()?;
+    Some((repo.to_string(), number))
+}
+
 /// Severity icon for display.
 pub fn severity_icon(severity: &Severity) -> &'static str {
     match severity {
@@ -1520,5 +1558,76 @@ pub fn elapsed_display(created_at: &Option<DateTime<Local>>) -> String {
             }
         }
         None => "?".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::buzz::signal::{Severity, SignalRecord, SignalStatus};
+    use chrono::Utc;
+
+    fn make_signal(source: &str, external_id: &str, metadata: Option<&str>) -> SignalRecord {
+        SignalRecord {
+            id: 1,
+            source: source.to_string(),
+            external_id: external_id.to_string(),
+            title: "Test PR".to_string(),
+            body: None,
+            severity: Severity::Info,
+            status: SignalStatus::Open,
+            url: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            resolved_at: None,
+            metadata: metadata.map(String::from),
+        }
+    }
+
+    #[test]
+    fn test_review_signal_target_from_metadata() {
+        let signal = make_signal(
+            "github_review_queue",
+            "rq-ApiariTools/apiari-42",
+            Some(r#"{"repo":"ApiariTools/apiari","pr_number":42,"author":"user1"}"#),
+        );
+        let result = review_signal_target(&signal);
+        assert_eq!(result, Some(("ApiariTools/apiari".to_string(), 42)));
+    }
+
+    #[test]
+    fn test_review_signal_target_fallback_from_external_id() {
+        let signal = make_signal(
+            "github_review_queue",
+            "rq-ApiariTools/apiari-42",
+            Some(r#"{"repo":"ApiariTools/apiari","author":"user1"}"#), // no pr_number
+        );
+        let result = review_signal_target(&signal);
+        assert_eq!(result, Some(("ApiariTools/apiari".to_string(), 42)));
+    }
+
+    #[test]
+    fn test_review_signal_target_no_metadata() {
+        let signal = make_signal("github_review_queue", "rq-org/repo-99", None);
+        let result = review_signal_target(&signal);
+        assert_eq!(result, Some(("org/repo".to_string(), 99)));
+    }
+
+    #[test]
+    fn test_review_signal_target_linear_returns_none() {
+        let signal = make_signal(
+            "linear_review_queue",
+            "linear-123",
+            Some(r#"{"repo":"org/repo","pr_number":123}"#),
+        );
+        let result = review_signal_target(&signal);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_review_signal_target_non_review_source_returns_none() {
+        let signal = make_signal("sentry", "sentry-42", None);
+        let result = review_signal_target(&signal);
+        assert_eq!(result, None);
     }
 }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -1058,7 +1058,7 @@ async fn handle_action(
                     .output()
                     .await;
             });
-            app.flash(format!("Comment sent on PR #{pr_number} in {repo}"));
+            app.flash(format!("Sending comment on PR #{pr_number} in {repo}..."));
         }
         KeyAction::ResolveSignal(id) => {
             let db = config::db_path();

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -6,7 +6,7 @@ pub mod history;
 pub mod render;
 pub mod theme;
 
-use app::{App, Mode, Panel, PendingAction, View};
+use app::{App, Mode, Panel, PendingAction, View, review_signal_target};
 use color_eyre::Result;
 use crossterm::ExecutableCommand;
 use crossterm::event::{Event, EventStream, KeyCode, KeyModifiers};
@@ -58,10 +58,22 @@ enum KeyAction {
     None,
     Quit,
     SendChat(String),
-    SendWorkerMessage { worker_id: String, text: String },
+    SendWorkerMessage {
+        worker_id: String,
+        text: String,
+    },
     OpenUrl(String),
     CloseWorker(String),
     ResolveSignal(i64),
+    ApproveReview {
+        repo: String,
+        pr_number: u64,
+    },
+    CommentReview {
+        repo: String,
+        pr_number: u64,
+        body: String,
+    },
     Redraw,
 }
 
@@ -300,6 +312,9 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
                     match action {
                         PendingAction::CloseWorker(id) => return KeyAction::CloseWorker(id),
                         PendingAction::ResolveSignal(id) => return KeyAction::ResolveSignal(id),
+                        PendingAction::ApproveReview { repo, pr_number } => {
+                            return KeyAction::ApproveReview { repo, pr_number };
+                        }
                     }
                 }
             }
@@ -311,6 +326,11 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
             _ => {}
         }
         return KeyAction::Redraw;
+    }
+
+    // ── Review comment input ──
+    if app.review_comment_active {
+        return handle_review_comment_key(app, key);
     }
 
     // ── Help overlay ──
@@ -390,13 +410,39 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
         KeyCode::Char('j') | KeyCode::Down => app.select_next_in_panel(),
         KeyCode::Char('k') | KeyCode::Up => app.select_prev_in_panel(),
         KeyCode::Enter => app.drill_in(),
-        KeyCode::Char('c') => {
-            app.focused_panel = Panel::Chat;
-            app.chat_focused = true;
-            if let Some(ws) = app.current_ws_mut() {
-                ws.has_unread_response = false;
+        KeyCode::Char('a') => {
+            if app.focused_panel == Panel::Reviews {
+                if let Some(signal) = app.selected_signal() {
+                    if let Some((repo, pr_number)) = review_signal_target(signal) {
+                        app.pending_action = Some(PendingAction::ApproveReview { repo, pr_number });
+                        app.mode = Mode::Confirm;
+                    } else {
+                        app.flash("Linear reviews are read-only");
+                    }
+                }
             }
-            app.needs_redraw = true;
+        }
+        KeyCode::Char('c') => {
+            if app.focused_panel == Panel::Reviews {
+                if let Some(signal) = app.selected_signal() {
+                    if let Some((repo, pr_number)) = review_signal_target(signal) {
+                        app.review_comment_active = true;
+                        app.review_comment_input.clear();
+                        app.review_comment_repo = repo;
+                        app.review_comment_pr = pr_number;
+                        app.needs_redraw = true;
+                    } else {
+                        app.flash("Linear reviews are read-only");
+                    }
+                }
+            } else {
+                app.focused_panel = Panel::Chat;
+                app.chat_focused = true;
+                if let Some(ws) = app.current_ws_mut() {
+                    ws.has_unread_response = false;
+                }
+                app.needs_redraw = true;
+            }
         }
         KeyCode::Char('z') => app.toggle_zoom(),
         KeyCode::Char('h') | KeyCode::Left => {
@@ -584,6 +630,42 @@ fn handle_worker_input_key(
     KeyAction::Redraw
 }
 
+// ── Review comment input keys ────────────────────────────
+
+fn handle_review_comment_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
+    match key.code {
+        KeyCode::Enter => {
+            let text = std::mem::take(&mut app.review_comment_input);
+            let repo = std::mem::take(&mut app.review_comment_repo);
+            let pr = app.review_comment_pr;
+            app.review_comment_active = false;
+            app.needs_redraw = true;
+            if !text.trim().is_empty() {
+                return KeyAction::CommentReview {
+                    repo,
+                    pr_number: pr,
+                    body: text,
+                };
+            }
+        }
+        KeyCode::Esc => {
+            app.review_comment_input.clear();
+            app.review_comment_active = false;
+            app.needs_redraw = true;
+        }
+        KeyCode::Backspace => {
+            app.review_comment_input.pop();
+            app.needs_redraw = true;
+        }
+        KeyCode::Char(c) => {
+            app.review_comment_input.push(c);
+            app.needs_redraw = true;
+        }
+        _ => {}
+    }
+    KeyAction::Redraw
+}
+
 // ── Signal detail keys ───────────────────────────────────
 
 fn handle_signal_detail_key(
@@ -717,6 +799,29 @@ fn handle_review_list_key(app: &mut App, key: crossterm::event::KeyEvent) -> Key
                         .nth(app.review_list_selection)
                 }) {
                     app.enter_signal_detail(orig_idx);
+                }
+            }
+        }
+        KeyCode::Char('a') => {
+            if let Some(signal) = app.selected_signal() {
+                if let Some((repo, pr_number)) = review_signal_target(signal) {
+                    app.pending_action = Some(PendingAction::ApproveReview { repo, pr_number });
+                    app.mode = Mode::Confirm;
+                } else {
+                    app.flash("Linear reviews are read-only");
+                }
+            }
+        }
+        KeyCode::Char('c') => {
+            if let Some(signal) = app.selected_signal() {
+                if let Some((repo, pr_number)) = review_signal_target(signal) {
+                    app.review_comment_active = true;
+                    app.review_comment_input.clear();
+                    app.review_comment_repo = repo;
+                    app.review_comment_pr = pr_number;
+                    app.needs_redraw = true;
+                } else {
+                    app.flash("Linear reviews are read-only");
                 }
             }
         }
@@ -918,6 +1023,44 @@ async fn handle_action(
                 });
                 app.flash(format!("Closing worker {id}..."));
             }
+        }
+        KeyAction::ApproveReview { repo, pr_number } => {
+            let r = repo.clone();
+            let pr = pr_number;
+            tokio::spawn(async move {
+                let output = tokio::process::Command::new("gh")
+                    .args(["pr", "review", &pr.to_string(), "--approve", "--repo", &r])
+                    .output()
+                    .await;
+                output
+            });
+            app.flash(format!("Approving PR #{pr_number} in {repo}..."));
+        }
+        KeyAction::CommentReview {
+            repo,
+            pr_number,
+            body,
+        } => {
+            let r = repo.clone();
+            let pr = pr_number;
+            let b = body.clone();
+            tokio::spawn(async move {
+                let output = tokio::process::Command::new("gh")
+                    .args([
+                        "pr",
+                        "review",
+                        &pr.to_string(),
+                        "--comment",
+                        "--body",
+                        &b,
+                        "--repo",
+                        &r,
+                    ])
+                    .output()
+                    .await;
+                output
+            });
+            app.flash(format!("Comment sent on PR #{pr_number} in {repo}"));
         }
         KeyAction::ResolveSignal(id) => {
             let db = config::db_path();

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -411,14 +411,14 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
         KeyCode::Char('k') | KeyCode::Up => app.select_prev_in_panel(),
         KeyCode::Enter => app.drill_in(),
         KeyCode::Char('a') => {
-            if app.focused_panel == Panel::Reviews {
-                if let Some(signal) = app.selected_signal() {
-                    if let Some((repo, pr_number)) = review_signal_target(signal) {
-                        app.pending_action = Some(PendingAction::ApproveReview { repo, pr_number });
-                        app.mode = Mode::Confirm;
-                    } else {
-                        app.flash("Linear reviews are read-only");
-                    }
+            if app.focused_panel == Panel::Reviews
+                && let Some(signal) = app.selected_signal()
+            {
+                if let Some((repo, pr_number)) = review_signal_target(signal) {
+                    app.pending_action = Some(PendingAction::ApproveReview { repo, pr_number });
+                    app.mode = Mode::Confirm;
+                } else {
+                    app.flash("Linear reviews are read-only");
                 }
             }
         }
@@ -1028,11 +1028,10 @@ async fn handle_action(
             let r = repo.clone();
             let pr = pr_number;
             tokio::spawn(async move {
-                let output = tokio::process::Command::new("gh")
+                let _ = tokio::process::Command::new("gh")
                     .args(["pr", "review", &pr.to_string(), "--approve", "--repo", &r])
                     .output()
                     .await;
-                output
             });
             app.flash(format!("Approving PR #{pr_number} in {repo}..."));
         }
@@ -1045,7 +1044,7 @@ async fn handle_action(
             let pr = pr_number;
             let b = body.clone();
             tokio::spawn(async move {
-                let output = tokio::process::Command::new("gh")
+                let _ = tokio::process::Command::new("gh")
                     .args([
                         "pr",
                         "review",
@@ -1058,7 +1057,6 @@ async fn handle_action(
                     ])
                     .output()
                     .await;
-                output
             });
             app.flash(format!("Comment sent on PR #{pr_number} in {repo}"));
         }

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -2002,7 +2002,15 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 app.zoomed_panel
             };
-            if app.chat_focused {
+            if app.review_comment_active {
+                vec![
+                    Span::raw(" "),
+                    Span::styled("enter", theme::key_hint()),
+                    Span::styled(":send  ", theme::key_desc()),
+                    Span::styled("esc", theme::key_hint()),
+                    Span::styled(":cancel", theme::key_desc()),
+                ]
+            } else if app.chat_focused {
                 vec![
                     Span::raw(" "),
                     Span::styled("enter", theme::key_hint()),
@@ -2042,21 +2050,14 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                     Span::styled("q", theme::key_hint()),
                     Span::styled(":quit", theme::key_desc()),
                 ]
-            } else if app.review_comment_active {
-                vec![
-                    Span::raw(" "),
-                    Span::styled("enter", theme::key_hint()),
-                    Span::styled(":send  ", theme::key_desc()),
-                    Span::styled("esc", theme::key_hint()),
-                    Span::styled(":cancel", theme::key_desc()),
-                ]
             } else {
                 let has_reviews = app.current_ws().is_some_and(|ws| {
                     ws.signals
                         .iter()
                         .any(|s| s.source.ends_with("_review_queue"))
                 });
-                let review_focused = app.focused_panel == Panel::Reviews
+                let on_reviews_panel = app.focused_panel == Panel::Reviews;
+                let github_review = on_reviews_panel
                     && app
                         .selected_signal()
                         .is_some_and(|s| s.source == "github_review_queue");
@@ -2069,12 +2070,12 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                     Span::styled("enter", theme::key_hint()),
                     Span::styled(":detail  ", theme::key_desc()),
                 ];
-                if review_focused {
+                if github_review {
                     h.push(Span::styled("a", theme::key_hint()));
                     h.push(Span::styled(":approve  ", theme::key_desc()));
                     h.push(Span::styled("c", theme::key_hint()));
                     h.push(Span::styled(":comment  ", theme::key_desc()));
-                } else {
+                } else if !on_reviews_panel {
                     h.push(Span::styled("c", theme::key_hint()));
                     h.push(Span::styled(":chat  ", theme::key_desc()));
                 }

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -55,6 +55,11 @@ pub fn draw(frame: &mut Frame, app: &App) {
         }
         _ => {}
     }
+
+    // Review comment input overlay
+    if app.review_comment_active {
+        draw_review_comment_input(frame, size, app);
+    }
 }
 
 // ── Tab bar ──────────────────────────────────────────────
@@ -1861,6 +1866,10 @@ fn draw_review_list(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(":nav  ", theme::key_desc()),
         Span::styled("enter", theme::key_hint()),
         Span::styled(":detail  ", theme::key_desc()),
+        Span::styled("a", theme::key_hint()),
+        Span::styled(":approve  ", theme::key_desc()),
+        Span::styled("c", theme::key_hint()),
+        Span::styled(":comment  ", theme::key_desc()),
         Span::styled("o", theme::key_hint()),
         Span::styled(":open  ", theme::key_desc()),
         Span::styled("esc", theme::key_hint()),
@@ -2033,12 +2042,24 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                     Span::styled("q", theme::key_hint()),
                     Span::styled(":quit", theme::key_desc()),
                 ]
+            } else if app.review_comment_active {
+                vec![
+                    Span::raw(" "),
+                    Span::styled("enter", theme::key_hint()),
+                    Span::styled(":send  ", theme::key_desc()),
+                    Span::styled("esc", theme::key_hint()),
+                    Span::styled(":cancel", theme::key_desc()),
+                ]
             } else {
                 let has_reviews = app.current_ws().is_some_and(|ws| {
                     ws.signals
                         .iter()
                         .any(|s| s.source.ends_with("_review_queue"))
                 });
+                let review_focused = app.focused_panel == Panel::Reviews
+                    && app
+                        .selected_signal()
+                        .is_some_and(|s| s.source == "github_review_queue");
                 let mut h = vec![
                     Span::raw(" "),
                     Span::styled("tab", theme::key_hint()),
@@ -2047,13 +2068,20 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                     Span::styled(":nav  ", theme::key_desc()),
                     Span::styled("enter", theme::key_hint()),
                     Span::styled(":detail  ", theme::key_desc()),
-                    Span::styled("c", theme::key_hint()),
-                    Span::styled(":chat  ", theme::key_desc()),
-                    Span::styled("z", theme::key_hint()),
-                    Span::styled(":zoom  ", theme::key_desc()),
-                    Span::styled("p", theme::key_hint()),
-                    Span::styled(":prs  ", theme::key_desc()),
                 ];
+                if review_focused {
+                    h.push(Span::styled("a", theme::key_hint()));
+                    h.push(Span::styled(":approve  ", theme::key_desc()));
+                    h.push(Span::styled("c", theme::key_hint()));
+                    h.push(Span::styled(":comment  ", theme::key_desc()));
+                } else {
+                    h.push(Span::styled("c", theme::key_hint()));
+                    h.push(Span::styled(":chat  ", theme::key_desc()));
+                }
+                h.push(Span::styled("z", theme::key_hint()));
+                h.push(Span::styled(":zoom  ", theme::key_desc()));
+                h.push(Span::styled("p", theme::key_hint()));
+                h.push(Span::styled(":prs  ", theme::key_desc()));
                 if has_reviews {
                     h.push(Span::styled("r", theme::key_hint()));
                     h.push(Span::styled(":reviews  ", theme::key_desc()));
@@ -2125,17 +2153,39 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("esc", theme::key_hint()),
             Span::styled(":back", theme::key_desc()),
         ],
-        View::ReviewList => vec![
-            Span::raw(" "),
-            Span::styled("j/k", theme::key_hint()),
-            Span::styled(":nav  ", theme::key_desc()),
-            Span::styled("enter", theme::key_hint()),
-            Span::styled(":detail  ", theme::key_desc()),
-            Span::styled("o", theme::key_hint()),
-            Span::styled(":open  ", theme::key_desc()),
-            Span::styled("esc", theme::key_hint()),
-            Span::styled(":back", theme::key_desc()),
-        ],
+        View::ReviewList => {
+            if app.review_comment_active {
+                vec![
+                    Span::raw(" "),
+                    Span::styled("enter", theme::key_hint()),
+                    Span::styled(":send  ", theme::key_desc()),
+                    Span::styled("esc", theme::key_hint()),
+                    Span::styled(":cancel", theme::key_desc()),
+                ]
+            } else {
+                let is_github = app
+                    .selected_signal()
+                    .is_some_and(|s| s.source == "github_review_queue");
+                let mut h = vec![
+                    Span::raw(" "),
+                    Span::styled("j/k", theme::key_hint()),
+                    Span::styled(":nav  ", theme::key_desc()),
+                    Span::styled("enter", theme::key_hint()),
+                    Span::styled(":detail  ", theme::key_desc()),
+                ];
+                if is_github {
+                    h.push(Span::styled("a", theme::key_hint()));
+                    h.push(Span::styled(":approve  ", theme::key_desc()));
+                    h.push(Span::styled("c", theme::key_hint()));
+                    h.push(Span::styled(":comment  ", theme::key_desc()));
+                }
+                h.push(Span::styled("o", theme::key_hint()));
+                h.push(Span::styled(":open  ", theme::key_desc()));
+                h.push(Span::styled("esc", theme::key_hint()));
+                h.push(Span::styled(":back", theme::key_desc()));
+                h
+            }
+        }
     };
 
     // Right-aligned daemon status with ECG heartbeat trace
@@ -2369,6 +2419,9 @@ fn draw_confirm_overlay(frame: &mut Frame, area: Rect, action: &PendingAction) {
     let message = match action {
         PendingAction::CloseWorker(id) => format!("Close worker '{id}'?"),
         PendingAction::ResolveSignal(id) => format!("Resolve signal #{id}?"),
+        PendingAction::ApproveReview { repo, pr_number } => {
+            format!("Approve PR #{pr_number} in {repo}?")
+        }
     };
 
     let w = (message.len() as u16 + 8).min(area.width.saturating_sub(4));
@@ -2399,6 +2452,43 @@ fn draw_confirm_overlay(frame: &mut Frame, area: Rect, action: &PendingAction) {
     ];
 
     let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, inner);
+}
+
+fn draw_review_comment_input(frame: &mut Frame, area: Rect, app: &App) {
+    let title = format!(
+        " Comment on PR #{} in {} ",
+        app.review_comment_pr, app.review_comment_repo
+    );
+    let w = (area.width.saturating_sub(4)).min(60);
+    let h = 5u16;
+    let x = (area.width.saturating_sub(w)) / 2;
+    let y = (area.height.saturating_sub(h)) / 2;
+    let popup = Rect::new(x, y, w, h);
+
+    frame.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::border_active())
+        .title(Span::styled(title, theme::accent()));
+
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let input_text = format!(" {}_", app.review_comment_input);
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![Span::styled(input_text, theme::text())]),
+        Line::from(vec![
+            Span::styled("  enter", theme::key_hint()),
+            Span::styled(":send  ", theme::key_desc()),
+            Span::styled("esc", theme::key_hint()),
+            Span::styled(":cancel", theme::key_desc()),
+        ]),
+    ];
+
+    let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(paragraph, inner);
 }
 


### PR DESCRIPTION
## Summary
- Adds `a` (approve) and `c` (comment) keyboard shortcuts for GitHub review queue signals in both the dashboard Reviews panel and the full-screen ReviewList view
- Approve shows a y/n confirmation overlay, then runs `gh pr review --approve`
- Comment opens an inline input popup, then runs `gh pr review --comment --body "..."`
- Status bar hints update contextually to show `a:approve c:comment` when a GitHub review signal is focused
- Linear review signals are treated as read-only (flash message on action attempt)
- Adds `pr_number` to review queue signal metadata for direct access without parsing external_id
- Includes `review_signal_target()` helper with fallback parsing from `external_id`

## Test plan
- [x] `cargo check -p apiari` — compiles with no warnings
- [x] `cargo test -p apiari` — all 188 tests pass (5 new tests for `review_signal_target()`)
- [ ] Manual: focus Reviews panel on dashboard, press `a` on GitHub signal → confirm overlay → approve
- [ ] Manual: press `c` on GitHub signal → comment input popup → send comment
- [ ] Manual: press `a`/`c` on Linear signal → "Linear reviews are read-only" flash
- [ ] Manual: open ReviewList (`r`), verify `a`/`c` work there too
- [ ] Manual: status bar shows `a:approve c:comment` only for GitHub signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)