### PR TITLE
fix: add missing struct fields to fix CI on main

### DIFF
--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -346,6 +346,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             resolved_at: None,
+            snoozed_until: None,
             metadata: None,
         };
         let ci_fail = SignalRecord {
@@ -360,6 +361,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             resolved_at: None,
+            snoozed_until: None,
             metadata: None,
         };
         let other = make_signal("sentry", "Server error spike", Severity::Warning);

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -1452,6 +1452,7 @@ mod tests {
             spinner_tick: 0,
             last_worker_refresh: std::time::Instant::now(),
             last_signal_refresh: std::time::Instant::now(),
+            snooze_selection: 0,
         }
     }
 


### PR DESCRIPTION
## Summary
- PR #30 (snooze) added `snoozed_until` to `SignalRecord` and `snooze_selection` to `App`
- PR #31 (CI notifications) added new test initializers written before #30 merged, so they were missing the new fields
- Adds `snoozed_until: None` to two `SignalRecord` initializers in `prompt.rs` tests and `snooze_selection: 0` to the `App` initializer in `ui/mod.rs`

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo fmt -p apiari` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)