### PR TITLE
feat: add release workflow and cargo-binstall metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build ${{ matrix.target }}
@@ -24,11 +27,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo build --release -p apiari
+        run: cargo build --release --locked -p apiari --target ${{ matrix.target }}
       - name: Rename binary
-        run: mv target/release/apiari apiari-${{ matrix.target }}
+        run: mv target/${{ matrix.target }}/release/apiari apiari-${{ matrix.target }}
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-13
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --release -p apiari
+      - name: Rename binary
+        run: mv target/release/apiari apiari-${{ matrix.target }}
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: apiari-${{ matrix.target }}

--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -34,5 +34,10 @@ async-imap = "0.10"
 async-native-tls = "0.5"
 mail-parser = "0.9"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ binary-ext }"
+bin-dir = "{ name }{ binary-ext }"
+pkg-fmt = "bin"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -3,6 +3,7 @@ name = "apiari"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
+repository = "https://github.com/ApiariTools/apiari"
 
 [[bin]]
 name = "apiari"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` that builds release binaries on tag push (`v*`) for macOS arm64, macOS x86_64, and Linux x86_64, uploading them to GitHub Releases via `softprops/action-gh-release@v2`
- Add `[package.metadata.binstall]` to `crates/apiari/Cargo.toml` so `cargo binstall apiari` resolves binaries from GitHub Releases

## Test plan
- [ ] Push a `v*` tag and verify the workflow triggers and builds all three targets
- [ ] Verify release assets are uploaded with correct names (`apiari-{target}`)
- [ ] Verify `cargo binstall apiari` resolves the correct binary URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)