### PR TITLE
feat: add Linear, email, and Notion to coordinator prompt

### DIFF
--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -62,8 +62,11 @@ pub fn build_system_prompt(
 
     prompt.push_str(
         "## Signals\n\
-         You have access to real-time signals from GitHub, Sentry, and swarm workers. \
-         When signals arrive, you proactively notify the user about important events.\n\n",
+         You have access to real-time signals from GitHub, Sentry, swarm workers, \
+         Linear, email (IMAP), and Notion. \
+         When signals arrive, you proactively notify the user about important events.\n\
+         All review-queue sources (GitHub, Linear, email, Notion) produce signals \
+         ending with `_review_queue` that auto-appear in the Reviews panel.\n\n",
     );
 
     // Separate CI signals from other signals for dedicated section

--- a/crates/apiari/src/buzz/coordinator/skills/email.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/email.rs
@@ -1,0 +1,39 @@
+//! Email/IMAP skill — teaches the coordinator about email inbox monitoring.
+
+use super::SkillContext;
+
+pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
+    if !ctx.has_email {
+        return None;
+    }
+
+    let names = ctx.email_names.join(", ");
+
+    Some(format!(
+        "## Email (IMAP)\n\
+         This workspace has {count} email watcher(s) configured: {names}.\n\
+         Email signals appear in the signal store with source `{{name}}_email_review_queue`.\n\n\
+         Configuration is in {config} under `[[watchers.email]]`:\n\
+         ```toml\n\
+         [[watchers.email]]\n\
+         name = \"fastmail\"\n\
+         host = \"imap.fastmail.com\"\n\
+         port = 993\n\
+         tls = true\n\
+         username = \"user@example.com\"\n\
+         password = \"app-password\"\n\
+         folder = \"INBOX\"\n\
+         filter = \"UNSEEN\"\n\
+         include_body = false\n\
+         \n\
+         [watchers.email.summarizer]   # optional Ollama summarization\n\
+         base_url = \"http://localhost:11434\"\n\
+         model = \"llama3.2:3b\"\n\
+         ```\n\n\
+         Email watchers connect via IMAP, poll for messages matching the filter,\n\
+         and create signals with sender, subject, and optional body summary.\n\
+         The optional `summarizer` section enables local LLM summarization of email bodies.\n",
+        count = ctx.email_names.len(),
+        config = ctx.config_path.display(),
+    ))
+}

--- a/crates/apiari/src/buzz/coordinator/skills/linear.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/linear.rs
@@ -1,0 +1,29 @@
+//! Linear skill — teaches the coordinator about Linear issue tracking integration.
+
+use super::SkillContext;
+
+pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
+    if !ctx.has_linear {
+        return None;
+    }
+
+    let names = ctx.linear_names.join(", ");
+
+    Some(format!(
+        "## Linear\n\
+         This workspace has {count} Linear watcher(s) configured: {names}.\n\
+         Linear signals appear in the signal store with source `linear_review_queue`.\n\n\
+         Configuration is in {config} under `[[watchers.linear]]`:\n\
+         ```toml\n\
+         [[watchers.linear]]\n\
+         name = \"linear\"\n\
+         api_key = \"lin_api_xxxx\"\n\
+         user_id = \"your-linear-user-id\"\n\
+         query = \"assignee:me\"   # supports: assignee:me, mentions:me, subscriber:me, or custom filter\n\
+         ```\n\n\
+         Linear watchers poll for issues matching the configured query and create signals\n\
+         in the review queue. Each signal includes issue title, state, priority, and URL.\n",
+        count = ctx.linear_names.len(),
+        config = ctx.config_path.display(),
+    ))
+}

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -4,7 +4,10 @@
 //! based on the workspace configuration. Each skill contributes a block
 //! of prompt text; `build_skills_prompt()` aggregates them all.
 
+mod email;
 mod github;
