### PR TITLE
fix: improve CI pass/fail notification reliability

### DIFF
--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -109,12 +109,7 @@ pub fn build_system_prompt(
             "Proactively mention CI results to the user when relevant to PRs they are watching.\n",
         );
         for signal in &ci_signals {
-            let icon = if signal.external_id.starts_with("ci-pass-") {
-                "passed"
-            } else {
-                "FAILED"
-            };
-            prompt.push_str(&format!("- CI {icon}: {title}", title = signal.title));
+            prompt.push_str(&format!("- {title}", title = signal.title));
             if let Some(ref url) = signal.url {
                 prompt.push_str(&format!(" ({url})"));
             }
@@ -370,10 +365,10 @@ mod tests {
 
         let prompt = build_system_prompt(&[ci_pass, ci_fail, other], &[], None, None, None);
 
-        // CI signals appear in dedicated section
+        // CI signals appear in dedicated section with titles as-is (no redundant prefix)
         assert!(prompt.contains("## Recent CI Activity"));
-        assert!(prompt.contains("CI passed: CI passed: add snooze (#30)"));
-        assert!(prompt.contains("CI FAILED: CI failed: add morning brief (#29)"));
+        assert!(prompt.contains("- CI passed: add snooze (#30)"));
+        assert!(prompt.contains("- CI failed: add morning brief (#29)"));
 
         // Non-CI signal appears in Current Signals, not in CI section
         assert!(prompt.contains("## Current Signals"));

--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -66,12 +66,20 @@ pub fn build_system_prompt(
          When signals arrive, you proactively notify the user about important events.\n\n",
     );
 
-    // Open signals section
-    if signals.is_empty() {
+    // Separate CI signals from other signals for dedicated section
+    let (ci_signals, other_signals): (Vec<&SignalRecord>, Vec<&SignalRecord>) =
+        signals.iter().partition(|s| {
+            s.source == "github"
+                && (s.external_id.starts_with("ci-pass-")
+                    || s.external_id.starts_with("ci-failure-"))
+        });
+
+    // Open signals section (non-CI)
+    if other_signals.is_empty() {
         prompt.push_str("## Current Signals\nNo open signals.\n\n");
     } else {
         prompt.push_str("## Current Signals\n");
-        for signal in signals {
+        for signal in &other_signals {
             prompt.push_str(&format!(
                 "- [{severity}] [{source}] {title}",
                 severity = signal.severity,
@@ -90,6 +98,27 @@ pub fn build_system_prompt(
                 };
                 prompt.push_str(&format!("  {truncated}\n"));
             }
+        }
+        prompt.push('\n');
+    }
+
+    // Dedicated CI activity section
+    if !ci_signals.is_empty() {
+        prompt.push_str("## Recent CI Activity\n");
+        prompt.push_str(
+            "Proactively mention CI results to the user when relevant to PRs they are watching.\n",
+        );
+        for signal in &ci_signals {
+            let icon = if signal.external_id.starts_with("ci-pass-") {
+                "passed"
+            } else {
+                "FAILED"
+            };
+            prompt.push_str(&format!("- CI {icon}: {title}", title = signal.title));
+            if let Some(ref url) = signal.url {
+                prompt.push_str(&format!(" ({url})"));
+            }
+            prompt.push('\n');
         }
         prompt.push('\n');
     }
@@ -305,6 +334,59 @@ mod tests {
             !prompt.contains("use the Edit tool"),
             "prompt must not instruct to use Edit tool"
         );
+    }
+
+    #[test]
+    fn test_ci_signals_in_dedicated_section() {
+        let ci_pass = SignalRecord {
+            id: 1,
+            source: "github".to_string(),
+            external_id: "ci-pass-30-12345".to_string(),
+            title: "CI passed: add snooze (#30)".to_string(),
+            body: None,
+            severity: Severity::Info,
+            status: SignalStatus::Open,
+            url: Some("https://github.com/org/repo/actions/runs/12345".to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            resolved_at: None,
+            metadata: None,
+        };
+        let ci_fail = SignalRecord {
+            id: 2,
+            source: "github".to_string(),
+            external_id: "ci-failure-29-12346".to_string(),
+            title: "CI failed: add morning brief (#29)".to_string(),
+            body: None,
+            severity: Severity::Error,
+            status: SignalStatus::Open,
+            url: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            resolved_at: None,
+            metadata: None,
+        };
+        let other = make_signal("sentry", "Server error spike", Severity::Warning);
+
+        let prompt = build_system_prompt(&[ci_pass, ci_fail, other], &[], None, None, None);
+
+        // CI signals appear in dedicated section
+        assert!(prompt.contains("## Recent CI Activity"));
+        assert!(prompt.contains("CI passed: CI passed: add snooze (#30)"));
+        assert!(prompt.contains("CI FAILED: CI failed: add morning brief (#29)"));
+
+        // Non-CI signal appears in Current Signals, not in CI section
+        assert!(prompt.contains("## Current Signals"));
+        assert!(prompt.contains("Server error spike"));
+    }
+
+    #[test]
+    fn test_no_ci_section_when_no_ci_signals() {
+        let signals = vec![make_signal("sentry", "Bug", Severity::Error)];
+        let prompt = build_system_prompt(&signals, &[], None, None, None);
+        assert!(!prompt.contains("## Recent CI Activity"));
+        assert!(prompt.contains("## Current Signals"));
+        assert!(prompt.contains("Bug"));
     }
 
     #[test]

--- a/crates/apiari/src/buzz/pipeline/mod.rs
+++ b/crates/apiari/src/buzz/pipeline/mod.rs
@@ -89,6 +89,19 @@ impl Pipeline {
         }
     }
 
+    /// Process a force-notified signal (e.g. CI pass on re-poll).
+    /// Bypasses pipeline rules and uses rate-limiting to prevent duplicate sends.
+    pub fn process_force_notify(&mut self, signal: &SignalRecord) -> Option<String> {
+        let fingerprint = format!("{}:{}", signal.source, signal.external_id);
+        // Rate-limit force notifications to once per 5 minutes
+        if self.log.should_send(&fingerprint, 300) {
+            self.log.record_sent(&fingerprint);
+            Some(format_signal_notification(signal))
+        } else {
+            None
+        }
+    }
+
     /// Flush any pending batches. Returns an optional batch summary message.
     pub fn flush_batches(&mut self) -> Option<String> {
         if let Some(signals) = self.batch.flush_if_ready() {
@@ -304,5 +317,27 @@ mod tests {
         // Info: batched
         let info = make_signal("sentry", "i1", "Info", Severity::Info);
         assert!(pipeline.process(&info).is_none()); // batched
+    }
+
+    #[test]
+    fn test_force_notify_bypasses_rules_with_rate_limit() {
+        let mut pipeline = Pipeline::new(vec![], 60);
+        let signal = make_signal(
+            "github",
+            "ci-pass-42-1000",
+            "CI passed: feat (#42)",
+            Severity::Info,
+        );
+
+        // Normal process: Info severity → batched (no immediate notification)
+        assert!(pipeline.process(&signal).is_none());
+
+        // Force notify: bypasses rules, sends directly
+        let result = pipeline.process_force_notify(&signal);
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("CI passed"));
+
+        // Second force notify: rate-limited (300s window)
+        assert!(pipeline.process_force_notify(&signal).is_none());
     }
 }

--- a/crates/apiari/src/buzz/signal/store.rs
+++ b/crates/apiari/src/buzz/signal/store.rs
@@ -911,6 +911,86 @@ mod tests {
     }
 
     #[test]
+    fn test_ci_pass_different_run_ids_are_new() {
+        let store = test_store();
+        // Same PR, different run IDs — each should be a new signal
+        let u1 = make_update(
+            "github",
+            "ci-pass-42-1000",
+            "CI passed: feat (#42)",
+            Severity::Info,
+        );
+        let u2 = make_update(
+            "github",
+            "ci-pass-42-1001",
+            "CI passed: feat (#42)",
+            Severity::Info,
+        );
+
+        let (id1, new1) = store.upsert_signal(&u1).unwrap();
+        let (id2, new2) = store.upsert_signal(&u2).unwrap();
+
+        assert!(new1, "first CI pass signal should be new");
+        assert!(new2, "re-run CI pass signal should also be new");
+        assert_ne!(
+            id1, id2,
+            "different run IDs should produce different signals"
+        );
+    }
+
+    #[test]
+    fn test_ci_pass_same_run_id_is_update() {
+        let store = test_store();
+        let u1 = make_update(
+            "github",
+            "ci-pass-42-1000",
+            "CI passed: feat (#42)",
+            Severity::Info,
+        );
+        let u2 = make_update(
+            "github",
+            "ci-pass-42-1000",
+            "CI passed: feat (#42)",
+            Severity::Info,
+        );
+
+        let (id1, new1) = store.upsert_signal(&u1).unwrap();
+        let (id2, new2) = store.upsert_signal(&u2).unwrap();
+
+        assert!(new1);
+        assert!(!new2, "same run ID should be an update, not new");
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_resolve_missing_signals_ci_run_transition() {
+        let store = test_store();
+
+        // Old CI run signal
+        store
+            .upsert_signal(&make_update(
+                "github",
+                "ci-pass-42-1000",
+                "CI passed: feat (#42)",
+                Severity::Info,
+            ))
+            .unwrap();
+
+        // New CI run replaces old — reconciliation should resolve the old one
+        let current_ids = vec!["ci-pass-42-1001".to_string()];
+        let resolved = store
+            .resolve_missing_signals("github", &current_ids)
+            .unwrap();
+        assert_eq!(resolved, 1, "old CI run signal should be resolved");
+
+        let open = store.get_open_signals().unwrap();
+        assert!(
+            !open.iter().any(|s| s.external_id == "ci-pass-42-1000"),
+            "old CI run should no longer be open"
+        );
+    }
+
+    #[test]
     fn test_metadata_preserved_on_update() {
         let store = test_store();
 

--- a/crates/apiari/src/buzz/watcher/github.rs
+++ b/crates/apiari/src/buzz/watcher/github.rs
@@ -509,29 +509,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ci_pass_rerun_unique_external_ids() {
-        // Two different run IDs for the same PR should produce different external_ids
-        let pr_number = 30u64;
-        let run_id_1 = 1000u64;
-        let run_id_2 = 1001u64;
-
-        let key1 = format!("ci-pass-{pr_number}-{run_id_1}");
-        let key2 = format!("ci-pass-{pr_number}-{run_id_2}");
-
-        assert_ne!(key1, key2, "re-runs should have unique external_ids");
-        assert_eq!(key1, "ci-pass-30-1000");
-        assert_eq!(key2, "ci-pass-30-1001");
-    }
-
-    #[test]
-    fn test_ci_failure_includes_pr_number() {
-        let pr_number = 42u64;
-        let run_id = 999u64;
-        let key = format!("ci-failure-{pr_number}-{run_id}");
-        assert_eq!(key, "ci-failure-42-999");
-    }
-
-    #[test]
     fn test_labeled_issue_critical() {
         let issue = serde_json::json!({
             "number": 1,

--- a/crates/apiari/src/buzz/watcher/github.rs
+++ b/crates/apiari/src/buzz/watcher/github.rs
@@ -254,7 +254,7 @@ impl Watcher for GithubWatcher {
                     match conclusion {
                         Some("failure") => {
                             if let Some(run_id) = run_id {
-                                let key = format!("ci-failure-{run_id}");
+                                let key = format!("ci-failure-{pr_number}-{run_id}");
                                 let mut signal = SignalUpdate::new(
                                     "github",
                                     &key,
@@ -269,7 +269,7 @@ impl Watcher for GithubWatcher {
                         }
                         Some("success") => {
                             if let Some(run_id) = run_id {
-                                let key = format!("ci-pass-{run_id}");
+                                let key = format!("ci-pass-{pr_number}-{run_id}");
                                 let mut signal = SignalUpdate::new(
                                     "github",
                                     &key,
@@ -468,7 +468,7 @@ mod tests {
         let pr_number = 42u64;
         let run_url = "https://github.com/org/repo/actions/runs/456";
 
-        let key = format!("ci-failure-{run_id}");
+        let key = format!("ci-failure-{pr_number}-{run_id}");
         let signal = SignalUpdate::new(
             "github",
             &key,
@@ -478,7 +478,7 @@ mod tests {
         .with_body(run_url)
         .with_url(run_url);
 
-        assert_eq!(signal.external_id, "ci-failure-456");
+        assert_eq!(signal.external_id, "ci-failure-42-456");
         assert_eq!(signal.severity, Severity::Error);
         assert!(signal.title.contains("CI failed"));
         assert!(signal.title.contains("#42"));
@@ -493,7 +493,7 @@ mod tests {
         let pr_number = 42u64;
         let run_url = "https://github.com/org/repo/actions/runs/789";
 
-        let key = format!("ci-pass-{run_id}");
+        let key = format!("ci-pass-{pr_number}-{run_id}");
         let signal = SignalUpdate::new(
             "github",
             &key,
@@ -502,10 +502,33 @@ mod tests {
         )
         .with_url(run_url);
 
-        assert_eq!(signal.external_id, "ci-pass-789");
+        assert_eq!(signal.external_id, "ci-pass-42-789");
         assert_eq!(signal.severity, Severity::Info);
         assert!(signal.title.contains("CI passed"));
         assert!(signal.title.contains("#42"));
+    }
+
+    #[test]
+    fn test_ci_pass_rerun_unique_external_ids() {
+        // Two different run IDs for the same PR should produce different external_ids
+        let pr_number = 30u64;
+        let run_id_1 = 1000u64;
+        let run_id_2 = 1001u64;
+
+        let key1 = format!("ci-pass-{pr_number}-{run_id_1}");
+        let key2 = format!("ci-pass-{pr_number}-{run_id_2}");
+
+        assert_ne!(key1, key2, "re-runs should have unique external_ids");
+        assert_eq!(key1, "ci-pass-30-1000");
+        assert_eq!(key2, "ci-pass-30-1001");
+    }
+
+    #[test]
+    fn test_ci_failure_includes_pr_number() {
+        let pr_number = 42u64;
+        let run_id = 999u64;
+        let key = format!("ci-failure-{pr_number}-{run_id}");
+        assert_eq!(key, "ci-failure-42-999");
     }
 
     #[test]

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -786,9 +786,16 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                 );
                                 for update in &updates {
                                     match slot.store.upsert_signal(update) {
-                                        Ok((id, true)) => {
+                                        Ok((id, is_new)) => {
+                                            // CI pass signals always notify (even on updates)
+                                            // to guard against dedup collisions swallowing notifications
+                                            let force_notify = update.source == "github"
+                                                && update.external_id.starts_with("ci-pass-");
+                                            let should_notify = is_new || force_notify;
+
                                             // Collect new swarm signals for coordinator follow-through
-                                            if watcher_name == "swarm"
+                                            if is_new
+                                                && watcher_name == "swarm"
                                                 && let Ok(Some(record)) = slot.store.get_signal(id)
                                             {
                                                 let desc = if let Some(ref url) = record.url {
@@ -801,7 +808,8 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                 new_swarm_events.push(desc);
                                             }
 
-                                            if let Ok(Some(record)) = slot.store.get_signal(id)
+                                            if should_notify
+                                                && let Ok(Some(record)) = slot.store.get_signal(id)
                                                 && let Some(text) = slot.pipeline.process(&record)
                                                 && let Some(tg) = &slot.config.telegram
                                                 && let Some(channel) = telegram_channels.get(&tg.bot_token)
@@ -817,7 +825,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                 }
                                             }
                                         }
-                                        Ok((_, false)) => {} // existing signal updated, no notification
                                         Err(e) => {
                                             error!("[{}] failed to upsert signal: {e}", slot.name);
                                         }

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -787,12 +787,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                 for update in &updates {
                                     match slot.store.upsert_signal(update) {
                                         Ok((id, is_new)) => {
-                                            // CI pass signals always notify (even on updates)
-                                            // to guard against dedup collisions swallowing notifications
-                                            let force_notify = update.source == "github"
-                                                && update.external_id.starts_with("ci-pass-");
-                                            let should_notify = is_new || force_notify;
-
                                             // Collect new swarm signals for coordinator follow-through
                                             if is_new
                                                 && watcher_name == "swarm"
@@ -808,9 +802,25 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                 new_swarm_events.push(desc);
                                             }
 
-                                            if should_notify
-                                                && let Ok(Some(record)) = slot.store.get_signal(id)
-                                                && let Some(text) = slot.pipeline.process(&record)
+                                            // Determine notification text:
+                                            // - New signals go through normal pipeline rules
+                                            // - CI pass re-polls use rate-limited force-notify
+                                            //   (bypasses Batch to prevent duplicate accumulation)
+                                            let text = if is_new {
+                                                slot.store.get_signal(id).ok().flatten().and_then(|record| {
+                                                    slot.pipeline.process(&record)
+                                                })
+                                            } else if update.source == "github"
+                                                && update.external_id.starts_with("ci-pass-")
+                                            {
+                                                slot.store.get_signal(id).ok().flatten().and_then(|record| {
+                                                    slot.pipeline.process_force_notify(&record)
+                                                })
+                                            } else {
+                                                None
+                                            };
+
+                                            if let Some(text) = text
                                                 && let Some(tg) = &slot.config.telegram
                                                 && let Some(channel) = telegram_channels.get(&tg.bot_token)
                                             {


### PR DESCRIPTION
## Summary
- **CI signal external_ids now include PR number** (`ci-pass-{pr_number}-{run_id}`) for better identifiability and cleaner reconciliation across re-runs
- **Force-notify on CI pass** regardless of `is_new` flag in daemon loop — guards against dedup collisions silently swallowing notifications
- **Dedicated "Recent CI Activity" section** in coordinator system prompt so Bee proactively surfaces CI results for watched PRs without waiting to be asked
- **8 new unit tests** covering CI signal dedup, reconciliation transitions, and coordinator prompt rendering

## Test plan
- [x] All 190 existing tests pass
- [x] New tests for CI pass dedup with different run IDs (`test_ci_pass_different_run_ids_are_new`)
- [x] New test for same run ID update behavior (`test_ci_pass_same_run_id_is_update`)
- [x] New test for reconciliation across CI run transitions (`test_resolve_missing_signals_ci_run_transition`)
- [x] New tests for CI section in coordinator prompt (`test_ci_signals_in_dedicated_section`, `test_no_ci_section_when_no_ci_signals`)
- [x] clippy clean, cargo fmt applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)