### PR TITLE
docs: recommend notifications:unread as primary Linear query

### DIFF
--- a/crates/apiari/src/buzz/coordinator/skills/linear.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/linear.rs
@@ -16,12 +16,23 @@ pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
          Configuration is in {config} under `[[watchers.linear]]`:\n\
          ```toml\n\
          [[watchers.linear]]\n\
-         name = \"linear\"\n\
          api_key = \"lin_api_xxxx\"\n\
-         user_id = \"your-linear-user-id\"\n\
-         query = \"assignee:me\"   # supports: assignee:me, mentions:me, subscriber:me, or custom filter\n\
+         poll_interval_secs = 60\n\
+         \n\
+         # Recommended: unread notifications (mentions, assignments, comments)\n\
+         [[watchers.linear.review_queue]]\n\
+         name = \"Unread notifications\"\n\
+         query = \"notifications:unread\"\n\
+         \n\
+         # Optional: explicitly assigned issues\n\
+         [[watchers.linear.review_queue]]\n\
+         name = \"Assigned to me\"\n\
+         query = \"assignee:me\"\n\
          ```\n\n\
-         Linear watchers poll for issues matching the configured query and create signals\n\
+         The `notifications:unread` query mirrors the Linear notification bell — it surfaces\n\
+         unread mentions, assignments, and comments — and is the most useful single query\n\
+         for staying on top of what needs attention.\n\n\
+         Linear watchers poll for issues matching the configured queries and create signals\n\
          in the review queue. Each signal includes issue title, state, priority, and URL.\n",
         count = ctx.linear_names.len(),
         config = ctx.config_path.display(),


### PR DESCRIPTION
## Summary
- Updated the coordinator Linear skill to recommend `notifications:unread` as the primary query, with `assignee:me` as an optional secondary
- Updated the example config to use the `[[watchers.linear.review_queue]]` table array format
- Added explanation that `notifications:unread` mirrors the Linear notification bell (unread mentions, assignments, comments)

## Test plan
- [ ] Verify `cargo fmt` passes
- [ ] Verify `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)