+mod linear;
+mod notion;
 mod sentry;
 mod signals;
 mod swarm;
@@ -21,6 +24,12 @@ pub struct SkillContext {
     pub has_swarm: bool,
     pub has_review_queue: bool,
     pub review_queue_names: Vec<String>,
+    pub has_linear: bool,
+    pub linear_names: Vec<String>,
+    pub has_email: bool,
+    pub email_names: Vec<String>,
+    pub has_notion: bool,
+    pub notion_names: Vec<String>,
     /// Custom prompt preamble loaded from prompt_file.
     /// If set, replaces the default identity/role sections in the system prompt.
     pub prompt_preamble: Option<String>,
@@ -44,6 +53,15 @@ pub fn build_skills_prompt(ctx: &SkillContext) -> String {
         sections.push(s);
     }
     if let Some(s) = swarm::build_prompt(ctx) {
+        sections.push(s);
+    }
+    if let Some(s) = linear::build_prompt(ctx) {
+        sections.push(s);
+    }
+    if let Some(s) = email::build_prompt(ctx) {
+        sections.push(s);
+    }
+    if let Some(s) = notion::build_prompt(ctx) {
         sections.push(s);
     }
 
@@ -112,6 +130,12 @@ mod tests {
             has_swarm: true,
             has_review_queue: false,
             review_queue_names: vec![],
+            has_linear: false,
+            linear_names: vec![],
+            has_email: false,
+            email_names: vec![],
+            has_notion: false,
+            notion_names: vec![],
             prompt_preamble: None,
         }
     }
@@ -150,6 +174,54 @@ mod tests {
         ctx.repos.clear();
         let prompt = build_skills_prompt(&ctx);
         assert!(!prompt.contains("## GitHub"));
+    }
+
+    #[test]
+    fn test_build_skills_prompt_with_linear() {
+        let mut ctx = test_ctx();
+        ctx.has_linear = true;
+        ctx.linear_names = vec!["linear".to_string()];
+        let prompt = build_skills_prompt(&ctx);
+        assert!(prompt.contains("## Linear"));
+    }
+
+    #[test]
+    fn test_build_skills_prompt_no_linear() {
+        let ctx = test_ctx();
+        let prompt = build_skills_prompt(&ctx);
+        assert!(!prompt.contains("## Linear"));
+    }
+
+    #[test]
+    fn test_build_skills_prompt_with_email() {
+        let mut ctx = test_ctx();
+        ctx.has_email = true;
+        ctx.email_names = vec!["fastmail".to_string()];
+        let prompt = build_skills_prompt(&ctx);
+        assert!(prompt.contains("## Email"));
+    }
+
+    #[test]
+    fn test_build_skills_prompt_no_email() {
+        let ctx = test_ctx();
+        let prompt = build_skills_prompt(&ctx);
+        assert!(!prompt.contains("## Email"));
+    }
+
+    #[test]
+    fn test_build_skills_prompt_with_notion() {
+        let mut ctx = test_ctx();
+        ctx.has_notion = true;
+        ctx.notion_names = vec!["notion".to_string()];
+        let prompt = build_skills_prompt(&ctx);
+        assert!(prompt.contains("## Notion"));
+    }
+
+    #[test]
+    fn test_build_skills_prompt_no_notion() {
+        let ctx = test_ctx();
+        let prompt = build_skills_prompt(&ctx);
+        assert!(!prompt.contains("## Notion"));
     }
 
     #[test]

