### PR TITLE
fix: use macos-latest for x86_64-apple-darwin release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - os: macos-latest
             target: aarch64-apple-darwin
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary
- The `macos-13` runner is no longer supported by GitHub Actions, causing the `x86_64-apple-darwin` build job in the release workflow to fail with `The configuration 'macos-13-us-default' is not supported`
- Changed to `macos-latest` which cross-compiles x86_64 via the existing `--target` flag

## Context
The original task described a `--locked` Cargo.lock sync issue, but that was already fixed in commit `83a9042`. The actual remaining failure was the deprecated macOS runner.

## Test plan
- [ ] Merge this PR, then delete and re-create the `v0.1.1` tag to re-trigger the release workflow
- [ ] Verify all three build targets (aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu) succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)