### PR TITLE
feat: add snooze/defer functionality to signals

### DIFF
--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -182,6 +182,7 @@ mod tests {
             updated_at: Utc::now(),
             resolved_at: None,
             metadata: None,
+            snoozed_until: None,
         }
     }
 

--- a/crates/apiari/src/buzz/pipeline/batch.rs
+++ b/crates/apiari/src/buzz/pipeline/batch.rs
@@ -79,6 +79,7 @@ mod tests {
             updated_at: Utc::now(),
             resolved_at: None,
             metadata: None,
+            snoozed_until: None,
         }
     }
 

--- a/crates/apiari/src/buzz/pipeline/format.rs
+++ b/crates/apiari/src/buzz/pipeline/format.rs
@@ -87,6 +87,7 @@ mod tests {
             updated_at: Utc::now(),
             resolved_at: None,
             metadata: None,
+            snoozed_until: None,
         }
     }
 

--- a/crates/apiari/src/buzz/pipeline/mod.rs
+++ b/crates/apiari/src/buzz/pipeline/mod.rs
@@ -128,6 +128,7 @@ mod tests {
             updated_at: Utc::now(),
             resolved_at: None,
             metadata: None,
+            snoozed_until: None,
         }
     }
 

--- a/crates/apiari/src/buzz/signal/mod.rs
+++ b/crates/apiari/src/buzz/signal/mod.rs
@@ -100,6 +100,7 @@ pub struct SignalRecord {
     pub updated_at: DateTime<Utc>,
     pub resolved_at: Option<DateTime<Utc>>,
     pub metadata: Option<String>,
+    pub snoozed_until: Option<DateTime<Utc>>,
 }
 
 /// An update from a watcher — upserted into the store by (source, external_id).

--- a/crates/apiari/src/buzz/signal/store.rs
+++ b/crates/apiari/src/buzz/signal/store.rs
@@ -99,10 +99,17 @@ impl SignalStore {
             ",
         )?;
 
-        // Migration: add snoozed_until column if missing
-        let _ = self
+        // Migration: add snoozed_until column if missing.
+        // Ignore "duplicate column" errors (column already exists), propagate others.
+        if let Err(e) = self
             .conn
-            .execute_batch("ALTER TABLE signals ADD COLUMN snoozed_until TEXT;");
+            .execute_batch("ALTER TABLE signals ADD COLUMN snoozed_until TEXT;")
+        {
+            let msg = e.to_string();
+            if !msg.contains("duplicate column") {
+                return Err(e).wrap_err("failed to add snoozed_until column");
+            }
+        }
 
         Ok(())
     }

--- a/crates/apiari/src/buzz/signal/store.rs
+++ b/crates/apiari/src/buzz/signal/store.rs
@@ -98,6 +98,12 @@ impl SignalStore {
                 ON conversations(workspace, created_at);
             ",
         )?;
+
+        // Migration: add snoozed_until column if missing
+        let _ = self
+            .conn
+            .execute_batch("ALTER TABLE signals ADD COLUMN snoozed_until TEXT;");
+
         Ok(())
     }
 