--- a/crates/apiari/src/buzz/coordinator/skills/notion.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/notion.rs
@@ -1,0 +1,30 @@
+//! Notion skill — teaches the coordinator about Notion workspace monitoring.
+
+use super::SkillContext;
+
+pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
+    if !ctx.has_notion {
+        return None;
+    }
+
+    let names = ctx.notion_names.join(", ");
+
+    Some(format!(
+        "## Notion\n\
+         This workspace has {count} Notion watcher(s) configured: {names}.\n\
+         Notion signals appear in the signal store with source `{{name}}_review_queue`.\n\n\
+         Configuration is in {config} under `[[watchers.notion]]`:\n\
+         ```toml\n\
+         [[watchers.notion]]\n\
+         name = \"notion\"\n\
+         token = \"secret_xxxx\"\n\
+         user_id = \"notion-user-id\"\n\
+         poll_database_ids = [\"db-id-1\"]  # optional: databases to scan for assignments\n\
+         ```\n\n\
+         Notion watchers poll for mentions and assignments using the Notion API.\n\
+         When `poll_database_ids` is set, the watcher also scans those databases\n\
+         for pages assigned to the configured user.\n",
+        count = ctx.notion_names.len(),
+        config = ctx.config_path.display(),
+    ))
+}

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -126,6 +126,9 @@ pub struct WatchersConfig {
     /// Notion watchers via `[[watchers.notion]]`.
     #[serde(default)]
     pub notion: Vec<NotionWatcherConfig>,
+    /// Linear watchers via `[[watchers.linear]]`.
+    #[serde(default)]
+    pub linear: Vec<LinearWatcherConfig>,
 }
 
 /// Email mailbox configuration.
@@ -170,6 +173,22 @@ pub struct NotionWatcherConfig {
     pub poll_database_ids: Option<Vec<String>>,
     #[serde(default = "default_notion_interval")]
     pub interval_secs: u64,
+}
+
+/// Linear watcher configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinearWatcherConfig {
+    pub name: String,
+    pub api_key: String,
+    pub user_id: String,
+    #[serde(default)]
+    pub query: Option<String>,
+    #[serde(default = "default_linear_interval")]
+    pub interval_secs: u64,
+}
+
+fn default_linear_interval() -> u64 {
+    60
 }
 
 fn default_notion_interval() -> u64 {
@@ -404,6 +423,24 @@ pub fn build_skill_context(
         .as_ref()
         .map(|g| g.review_queue.iter().map(|e| e.name.clone()).collect())
         .unwrap_or_default();
+    let linear_names: Vec<String> = config
+        .watchers
+        .linear
+        .iter()
+        .map(|l| l.name.clone())
+        .collect();
+    let email_names: Vec<String> = config
+        .watchers
+        .email
+        .iter()
+        .map(|e| e.name.clone())
+        .collect();
+    let notion_names: Vec<String> = config
+        .watchers
+        .notion
+        .iter()
+        .map(|n| n.name.clone())
+        .collect();
     crate::buzz::coordinator::skills::SkillContext {
         workspace_name: workspace_name.to_string(),
         workspace_root: config.root.clone(),
@@ -413,6 +450,12 @@ pub fn build_skill_context(
         has_swarm: config.watchers.swarm.is_some(),
         has_review_queue: !review_queue_names.is_empty(),
         review_queue_names,
+        has_linear: !linear_names.is_empty(),
+        linear_names,
+        has_email: !email_names.is_empty(),
+        email_names,
+        has_notion: !notion_names.is_empty(),
+        notion_names,
         prompt_preamble: config.coordinator.prompt.clone(),
     }
 }


### PR DESCRIPTION
## Summary
- Add skill files (`linear.rs`, `email.rs`, `notion.rs`) so the coordinator (Bee) knows about all current watchers and can answer user questions about setup
- Add `LinearWatcherConfig` to apiari config so `[[watchers.linear]]` TOML sections are deserialized
- Add `has_linear`, `has_email`, `has_notion` flags + name vectors to `SkillContext`, wired through `build_skill_context`
- Update the Signals section in `prompt.rs` to mention all signal sources including Linear, email, and Notion

## Test plan
- [x] All 57 coordinator tests pass (including 6 new skill tests)
- [x] `cargo check -p apiari` clean
- [x] `cargo fmt -p apiari && cargo fmt -p hive` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)