### PR TITLE
feat: add swarm installation check to apiari init

### DIFF
--- a/crates/apiari/src/init.rs
+++ b/crates/apiari/src/init.rs
@@ -102,9 +102,43 @@ pub fn run_init(name_override: Option<&str>) -> Result<()> {
     if swarm_installed {
         println!("  \u{2713} swarm already installed\n");
     } else {
-        println!("  swarm is not installed. Installing apiari-swarm...\n");
+        println!("  swarm is not installed. Installing via cargo binstall...\n");
+
+        // Ensure cargo-binstall is available
+        let has_binstall = std::process::Command::new("cargo")
+            .args(["binstall", "--help"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        if !has_binstall {
+            println!("  Installing cargo-binstall first...\n");
+            let bs_status = std::process::Command::new("cargo")
+                .args(["install", "cargo-binstall"])
+                .stdout(std::process::Stdio::inherit())
+                .stderr(std::process::Stdio::inherit())
+                .status();
+            match bs_status {
+                Ok(s) if s.success() => {
+                    println!("\n  \u{2713} cargo-binstall installed\n");
+                }
+                Ok(_) => {
+                    eprintln!("\n  Failed to install cargo-binstall. You can retry manually:");
+                    eprintln!("  cargo install cargo-binstall\n");
+                    return Ok(());
+                }
+                Err(e) => {
+                    eprintln!("\n  Could not run cargo install: {e}");
+                    eprintln!("  Install manually: cargo install cargo-binstall\n");
+                    return Ok(());
+                }
+            }
+        }
+
         let install_status = std::process::Command::new("cargo")
-            .args(["install", "apiari-swarm"])
+            .args(["binstall", "-y", "apiari-swarm"])
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit())
             .status();
@@ -114,14 +148,13 @@ pub fn run_init(name_override: Option<&str>) -> Result<()> {
             }
             Ok(_) => {
                 eprintln!("\n  Failed to install apiari-swarm. You can retry manually:");
-                eprintln!("  cargo install apiari-swarm\n");
+                eprintln!("  cargo binstall -y apiari-swarm\n");
             }
             Err(e) => {
-                eprintln!("\n  Could not run cargo install: {e}");
-                eprintln!("  Install manually: cargo install apiari-swarm\n");
+                eprintln!("\n  Could not run cargo binstall: {e}");
+                eprintln!("  Install manually: cargo binstall -y apiari-swarm\n");
             }
         }
-        println!("  Note: if swarm fails to launch, run: codesign -f -s - ~/.cargo/bin/swarm\n");
     }
     println!("  Next steps:\n");
     println!("  1. Get a Telegram bot token from @BotFather (https://t.me/BotFather)");

--- a/crates/apiari/src/init.rs
+++ b/crates/apiari/src/init.rs
@@ -89,6 +89,40 @@ pub fn run_init(name_override: Option<&str>) -> Result<()> {
     let config_display = config_path.display();
 
     println!("\n  \u{2713} Created {config_display}\n");
+
+    // Check if swarm is available in PATH
+    let swarm_installed = std::process::Command::new("which")
+        .arg("swarm")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if swarm_installed {
+        println!("  \u{2713} swarm already installed\n");
+    } else {
+        println!("  swarm is not installed. Installing apiari-swarm...\n");
+        let install_status = std::process::Command::new("cargo")
+            .args(["install", "apiari-swarm"])
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .status();
+        match install_status {
+            Ok(s) if s.success() => {
+                println!("\n  \u{2713} apiari-swarm installed successfully\n");
+            }
+            Ok(_) => {
+                eprintln!("\n  Failed to install apiari-swarm. You can retry manually:");
+                eprintln!("  cargo install apiari-swarm\n");
+            }
+            Err(e) => {
+                eprintln!("\n  Could not run cargo install: {e}");
+                eprintln!("  Install manually: cargo install apiari-swarm\n");
+            }
+        }
+        println!("  Note: if swarm fails to launch, run: codesign -f -s - ~/.cargo/bin/swarm\n");
+    }
     println!("  Next steps:\n");
     println!("  1. Get a Telegram bot token from @BotFather (https://t.me/BotFather)");
     println!("     Send /newbot, follow the prompts, copy the token.\n");


### PR DESCRIPTION
## Summary
- After `apiari init` writes the workspace config, checks if `swarm` is available in PATH
- If found, prints `✓ swarm already installed`
- If not found, runs `cargo install apiari-swarm` with inherited stdout/stderr so the user sees progress
- Prints a macOS codesign reminder after installation

## Test plan
- [ ] Run `apiari init` with `swarm` already in PATH — verify "swarm already installed" message
- [ ] Run `apiari init` without `swarm` in PATH — verify it attempts `cargo install apiari-swarm`
- [ ] Verify codesign reminder is printed after installation attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)