### PR TITLE
feat: auto-start daemon with socket readiness wait

### DIFF
--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1479,12 +1479,25 @@ pub fn is_daemon_running() -> bool {
 }
 
 /// Ensure the daemon is running, starting it in the background if needed.
+/// If the daemon isn't running, starts it and waits up to ~3 seconds for the
+/// socket to become available.
 pub fn ensure_daemon() -> Result<()> {
     if is_daemon_running() {
         return Ok(());
     }
-    eprintln!("Starting daemon in the background...");
-    spawn_background()
+    eprintln!("Starting daemon...");
+    spawn_background()?;
+
+    // Wait for the daemon socket to appear (up to ~3 seconds)
+    let socket = config::socket_path();
+    for _ in 0..30 {
+        if socket.exists() {
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    Ok(())
 }
 
 fn read_pid() -> Option<u32> {


### PR DESCRIPTION
## Summary
- `ensure_daemon()` now auto-starts the daemon in the background when it isn't running, instead of just calling `spawn_background()` without waiting
- After starting, waits up to ~3 seconds for the daemon socket to appear before returning
- Prints "Starting daemon..." so the user knows what's happening
- Commands like `apiari status` and `apiari chat` now transparently start the daemon instead of requiring a manual `apiari daemon start`

## Test plan
- [ ] Run `apiari daemon stop` then `apiari status` — daemon should auto-start and status should display
- [ ] Run `apiari chat` without daemon running — should see "Starting daemon..." then enter chat
- [ ] Run with daemon already running — no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)