### PR TITLE
chore: bump apiari version to 0.1.1

### DIFF
--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/ApiariTools/apiari"


### PR DESCRIPTION
## Summary
- Bumps `apiari` crate version from `0.1.0` to `0.1.1` in `crates/apiari/Cargo.toml`

## Test plan
- [ ] Verify `Cargo.toml` shows version `0.1.1`
- [ ] Verify `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)