### PR TITLE
docs: add missing name field to Linear watcher example config

### DIFF
--- a/crates/apiari/src/buzz/coordinator/skills/linear.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/linear.rs
@@ -16,6 +16,7 @@ pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
          Configuration is in {config} under `[[watchers.linear]]`:\n\
          ```toml\n\
          [[watchers.linear]]\n\
+         name = \"linear\"\n\
          api_key = \"lin_api_xxxx\"\n\
          poll_interval_secs = 60\n\
          \n\


### PR DESCRIPTION
## Summary
- Added the required `name` field to the Linear watcher example config in the coordinator skills documentation (`linear.rs`)
- The `LinearWatcherConfig` struct requires `name: String` (no serde default), but the example was missing it, which would cause config parsing failures if copy-pasted

## Test plan
- [x] `cargo check -p apiari` passes
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)