### PR TITLE
feat: add crates.io publish step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,15 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: apiari-${{ matrix.target }}
+
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish to crates.io
+        run: cargo publish -p apiari
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `publish` job to the release workflow that publishes the `apiari` crate to crates.io after all build jobs complete
- Uses `CRATES_IO_TOKEN` secret for authentication

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] On next tag push, confirm the publish job runs after builds complete
- [ ] Ensure `CRATES_IO_TOKEN` secret is configured in the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)