### PR TITLE
feat: add number key shortcuts (1-5) for direct panel jumping

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -178,9 +178,9 @@ pub struct WorkspaceState {
     pub coordinator_preview: Option<String>,
     pub has_unread_response: bool,
     // State tracking for proactive notifications
-    prev_worker_phases: std::collections::HashMap<String, String>,
-    prev_signal_ids: std::collections::HashSet<i64>,
-    prev_pr_workers: std::collections::HashSet<String>,
+    pub(super) prev_worker_phases: std::collections::HashMap<String, String>,
+    pub(super) prev_signal_ids: std::collections::HashSet<i64>,
+    pub(super) prev_pr_workers: std::collections::HashSet<String>,
     // Dashboard extras
     pub sparkline_data: Vec<u64>,
     pub watcher_health: Vec<WatcherHealth>,

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -498,6 +498,31 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
         KeyCode::Char('q') => {
             return KeyAction::Quit;
         }
+        // Number keys 1-5: jump directly to a panel
+        KeyCode::Char(c @ '1'..='5') => {
+            app.zoomed_panel = None;
+            match c {
+                '1' => app.focused_panel = Panel::Workers,
+                '2' => app.focused_panel = Panel::Signals,
+                '3' => {
+                    if app.has_review_queue() {
+                        app.focused_panel = Panel::Reviews;
+                    } else {
+                        app.focused_panel = Panel::Signals;
+                    }
+                }
+                '4' => app.focused_panel = Panel::Feed,
+                '5' => {
+                    app.focused_panel = Panel::Chat;
+                    app.chat_focused = true;
+                    if let Some(ws) = app.current_ws_mut() {
+                        ws.has_unread_response = false;
+                    }
+                }
+                _ => unreachable!(),
+            }
+            app.needs_redraw = true;
+        }
         _ => {}
     }
     KeyAction::Redraw