@@ -167,11 +173,13 @@ impl SignalStore {
 
     /// Get all signals with non-resolved/stale status for this workspace.
     pub fn get_open_signals(&self) -> Result<Vec<SignalRecord>> {
+        let now = Utc::now().to_rfc3339();
         let mut stmt = self.conn.prepare(
             "SELECT id, source, external_id, title, body, severity, status,
-                    url, created_at, updated_at, resolved_at, metadata
+                    url, created_at, updated_at, resolved_at, metadata, snoozed_until
              FROM signals
              WHERE workspace = ?1 AND status IN ('open', 'updated')
+               AND (snoozed_until IS NULL OR snoozed_until <= ?2)
              ORDER BY
                 CASE severity
                     WHEN 'critical' THEN 0
@@ -183,7 +191,7 @@ impl SignalStore {
         )?;
 
         let records = stmt
-            .query_map(params![self.workspace], |row| {
+            .query_map(params![self.workspace, now], |row| {
                 Ok(SignalRecord {
                     id: row.get(0)?,
                     source: row.get(1)?,
@@ -199,6 +207,9 @@ impl SignalStore {
                         .get::<_, Option<String>>(10)?
                         .map(|s| parse_datetime(&s)),
                     metadata: row.get(11)?,
+                    snoozed_until: row
+                        .get::<_, Option<String>>(12)?
+                        .map(|s| parse_datetime(&s)),
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -210,7 +221,7 @@ impl SignalStore {
     pub fn get_signal(&self, id: i64) -> Result<Option<SignalRecord>> {
         let result = self.conn.query_row(
             "SELECT id, source, external_id, title, body, severity, status,
-                    url, created_at, updated_at, resolved_at, metadata
+                    url, created_at, updated_at, resolved_at, metadata, snoozed_until
              FROM signals WHERE id = ?1 AND workspace = ?2",
             params![id, self.workspace],
             |row| {
@@ -229,6 +240,9 @@ impl SignalStore {
                         .get::<_, Option<String>>(10)?
                         .map(|s| parse_datetime(&s)),
                     metadata: row.get(11)?,
+                    snoozed_until: row
+                        .get::<_, Option<String>>(12)?
+                        .map(|s| parse_datetime(&s)),
                 })
             },
         );
@@ -247,6 +261,17 @@ impl SignalStore {
             "UPDATE signals SET status = 'resolved', resolved_at = ?1, updated_at = ?1
              WHERE id = ?2 AND workspace = ?3",
             params![now, id, self.workspace],
+        )?;
+        Ok(())
+    }
+
+    /// Snooze a signal until the given timestamp.
+    pub fn snooze_signal(&self, id: i64, until: DateTime<Utc>) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "UPDATE signals SET snoozed_until = ?1, updated_at = ?2
+             WHERE id = ?3 AND workspace = ?4",
+            params![until.to_rfc3339(), now, id, self.workspace],
         )?;
         Ok(())
     }
@@ -331,7 +356,7 @@ impl SignalStore {
     pub fn get_all_signals(&self) -> Result<Vec<SignalRecord>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, source, external_id, title, body, severity, status,
-                    url, created_at, updated_at, resolved_at, metadata
+                    url, created_at, updated_at, resolved_at, metadata, snoozed_until
              FROM signals WHERE workspace = ?1 ORDER BY updated_at DESC",
         )?;
 
@@ -352,6 +377,9 @@ impl SignalStore {
                         .get::<_, Option<String>>(10)?
                         .map(|s| parse_datetime(&s)),
                     metadata: row.get(11)?,
+                    snoozed_until: row
+                        .get::<_, Option<String>>(12)?
+                        .map(|s| parse_datetime(&s)),
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -397,7 +425,7 @@ impl SignalStore {
     pub fn get_recent_signals(&self, n: usize) -> Result<Vec<SignalRecord>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, source, external_id, title, body, severity, status,
-                    url, created_at, updated_at, resolved_at, metadata
+                    url, created_at, updated_at, resolved_at, metadata, snoozed_until
              FROM signals WHERE workspace = ?1 ORDER BY updated_at DESC LIMIT ?2",
         )?;
         let records = stmt
@@ -417,6 +445,9 @@ impl SignalStore {
                         .get::<_, Option<String>>(10)?
                         .map(|s| parse_datetime(&s)),
                     metadata: row.get(11)?,
+                    snoozed_until: row
+                        .get::<_, Option<String>>(12)?
+                        .map(|s| parse_datetime(&s)),
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -926,5 +957,94 @@ mod tests {
         let record = store.get_signal(id).unwrap().unwrap();
         assert_eq!(record.title, "Bug (updated)");
         assert_eq!(record.metadata.as_deref(), Some(r#"{"count": 5}"#));
+    }
+
+    #[test]
+    fn test_snooze_signal_hides_from_open() {
+        let store = test_store();
+        let (id, _) = store
+            .upsert_signal(&make_update("sentry", "s1", "Bug", Severity::Error))
+            .unwrap();
+
+        // Snooze 1 hour into the future
+        let until = Utc::now() + chrono::Duration::hours(1);
+        store.snooze_signal(id, until).unwrap();
+
+        // Should not appear in open signals
+        let open = store.get_open_signals().unwrap();
+        assert!(open.is_empty());
+
+        // But should still be retrievable by ID
+        let record = store.get_signal(id).unwrap().unwrap();
+        assert!(record.snoozed_until.is_some());
+    }
+
+    #[test]
+    fn test_snooze_expired_reappears() {
+        let store = test_store();
+        let (id, _) = store
+            .upsert_signal(&make_update("sentry", "s1", "Bug", Severity::Error))
+            .unwrap();
+
+        // Snooze to the past — should reappear immediately
+        let past = Utc::now() - chrono::Duration::hours(1);
+        store.snooze_signal(id, past).unwrap();
+
+        let open = store.get_open_signals().unwrap();
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].id, id);
+    }
+
+    #[test]
+    fn test_upsert_preserves_snooze() {
+        let store = test_store();
+        let (id, _) = store
+            .upsert_signal(&make_update("sentry", "s1", "Bug", Severity::Error))
+            .unwrap();
+
+        // Snooze the signal
+        let until = Utc::now() + chrono::Duration::hours(2);
+        store.snooze_signal(id, until).unwrap();
+
+        // Re-upsert the same signal (as a watcher would)
+        store
+            .upsert_signal(&make_update(
+                "sentry",
+                "s1",
+                "Bug (updated)",
+                Severity::Error,
+            ))
+            .unwrap();
+
+        // Snooze should be preserved
+        let record = store.get_signal(id).unwrap().unwrap();
+        assert!(record.snoozed_until.is_some());
+        assert_eq!(record.title, "Bug (updated)");
+
+        // Still hidden from open signals
+        let open = store.get_open_signals().unwrap();
+        assert!(open.is_empty());
+    }
+
+    #[test]
+    fn test_snooze_replaces_existing() {
+        let store = test_store();
+        let (id, _) = store
+            .upsert_signal(&make_update("sentry", "s1", "Bug", Severity::Error))
+            .unwrap();
+
+        // First snooze
+        let until1 = Utc::now() + chrono::Duration::hours(1);
+        store.snooze_signal(id, until1).unwrap();
+
+        // Second snooze with different time
+        let until2 = Utc::now() + chrono::Duration::hours(4);
+        store.snooze_signal(id, until2).unwrap();
+
+        let record = store.get_signal(id).unwrap().unwrap();
+        let snoozed = record.snoozed_until.unwrap();
+        // The second snooze should have replaced the first
+        let diff = (snoozed - until2).num_seconds().abs();
+        assert!(diff < 2, "snooze should be close to until2");
     }
 }

--- a/crates/apiari/src/daemon/morning_brief.rs
+++ b/crates/apiari/src/daemon/morning_brief.rs
@@ -138,7 +138,10 @@ fn save_persisted_date(path: &Path, date: NaiveDate) {
     match serde_json::to_string_pretty(&state) {
         Ok(json) => {
             if let Err(e) = std::fs::write(path, json) {
-                warn!("failed to persist morning brief state to {}: {e}", path.display());
+                warn!(
+                    "failed to persist morning brief state to {}: {e}",
+                    path.display()
+                );
             }
         }
         Err(e) => {
@@ -357,6 +360,7 @@ mod tests {
             updated_at: Utc::now(),
             resolved_at: None,
             metadata: None,
+            snoozed_until: None,
         }
     }
 

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -4,7 +4,7 @@ use crate::buzz::coordinator::memory::MemoryStore;
 use crate::buzz::signal::store::SignalStore;
 use crate::buzz::signal::{Severity, SignalRecord};
 use apiari_tui::conversation::ConversationEntry;
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Datelike, Local, TimeZone, Utc};
 use serde::Deserialize;
 use std::io::{BufRead, Seek, SeekFrom};
 use std::path::Path;
@@ -64,7 +64,11 @@ pub enum PendingAction {
     CloseWorker(String), // worktree id
     ResolveSignal(i64),  // signal db id
     ApproveReview { repo: String, pr_number: u64 },
+    SnoozeSignal(i64), // signal db id
 }
+
+/// Snooze duration options for the duration picker.
+pub const SNOOZE_OPTIONS: &[&str] = &["1 hour", "4 hours", "Tomorrow 9am", "Next Monday 9am"];
 
 #[derive(Debug, Clone)]
 pub struct FlashMessage {
@@ -227,6 +231,8 @@ pub struct App {
     pub terminal_width: u16,
     // Activity graph (network-style throughput chart in status bar)
     pub activity_buf: Vec<u8>, // fixed array, each value = bar height 0-7
+    // Snooze
+    pub snooze_selection: usize,
     // Common
     pub pending_action: Option<PendingAction>,
     pub flash: Option<FlashMessage>,
@@ -338,6 +344,7 @@ impl App {
             last_extras_refresh: Instant::now(),
             terminal_width: 80,
             activity_buf: vec![0; 18],
+            snooze_selection: 0,
             pending_action: None,
             flash: None,
             needs_redraw: true,
@@ -952,6 +959,46 @@ impl App {
             expires: Instant::now() + std::time::Duration::from_secs(3),
         });
         self.needs_redraw = true;
+    }
+
+    /// Compute snooze-until timestamp from the selected duration index.
+    pub fn compute_snooze_until(selection: usize) -> DateTime<Utc> {
+        let now = Utc::now();
+        let local_now = Local::now();
+        match selection {
+            0 => now + chrono::Duration::hours(1),
+            1 => now + chrono::Duration::hours(4),
+            2 => {
+                // Tomorrow 9am local time
+                let tomorrow = local_now.date_naive() + chrono::Duration::days(1);
+                let nine_am = tomorrow.and_hms_opt(9, 0, 0).unwrap();
+                local_now
+                    .timezone()
+                    .from_local_datetime(&nine_am)
+                    .single()
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or(now + chrono::Duration::hours(12))
+            }
+            3 => {
+                // Next Monday 9am local time
+                let today = local_now.date_naive();
+                let days_until_monday = (8 - today.weekday().num_days_from_monday()) % 7;
+                let days_until_monday = if days_until_monday == 0 {
+                    7
+                } else {
+                    days_until_monday
+                };
+                let next_monday = today + chrono::Duration::days(days_until_monday as i64);
+                let nine_am = next_monday.and_hms_opt(9, 0, 0).unwrap();
+                local_now
+                    .timezone()
+                    .from_local_datetime(&nine_am)
+                    .single()
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or(now + chrono::Duration::hours(24))
+            }
+            _ => now + chrono::Duration::hours(1),
+        }
     }
 
     pub fn tick_flash(&mut self) {
@@ -1580,6 +1627,7 @@ mod tests {
             updated_at: Utc::now(),
             resolved_at: None,
             metadata: metadata.map(String::from),
+            snoozed_until: None,
         }
     }
 

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -982,7 +982,7 @@ impl App {
             3 => {
                 // Next Monday 9am local time
                 let today = local_now.date_naive();
-                let days_until_monday = (8 - today.weekday().num_days_from_monday()) % 7;
+                let days_until_monday = (7 - today.weekday().num_days_from_monday()) % 7;
                 let days_until_monday = if days_until_monday == 0 {
                     7
                 } else {

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -74,6 +74,7 @@ enum KeyAction {
         pr_number: u64,
         body: String,
     },
+    SnoozeSignal(i64, chrono::DateTime<chrono::Utc>),
     Redraw,
 }
 
@@ -305,6 +306,34 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
 
     // ── Confirm overlay ──
     if app.mode == Mode::Confirm {
+        // Snooze has its own key handling (j/k/enter/esc)
+        if matches!(app.pending_action, Some(PendingAction::SnoozeSignal(_))) {
+            match key.code {
+                KeyCode::Char('j') | KeyCode::Down => {
+                    if app.snooze_selection + 1 < app::SNOOZE_OPTIONS.len() {
+                        app.snooze_selection += 1;
+                    }
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    app.snooze_selection = app.snooze_selection.saturating_sub(1);
+                }
+                KeyCode::Enter => {
+                    if let Some(PendingAction::SnoozeSignal(id)) = app.pending_action.take() {
+                        app.mode = Mode::Normal;
+                        let until = app::App::compute_snooze_until(app.snooze_selection);
+                        return KeyAction::SnoozeSignal(id, until);
+                    }
+                }
+                KeyCode::Esc => {
+                    app.pending_action = None;
+                    app.mode = Mode::Normal;
+                    app.flash("Cancelled");
+                }
+                _ => {}
+            }
+            return KeyAction::Redraw;
+        }
+
         match key.code {
             KeyCode::Char('y') => {
                 if let Some(action) = app.pending_action.take() {
@@ -315,6 +344,7 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
                         PendingAction::ApproveReview { repo, pr_number } => {
                             return KeyAction::ApproveReview { repo, pr_number };
                         }
+                        PendingAction::SnoozeSignal(_) => unreachable!(),
                     }
                 }
             }
@@ -444,7 +474,6 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
                 app.needs_redraw = true;
             }
         }
-        KeyCode::Char('z') => app.toggle_zoom(),
         KeyCode::Char('h') | KeyCode::Left => {
             if app.zoomed_panel.is_some() || app.terminal_width < 50 {
                 app.prev_panel();
@@ -485,6 +514,18 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
                 let id = signal.id;
                 app.pending_action = Some(PendingAction::ResolveSignal(id));
                 app.mode = Mode::Confirm;
+            }
+        }
+        KeyCode::Char('z') => {
+            if matches!(app.focused_panel, Panel::Signals | Panel::Reviews) {
+                if let Some(signal) = app.selected_signal() {
+                    let id = signal.id;
+                    app.snooze_selection = 0;
+                    app.pending_action = Some(PendingAction::SnoozeSignal(id));
+                    app.mode = Mode::Confirm;
+                }
+            } else {
+                app.toggle_zoom();
             }
         }
         KeyCode::Char('G') => {
@@ -703,6 +744,16 @@ fn handle_signal_detail_key(
                 app.mode = Mode::Confirm;
             }
         }
+        KeyCode::Char('z') => {
+            if let Some(ws) = app.current_ws()
+                && let Some(signal) = ws.signals.get(idx)
+            {
+                let id = signal.id;
+                app.snooze_selection = 0;
+                app.pending_action = Some(PendingAction::SnoozeSignal(id));
+                app.mode = Mode::Confirm;
+            }
+        }
         KeyCode::Char('q') => return KeyAction::Quit,
         _ => {}
     }
@@ -748,6 +799,14 @@ fn handle_signal_list_key(app: &mut App, key: crossterm::event::KeyEvent) -> Key
             if let Some(signal) = app.selected_signal() {
                 let id = signal.id;
                 app.pending_action = Some(PendingAction::ResolveSignal(id));
+                app.mode = Mode::Confirm;
+            }
+        }
+        KeyCode::Char('z') => {
+            if let Some(signal) = app.selected_signal() {
+                let id = signal.id;
+                app.snooze_selection = 0;
+                app.pending_action = Some(PendingAction::SnoozeSignal(id));
                 app.mode = Mode::Confirm;
             }
         }
@@ -828,6 +887,14 @@ fn handle_review_list_key(app: &mut App, key: crossterm::event::KeyEvent) -> Key
         KeyCode::Char('o') => {
             if let Some(url) = app.selected_url() {
                 return KeyAction::OpenUrl(url);
+            }
+        }
+        KeyCode::Char('z') => {
+            if let Some(signal) = app.selected_signal() {
+                let id = signal.id;
+                app.snooze_selection = 0;
+                app.pending_action = Some(PendingAction::SnoozeSignal(id));
+                app.mode = Mode::Confirm;
             }
         }
         KeyCode::Char('q') => return KeyAction::Quit,
@@ -1072,6 +1139,25 @@ async fn handle_action(
                     }
                     Err(e) => {
                         app.flash(format!("Failed to resolve: {e}"));
+                    }
+                }
+            }
+        }
+        KeyAction::SnoozeSignal(id, until) => {
+            let db = config::db_path();
+            if let Some(ws) = app.current_ws()
+                && let Ok(store) = SignalStore::open(&db, &ws.name)
+            {
+                match store.snooze_signal(id, until) {
+                    Ok(()) => {
+                        let label = app::SNOOZE_OPTIONS
+                            .get(app.snooze_selection)
+                            .unwrap_or(&"snoozed");
+                        app.flash(format!("Signal #{id} snoozed until {label}"));
+                        app.refresh_signals();
+                    }
+                    Err(e) => {
+                        app.flash(format!("Failed to snooze: {e}"));
                     }
                 }
             }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -523,6 +523,8 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
                     app.snooze_selection = 0;
                     app.pending_action = Some(PendingAction::SnoozeSignal(id));
                     app.mode = Mode::Confirm;
+                } else {
+                    app.toggle_zoom();
                 }
             } else {
                 app.toggle_zoom();

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -50,7 +50,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
         Mode::Help => draw_help_overlay(frame, size),
         Mode::Confirm => {
             if let Some(ref action) = app.pending_action {
-                draw_confirm_overlay(frame, size, action);
+                draw_confirm_overlay(frame, size, action, app);
             }
         }
         _ => {}
@@ -1469,19 +1469,33 @@ fn render_signal_line(
     };
 
     let ago = time_ago(&signal.updated_at);
-    let meta = format!(" {:>8} {:>4}", signal.source, ago);
+    let is_snoozed = signal.snoozed_until.is_some_and(|t| t > chrono::Utc::now());
+    let snooze_tag = if is_snoozed { " zz" } else { "" };
+    let meta = format!("{snooze_tag} {:>8} {:>4}", signal.source, ago);
     let clean_title = strip_repo_prefix(&signal.title);
     let title_max = width.saturating_sub(meta.len() + 8);
     let title = trunc(clean_title, title_max);
 
-    Line::from(vec![
+    let mut spans = vec![
         Span::styled("\u{258c}", Style::default().fg(sev_color)),
         Span::styled(if selected { "\u{25b8}" } else { " " }, line_style),
         Span::styled(format!(" {icon} "), sev_style),
         Span::styled(title, line_style),
-        Span::styled(meta, theme::muted()),
-    ])
-    .style(bg)
+    ];
+    if is_snoozed {
+        spans.push(Span::styled(
+            snooze_tag.to_string(),
+            Style::default()
+                .fg(theme::SMOKE)
+                .add_modifier(Modifier::DIM),
+        ));
+        let rest_meta = format!(" {:>8} {:>4}", signal.source, ago);
+        spans.push(Span::styled(rest_meta, theme::muted()));
+    } else {
+        spans.push(Span::styled(meta, theme::muted()));
+    }
+
+    Line::from(spans).style(bg)
 }
 
 // ── Worker detail (full-screen) ──────────────────────────
@@ -1675,6 +1689,8 @@ fn draw_signal_detail(frame: &mut Frame, app: &App, area: Rect, idx: usize) {
         Span::styled(":open  ", theme::key_desc()),
         Span::styled("R", theme::key_hint()),
         Span::styled(":resolve  ", theme::key_desc()),
+        Span::styled("z", theme::key_hint()),
+        Span::styled(":snooze  ", theme::key_desc()),
         Span::styled("esc", theme::key_hint()),
         Span::styled(":back", theme::key_desc()),
     ]));
@@ -1728,6 +1744,8 @@ fn draw_signal_list(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(":open  ", theme::key_desc()),
         Span::styled("R", theme::key_hint()),
         Span::styled(":resolve  ", theme::key_desc()),
+        Span::styled("z", theme::key_hint()),
+        Span::styled(":snooze  ", theme::key_desc()),
         Span::styled("esc", theme::key_hint()),
         Span::styled(":back", theme::key_desc()),
     ]));
@@ -1872,6 +1890,8 @@ fn draw_review_list(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(":comment  ", theme::key_desc()),
         Span::styled("o", theme::key_hint()),
         Span::styled(":open  ", theme::key_desc()),
+        Span::styled("z", theme::key_hint()),
+        Span::styled(":snooze  ", theme::key_desc()),
         Span::styled("esc", theme::key_hint()),
         Span::styled(":back", theme::key_desc()),
     ]));
