### PR TITLE
chore: remove macOS x86_64 target from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
         include:
           - os: macos-latest
             target: aarch64-apple-darwin
-          - os: macos-latest
-            target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
     steps:


### PR DESCRIPTION
## Summary
- Removed the `x86_64-apple-darwin` (macos-13) target from the release build matrix
- Release now builds only for Linux x86_64 (`x86_64-unknown-linux-gnu`) and macOS arm64 (`aarch64-apple-darwin`)

## Test plan
- [ ] Verify the release workflow YAML is valid
- [ ] Confirm next tagged release builds only the two expected binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)