@@ -1273,4 +1298,122 @@ fn build_coordinator(workspace_name: &str) -> Option<Coordinator> {
     }));
 
     Some(coordinator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    /// Build a minimal App for key-handling tests (no file I/O).
+    fn test_app() -> App {
+        let ws_config: config::WorkspaceConfig =
+            serde_json::from_str(r#"{"root":"/tmp"}"#).unwrap();
+        let ws = app::WorkspaceState {
+            name: "test".into(),
+            config: ws_config,
+            signals: Vec::new(),
+            workers: Vec::new(),
+            chat_history: Vec::new(),
+            input: String::new(),
+            chat_scroll: apiari_tui::scroll::ScrollState::new(),
+            streaming: false,
+            coordinator_preview: None,
+            has_unread_response: false,
+            prev_worker_phases: Default::default(),
+            prev_signal_ids: Default::default(),
+            prev_pr_workers: Default::default(),
+            sparkline_data: vec![0; 24],
+            watcher_health: Vec::new(),
+            feed: Vec::new(),
+            feed_scroll: apiari_tui::scroll::ScrollState::new(),
+            thoughts: Vec::new(),
+        };
+        App {
+            workspaces: vec![ws],
+            active_tab: 0,
+            prefix_active: false,
+            view: View::Dashboard,
+            mode: Mode::Normal,
+            focused_panel: Panel::Home,
+            zoomed_panel: None,
+            worker_selection: 0,
+            signal_selection: 0,
+            review_selection: 0,
+            feed_selection: 0,
+            chat_focused: false,
+            worker_input: String::new(),
+            worker_input_active: false,
+            review_comment_active: false,
+            review_comment_input: String::new(),
+            review_comment_repo: String::new(),
+            review_comment_pr: 0,
+            content_scroll: 0,
+            signal_list_selection: 0,
+            review_list_selection: 0,
+            pr_list_selection: 0,
+            daemon_alive: false,
+            daemon_connected: false,
+            daemon_uptime_secs: None,
+            last_extras_refresh: std::time::Instant::now(),
+            terminal_width: 120,
+            activity_buf: vec![0; 18],
+            pending_action: None,
+            flash: None,
+            needs_redraw: false,
+            spinner_tick: 0,
+            last_worker_refresh: std::time::Instant::now(),
+            last_signal_refresh: std::time::Instant::now(),
+        }
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn test_key_1_jumps_to_workers() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Home;
+        app.zoomed_panel = Some(Panel::Home);
+
+        handle_dashboard_key(&mut app, key(KeyCode::Char('1')));
+
+        assert_eq!(app.focused_panel, Panel::Workers);
+        assert!(app.zoomed_panel.is_none(), "zoom should be cleared");
+    }
+
+    #[test]
+    fn test_key_5_jumps_to_chat_and_focuses() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Home;
+        assert!(!app.chat_focused);
+
+        handle_dashboard_key(&mut app, key(KeyCode::Char('5')));
+
+        assert_eq!(app.focused_panel, Panel::Chat);
+        assert!(app.chat_focused, "chat should be focused for input");
+    }
+
+    #[test]
+    fn test_number_keys_no_effect_when_chat_focused() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Chat;
+        app.chat_focused = true;
+
+        // When chat is focused, handle_dashboard_key delegates to
+        // handle_dashboard_chat_key which inserts the char into input.
+        handle_dashboard_key(&mut app, key(KeyCode::Char('1')));
+
+        // Panel should NOT have changed — the '1' went to chat input
+        assert_eq!(app.focused_panel, Panel::Chat);
+        // The character should have been inserted into the chat input
+        let input = &app.workspaces[0].input;
+        assert_eq!(input, "1");
+    }
 }

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -2063,6 +2063,8 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                         .is_some_and(|s| s.source == "github_review_queue");
                 let mut h = vec![
                     Span::raw(" "),
+                    Span::styled("1-5", theme::key_hint()),
+                    Span::styled(":jump  ", theme::key_desc()),
                     Span::styled("tab", theme::key_hint()),
                     Span::styled(":panel  ", theme::key_desc()),
                     Span::styled("j/k", theme::key_hint()),
@@ -2288,7 +2290,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 
 fn draw_help_overlay(frame: &mut Frame, area: Rect) {
     let w = 54u16.min(area.width.saturating_sub(4));
-    let h = 31u16.min(area.height.saturating_sub(4));
+    let h = 32u16.min(area.height.saturating_sub(4));
     let x = (area.width.saturating_sub(w)) / 2;
     let y = (area.height.saturating_sub(h)) / 2;
     let popup = Rect::new(x, y, w, h);
@@ -2324,6 +2326,10 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect) {
         Line::from(vec![
             Span::styled("  c             ", theme::key_hint()),
             Span::styled("Focus chat input", theme::key_desc()),
+        ]),
+        Line::from(vec![
+            Span::styled("  1-5           ", theme::key_hint()),
+            Span::styled("Jump to panel", theme::key_desc()),
         ]),
         Line::from(vec![
             Span::styled("  z             ", theme::key_hint()),


### PR DESCRIPTION
## Summary
- Bind keys `1`-`5` to jump directly to Workers, Signals, Reviews, Feed, and Chat panels in the dashboard view
- Key `3` falls back to Signals if no review queue is configured
- Key `5` also activates chat input mode immediately
- Clears zoom when jumping to a panel
- Number keys are safely ignored when chat input is focused (characters go to input)
- Adds `1-5:jump` hint to the status bar and help overlay

## Test plan
- [x] Unit test: `1` sets `focused_panel = Panel::Workers` and clears zoom
- [x] Unit test: `5` sets `focused_panel = Panel::Chat` and `chat_focused = true`
- [x] Unit test: number keys insert into chat input when `chat_focused == true`
- [ ] Manual: verify all 5 keys navigate to the correct panels in the TUI
- [ ] Manual: verify help overlay shows `1-5 Jump to panel`
- [ ] Manual: verify status bar shows `1-5:jump` hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)