@@ -2416,17 +2436,57 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect) {
 
 // ── Confirm overlay ──────────────────────────────────────
 
-fn draw_confirm_overlay(frame: &mut Frame, area: Rect, action: &PendingAction) {
-    let message = match action {
-        PendingAction::CloseWorker(id) => format!("Close worker '{id}'?"),
-        PendingAction::ResolveSignal(id) => format!("Resolve signal #{id}?"),
-        PendingAction::ApproveReview { repo, pr_number } => {
-            format!("Approve PR #{pr_number} in {repo}?")
+fn draw_confirm_overlay(frame: &mut Frame, area: Rect, action: &PendingAction, app: &App) {
+    match action {
+        PendingAction::SnoozeSignal(_) => {
+            draw_snooze_overlay(frame, area, app);
         }
-    };
+        _ => {
+            let message = match action {
+                PendingAction::CloseWorker(id) => format!("Close worker '{id}'?"),
+                PendingAction::ResolveSignal(id) => format!("Resolve signal #{id}?"),
+                PendingAction::ApproveReview { repo, pr_number } => {
+                    format!("Approve PR #{pr_number} in {repo}?")
+                }
+                PendingAction::SnoozeSignal(_) => unreachable!(),
+            };
 
-    let w = (message.len() as u16 + 8).min(area.width.saturating_sub(4));
-    let h = 5u16;
+            let w = (message.len() as u16 + 8).min(area.width.saturating_sub(4));
+            let h = 5u16;
+            let x = (area.width.saturating_sub(w)) / 2;
+            let y = (area.height.saturating_sub(h)) / 2;
+            let popup = Rect::new(x, y, w, h);
+
+            frame.render_widget(Clear, popup);
+
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_style(theme::border_active())
+                .title(Span::styled(" Confirm ", theme::title()));
+
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+
+            let lines = vec![
+                Line::from(""),
+                Line::from(vec![Span::styled(format!("  {message}"), theme::text())]),
+                Line::from(vec![
+                    Span::styled("  y", theme::key_hint()),
+                    Span::styled(":yes  ", theme::key_desc()),
+                    Span::styled("n", theme::key_hint()),
+                    Span::styled(":no", theme::key_desc()),
+                ]),
+            ];
+
+            let paragraph = Paragraph::new(lines);
+            frame.render_widget(paragraph, inner);
+        }
+    }
+}
+
+fn draw_snooze_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let w = 32u16.min(area.width.saturating_sub(4));
+    let h = (app::SNOOZE_OPTIONS.len() as u16 + 5).min(area.height.saturating_sub(2));
     let x = (area.width.saturating_sub(w)) / 2;
     let y = (area.height.saturating_sub(h)) / 2;
     let popup = Rect::new(x, y, w, h);
@@ -2436,21 +2496,45 @@ fn draw_confirm_overlay(frame: &mut Frame, area: Rect, action: &PendingAction) {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(theme::border_active())
-        .title(Span::styled(" Confirm ", theme::title()));
+        .title(Span::styled(" Snooze until... ", theme::title()));
 
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
-    let lines = vec![
-        Line::from(""),
-        Line::from(vec![Span::styled(format!("  {message}"), theme::text())]),
-        Line::from(vec![
-            Span::styled("  y", theme::key_hint()),
-            Span::styled(":yes  ", theme::key_desc()),
-            Span::styled("n", theme::key_hint()),
-            Span::styled(":no", theme::key_desc()),
-        ]),
-    ];
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(""));
+
+    for (i, option) in app::SNOOZE_OPTIONS.iter().enumerate() {
+        let selected = i == app.snooze_selection;
+        let marker = if selected { "\u{25b8} " } else { "  " };
+        let style = if selected {
+            theme::selected()
+        } else {
+            theme::text()
+        };
+        let bg = if selected {
+            Style::default().bg(theme::FOCUS_BG)
+        } else {
+            Style::default()
+        };
+        lines.push(
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled(format!("{marker}{option}"), style),
+            ])
+            .style(bg),
+        );
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled("  j/k", theme::key_hint()),
+        Span::styled(":select  ", theme::key_desc()),
+        Span::styled("enter", theme::key_hint()),
+        Span::styled(":snooze  ", theme::key_desc()),
+        Span::styled("esc", theme::key_hint()),
+        Span::styled(":cancel", theme::key_desc()),
+    ]));
 
     let paragraph = Paragraph::new(lines);
     frame.render_widget(paragraph, inner);


### PR DESCRIPTION
## Summary
- Adds the ability to snooze signals for a configurable duration (1h, 4h, tomorrow 9am, next Monday 9am)
- Snoozed signals are hidden from the open signals list until their snooze expires
- Watcher upserts preserve existing snooze timestamps (won't reset when re-polled)

## Changes
- **DB**: `snoozed_until TEXT` column migration + `snooze_signal()` store method
- **Model**: `snoozed_until: Option<DateTime<Utc>>` on `SignalRecord`
- **TUI**: `z` key triggers snooze duration picker (j/k navigate, enter confirms, esc cancels)
- **Render**: Snooze duration picker overlay, `zz` indicator on snoozed signals, `z:snooze` key hints
- **Tests**: 4 new unit tests (hide while snoozed, reappear after expiry, preserve on upsert, replace existing snooze)

## Test plan
- [x] All 187 existing tests pass
- [x] 4 new snooze-specific tests pass
- [ ] Manual: press `z` on a signal in detail view → duration picker appears
- [ ] Manual: select duration and confirm → signal disappears from open list
- [ ] Manual: snoozed signal reappears after snooze expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)