### PR TITLE
feat: daemon start/stop/restart subcommands and auto-start from UI

### DIFF
--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -440,11 +440,11 @@ async fn run_coordinator_task(
 
 /// Run the daemon in the foreground with auto-restart on errors.
 pub async fn run_foreground() -> Result<()> {
-    if let Some(pid) = read_pid() {
-        if is_process_alive(pid) {
-            eprintln!("daemon already running (pid: {pid})");
-            return Ok(());
-        }
+    if let Some(pid) = read_pid()
+        && is_process_alive(pid)
+    {
+        eprintln!("daemon already running (pid: {pid})");
+        return Ok(());
     }
     write_pid()?;
 
@@ -493,11 +493,11 @@ pub async fn run_foreground() -> Result<()> {
 
 /// Spawn the daemon in the background.
 pub fn spawn_background() -> Result<()> {
-    if let Some(pid) = read_pid() {
-        if is_process_alive(pid) {
-            eprintln!("daemon already running (pid: {pid})");
-            return Ok(());
-        }
+    if let Some(pid) = read_pid()
+        && is_process_alive(pid)
+    {
+        eprintln!("daemon already running (pid: {pid})");
+        return Ok(());
     }
 
     let exe = std::env::current_exe()?;

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -440,6 +440,12 @@ async fn run_coordinator_task(
 
 /// Run the daemon in the foreground with auto-restart on errors.
 pub async fn run_foreground() -> Result<()> {
+    if let Some(pid) = read_pid() {
+        if is_process_alive(pid) {
+            eprintln!("daemon already running (pid: {pid})");
+            return Ok(());
+        }
+    }
     write_pid()?;
 
     loop {
@@ -466,7 +472,9 @@ pub async fn run_foreground() -> Result<()> {
                 info!("exec'ing new binary...");
                 remove_pid();
                 let exe = std::env::current_exe()?;
-                let err = std::process::Command::new(&exe).arg("daemon").exec();
+                let err = std::process::Command::new(&exe)
+                    .args(["daemon", "start", "--foreground"])
+                    .exec();
                 // exec only returns on error
                 error!("exec failed: {err}");
                 break;
@@ -485,6 +493,13 @@ pub async fn run_foreground() -> Result<()> {
 
 /// Spawn the daemon in the background.
 pub fn spawn_background() -> Result<()> {
+    if let Some(pid) = read_pid() {
+        if is_process_alive(pid) {
+            eprintln!("daemon already running (pid: {pid})");
+            return Ok(());
+        }
+    }
+
     let exe = std::env::current_exe()?;
     let log = log_path();
     std::fs::create_dir_all(config::config_dir())?;
@@ -493,7 +508,7 @@ pub fn spawn_background() -> Result<()> {
     let stderr_file = log_file.try_clone()?;
 
     let child = std::process::Command::new(exe)
-        .args(["daemon"])
+        .args(["daemon", "start", "--foreground"])
         .stdout(log_file)
         .stderr(stderr_file)
         .stdin(std::process::Stdio::null())
@@ -501,6 +516,31 @@ pub fn spawn_background() -> Result<()> {
 
     eprintln!("apiari daemon started (pid {})", child.id());
     eprintln!("log: {}", log.display());
+    Ok(())
+}
+
+/// Stop the running daemon via PID file.
+pub fn stop_daemon() -> Result<()> {
+    if let Some(pid) = read_pid() {
+        if is_process_alive(pid) {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGTERM);
+            }
+            // Wait briefly for the process to exit
+            for _ in 0..20 {
+                if !is_process_alive(pid) {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            eprintln!("daemon stopped (pid: {pid})");
+        } else {
+            eprintln!("daemon not running (stale pid file)");
+        }
+        remove_pid();
+    } else {
+        eprintln!("daemon not running");
+    }
     Ok(())
 }
 

--- a/crates/apiari/src/main.rs
+++ b/crates/apiari/src/main.rs
@@ -17,6 +17,24 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
+enum DaemonCommand {
+    /// Start the daemon (background by default)
+    Start {
+        /// Run in foreground (for debugging)
+        #[arg(long)]
+        foreground: bool,
+    },
+    /// Stop the running daemon
+    Stop,
+    /// Restart the daemon
+    Restart {
+        /// Run in foreground (for debugging)
+        #[arg(long)]
+        foreground: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum Command {
     /// Initialize a workspace config from the current directory
     Init {
@@ -25,10 +43,13 @@ enum Command {
         name: Option<String>,
     },
 
-    /// Start the daemon (watches all workspaces)
+    /// Manage the daemon (watches all workspaces)
     Daemon {
-        /// Run in background
-        #[arg(long)]
+        #[command(subcommand)]
+        command: Option<DaemonCommand>,
+
+        /// Deprecated: use `apiari daemon start` instead
+        #[arg(long, hide = true)]
         background: bool,
     },
 
@@ -76,13 +97,39 @@ async fn main() -> Result<()> {
         Command::Init { name } => {
             init::run_init(name.as_deref())?;
         }
-        Command::Daemon { background } => {
-            if background {
-                daemon::spawn_background()?;
-            } else {
-                daemon::run_foreground().await?;
+        Command::Daemon {
+            command,
+            background,
+        } => match command {
+            Some(DaemonCommand::Start { foreground }) => {
+                if foreground {
+                    daemon::run_foreground().await?;
+                } else {
+                    daemon::spawn_background()?;
+                }
             }
-        }
+            Some(DaemonCommand::Stop) => {
+                daemon::stop_daemon()?;
+            }
+            Some(DaemonCommand::Restart { foreground }) => {
+                daemon::stop_daemon()?;
+                if foreground {
+                    daemon::run_foreground().await?;
+                } else {
+                    daemon::spawn_background()?;
+                }
+            }
+            None => {
+                if background {
+                    eprintln!(
+                        "Note: `--background` is deprecated. Use `apiari daemon start` instead."
+                    );
+                    daemon::spawn_background()?;
+                } else {
+                    daemon::run_foreground().await?;
+                }
+            }
+        },
         Command::Status { workspace } => {
             daemon::ensure_daemon()?;
             daemon::show_status(workspace.as_deref())?;

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -92,7 +92,7 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
         eprintln!();
         eprintln!("Get a Telegram bot token from @BotFather (https://t.me/BotFather)");
         eprintln!("and your chat ID from @userinfobot (https://t.me/userinfobot).");
-        eprintln!("Then edit the config and run: apiari daemon --background");
+        eprintln!("Then edit the config and run: apiari daemon start");
         return Ok(());
     }
 
@@ -101,6 +101,22 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
     // Coordinator channels
     let (user_tx, user_rx) = mpsc::channel::<UserMessage>(32);
     let (coord_tx, coord_rx) = mpsc::channel::<CoordResponse>(64);
+
+    // Auto-start daemon if not running
+    if !crate::daemon::is_daemon_running() {
+        eprintln!("Starting daemon in the background...");
+        if let Err(e) = crate::daemon::spawn_background() {
+            eprintln!("Warning: failed to start daemon: {e}");
+        } else {
+            // Wait for the daemon to create the socket
+            for _ in 0..20 {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                if daemon_client::socket_exists() && crate::daemon::is_daemon_running() {
+                    break;
+                }
+            }
+        }
+    }
 
     // Choose daemon client (shared session) or local coordinator (standalone)
     let use_daemon = daemon_client::socket_exists() && crate::daemon::is_daemon_running();


### PR DESCRIPTION
## Summary
- Adds `apiari daemon start|stop|restart` subcommand structure replacing the flat `--background` flag
- Enforces single daemon instance via PID file check before starting
- `apiari daemon stop` sends SIGTERM and waits for clean shutdown
- `apiari ui` auto-starts the daemon in background if not already running
- `apiari daemon --background` still works with a deprecation hint

## Test plan
- [ ] `apiari daemon start` starts daemon in background, prints pid
- [ ] `apiari daemon start` when already running prints "daemon already running (pid: N)"
- [ ] `apiari daemon start --foreground` runs in foreground
- [ ] `apiari daemon stop` stops running daemon
- [ ] `apiari daemon restart` stops + starts daemon
- [ ] `apiari daemon --background` works with deprecation message
- [ ] `apiari ui` auto-starts daemon if not running
- [ ] Bare `apiari daemon` still runs in foreground (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)