### PR TITLE
feat: add TCP socket support to apiari daemon

### DIFF
--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -72,6 +72,20 @@ pub struct WorkspaceConfig {
     /// Morning brief configuration.
     #[serde(default)]
     pub morning_brief: Option<MorningBriefConfig>,
+
+    /// Enable TCP listener for the daemon on this port (e.g. 7474).
+    /// Disabled if not set.
+    #[serde(default)]
+    pub daemon_tcp_port: Option<u16>,
+
+    /// Remote daemon host (Tailscale/LAN IP). When set with `daemon_port`,
+    /// the TUI connects to this workspace via TCP instead of Unix socket.
+    #[serde(default)]
+    pub daemon_host: Option<String>,
+
+    /// Remote daemon TCP port. Used with `daemon_host`.
+    #[serde(default)]
+    pub daemon_port: Option<u16>,
 }
 
 /// Telegram bot configuration.
@@ -809,6 +823,9 @@ root = "/tmp/test"
             pipeline: PipelineConfig::default(),
             commands: vec![],
             morning_brief: None,
+            daemon_tcp_port: None,
+            daemon_host: None,
+            daemon_port: None,
         };
         assert_eq!(resolve_repos(&config), vec!["Org/Repo"]);
     }
@@ -825,6 +842,9 @@ root = "/tmp/test"
             pipeline: PipelineConfig::default(),
             commands: vec![],
             morning_brief: None,
+            daemon_tcp_port: None,
+            daemon_host: None,
+            daemon_port: None,
         };
         assert!(resolve_repos(&config).is_empty());
     }
@@ -845,11 +865,109 @@ root = "/tmp/test"
             pipeline: PipelineConfig::default(),
             commands: vec![],
             morning_brief: None,
+            daemon_tcp_port: None,
+            daemon_host: None,
+            daemon_port: None,
         };
 
         let buzz = to_buzz_config(&ws);
         assert!(buzz.telegram.is_some());
         assert_eq!(buzz.telegram.unwrap().chat_id, 123);
         assert_eq!(buzz.coordinator.model, "sonnet");
+    }
+
+    #[test]
+    fn test_tcp_config_defaults_to_none() {
+        let toml_str = r#"
+            root = "/tmp/test"
+        "#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.daemon_tcp_port.is_none());
+        assert!(config.daemon_host.is_none());
+        assert!(config.daemon_port.is_none());
+    }
+
+    #[test]
+    fn test_tcp_config_daemon_tcp_port() {
+        let toml_str = r#"
+            root = "/tmp/test"
+            daemon_tcp_port = 7474
+        "#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.daemon_tcp_port, Some(7474));
+        assert!(config.daemon_host.is_none());
+        assert!(config.daemon_port.is_none());
+    }
+
+    #[test]
+    fn test_tcp_config_remote_connection() {
+        let toml_str = r#"
+            root = "/tmp/test"
+            daemon_host = "100.64.0.1"
+            daemon_port = 7474
+        "#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.daemon_tcp_port.is_none());
+        assert_eq!(config.daemon_host.as_deref(), Some("100.64.0.1"));
+        assert_eq!(config.daemon_port, Some(7474));
+    }
+
+    #[test]
+    fn test_tcp_config_full() {
+        let toml_str = r#"
+            root = "/tmp/test"
+            daemon_tcp_port = 7474
+            daemon_host = "myserver.ts.net"
+            daemon_port = 7474
+        "#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.daemon_tcp_port, Some(7474));
+        assert_eq!(config.daemon_host.as_deref(), Some("myserver.ts.net"));
+        assert_eq!(config.daemon_port, Some(7474));
+    }
+
+    #[test]
+    fn test_tcp_remote_target_detection() {
+        // Simulates the TUI logic for choosing Unix vs TCP
+        let config_local: WorkspaceConfig = toml::from_str(r#"root = "/tmp""#).unwrap();
+        let config_remote: WorkspaceConfig = toml::from_str(
+            r#"
+            root = "/tmp"
+            daemon_host = "10.0.0.1"
+            daemon_port = 7474
+            "#,
+        )
+        .unwrap();
+
+        // Local: no remote target
+        let target = config_local
+            .daemon_host
+            .as_ref()
+            .zip(config_local.daemon_port);
+        assert!(target.is_none());
+
+        // Remote: has target
+        let target = config_remote
+            .daemon_host
+            .as_ref()
+            .zip(config_remote.daemon_port);
+        assert!(target.is_some());
+        let (host, port) = target.unwrap();
+        assert_eq!(host, "10.0.0.1");
+        assert_eq!(port, 7474);
+    }
+
+    #[test]
+    fn test_tcp_config_host_without_port_not_remote() {
+        let config: WorkspaceConfig = toml::from_str(
+            r#"
+            root = "/tmp"
+            daemon_host = "10.0.0.1"
+            "#,
+        )
+        .unwrap();
+        // Both host AND port needed for remote
+        let target = config.daemon_host.as_ref().zip(config.daemon_port);
+        assert!(target.is_none());
     }
 }

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -78,6 +78,11 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub daemon_tcp_port: Option<u16>,
 
+    /// Bind address for the TCP listener (default: "127.0.0.1").
+    /// Set to "0.0.0.0" to listen on all interfaces.
+    #[serde(default)]
+    pub daemon_tcp_bind: Option<String>,
+
     /// Remote daemon host (Tailscale/LAN IP). When set with `daemon_port`,
     /// the TUI connects to this workspace via TCP instead of Unix socket.
     #[serde(default)]
@@ -824,6 +829,7 @@ root = "/tmp/test"
             commands: vec![],
             morning_brief: None,
             daemon_tcp_port: None,
+            daemon_tcp_bind: None,
             daemon_host: None,
             daemon_port: None,
         };
@@ -843,6 +849,7 @@ root = "/tmp/test"
             commands: vec![],
             morning_brief: None,
             daemon_tcp_port: None,
+            daemon_tcp_bind: None,
             daemon_host: None,
             daemon_port: None,
         };
@@ -866,6 +873,7 @@ root = "/tmp/test"
             commands: vec![],
             morning_brief: None,
             daemon_tcp_port: None,
+            daemon_tcp_bind: None,
             daemon_host: None,
             daemon_port: None,
         };
@@ -883,6 +891,7 @@ root = "/tmp/test"
         "#;
         let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
         assert!(config.daemon_tcp_port.is_none());
+        assert!(config.daemon_tcp_bind.is_none());
         assert!(config.daemon_host.is_none());
         assert!(config.daemon_port.is_none());
     }
@@ -895,8 +904,22 @@ root = "/tmp/test"
         "#;
         let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.daemon_tcp_port, Some(7474));
+        // bind defaults to None (resolved to 127.0.0.1 at runtime)
+        assert!(config.daemon_tcp_bind.is_none());
         assert!(config.daemon_host.is_none());
         assert!(config.daemon_port.is_none());
+    }
+
+    #[test]
+    fn test_tcp_config_custom_bind_address() {
+        let toml_str = r#"
+            root = "/tmp/test"
+            daemon_tcp_port = 7474
+            daemon_tcp_bind = "0.0.0.0"
+        "#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.daemon_tcp_port, Some(7474));
+        assert_eq!(config.daemon_tcp_bind.as_deref(), Some("0.0.0.0"));
     }
 
     #[test]

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -797,16 +797,32 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
     let socket_path = config::socket_path();
     let (mut tui_rx, socket_server) = match socket::DaemonSocketServer::start(&socket_path) {
         Ok((rx, req_tx, server)) => {
-            // Start TCP listener if any workspace has daemon_tcp_port configured
-            for slot in &slots {
-                if let Some(port) = slot.config.daemon_tcp_port {
-                    match server.start_tcp(port, req_tx.clone()) {
-                        Ok(()) => info!("[daemon] TCP listener started on port {port}"),
-                        Err(e) => {
-                            warn!("[daemon] failed to start TCP listener on port {port}: {e}")
-                        }
+            // Start TCP listener if any workspace has daemon_tcp_port configured.
+            // Only one TCP listener is started; warn if multiple differ.
+            let tcp_configs: Vec<_> = slots
+                .iter()
+                .filter_map(|s| {
+                    s.config.daemon_tcp_port.map(|port| {
+                        let bind = s.config.daemon_tcp_bind.as_deref().unwrap_or("127.0.0.1");
+                        (port, bind.to_string())
+                    })
+                })
+                .collect();
+            if tcp_configs.len() > 1 {
+                let ports: Vec<_> = tcp_configs.iter().map(|(p, _)| *p).collect();
+                warn!(
+                    "[daemon] multiple workspaces configure daemon_tcp_port {:?}; using first",
+                    ports
+                );
+            }
+            if let Some((port, bind_addr)) = tcp_configs.into_iter().next() {
+                match server.start_tcp(port, &bind_addr, req_tx.clone()) {
+                    Ok(()) => {
+                        info!("[daemon] TCP listener started on {bind_addr}:{port}")
                     }
-                    break; // only one TCP listener needed
+                    Err(e) => {
+                        warn!("[daemon] failed to start TCP listener on {bind_addr}:{port}: {e}")
+                    }
                 }
             }
             (Some(rx), Some(server))

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -796,7 +796,21 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
     // Start TUI socket server (optional — warn on failure)
     let socket_path = config::socket_path();
     let (mut tui_rx, socket_server) = match socket::DaemonSocketServer::start(&socket_path) {
-        Ok((rx, server)) => (Some(rx), Some(server)),
+        Ok((rx, req_tx, server)) => {
+            // Start TCP listener if any workspace has daemon_tcp_port configured
+            for slot in &slots {
+                if let Some(port) = slot.config.daemon_tcp_port {
+                    match server.start_tcp(port, req_tx.clone()) {
+                        Ok(()) => info!("[daemon] TCP listener started on port {port}"),
+                        Err(e) => {
+                            warn!("[daemon] failed to start TCP listener on port {port}: {e}")
+                        }
+                    }
+                    break; // only one TCP listener needed
+                }
+            }
+            (Some(rx), Some(server))
+        }
         Err(e) => {
             warn!("failed to start TUI socket server: {e}");
             (None, None)

--- a/crates/apiari/src/daemon/socket.rs
+++ b/crates/apiari/src/daemon/socket.rs
@@ -9,8 +9,8 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::{UnixListener, UnixStream};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::{broadcast, mpsc};
 use tracing::{error, info, warn};
 
@@ -57,9 +57,15 @@ pub struct DaemonSocketServer {
 
 impl DaemonSocketServer {
     /// Start the socket server, returning a receiver for client requests.
+    ///
+    /// Also returns the request sender so callers can pass it to `start_tcp()`.
     pub fn start(
         socket_path: &Path,
-    ) -> std::io::Result<(mpsc::UnboundedReceiver<ClientRequest>, Arc<Self>)> {
+    ) -> std::io::Result<(
+        mpsc::UnboundedReceiver<ClientRequest>,
+        mpsc::UnboundedSender<ClientRequest>,
+        Arc<Self>,
+    )> {
         // Clean up stale socket
         let _ = std::fs::remove_file(socket_path);
         if let Some(parent) = socket_path.parent() {
@@ -81,8 +87,11 @@ impl DaemonSocketServer {
             server_clone.accept_loop(listener, req_tx_clone).await;
         });
 
-        info!("socket server listening on {}", socket_path.display());
-        Ok((req_rx, server))
+        info!(
+            "[daemon] Unix socket listening on {}",
+            socket_path.display()
+        );
+        Ok((req_rx, req_tx, server))
     }
 
     /// Accept loop — spawns a task per client.
@@ -94,11 +103,12 @@ impl DaemonSocketServer {
         loop {
             match listener.accept().await {
                 Ok((stream, _addr)) => {
-                    info!("TUI client connected");
+                    info!("TUI client connected (unix)");
                     let req_tx = req_tx.clone();
                     let activity_rx = self.activity_tx.subscribe();
                     tokio::spawn(async move {
-                        if let Err(e) = handle_client(stream, req_tx, activity_rx).await {
+                        let (reader, writer) = stream.into_split();
+                        if let Err(e) = handle_client(reader, writer, req_tx, activity_rx).await {
                             warn!("TUI client disconnected: {e}");
                         } else {
                             info!("TUI client disconnected");
@@ -107,6 +117,57 @@ impl DaemonSocketServer {
                 }
                 Err(e) => {
                     error!("socket accept error: {e}");
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+            }
+        }
+    }
+
+    /// Start a TCP listener on the given port, reusing the same protocol and request channel.
+    ///
+    /// Each TCP client gets the same per-client handler as Unix socket clients.
+    pub fn start_tcp(
+        self: &Arc<Self>,
+        port: u16,
+        req_tx: mpsc::UnboundedSender<ClientRequest>,
+    ) -> std::io::Result<()> {
+        let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+        let listener = std::net::TcpListener::bind(addr)?;
+        listener.set_nonblocking(true)?;
+        let listener = TcpListener::from_std(listener)?;
+
+        let server = self.clone();
+        tokio::spawn(async move {
+            server.accept_tcp_loop(listener, req_tx).await;
+        });
+
+        info!("[daemon] TCP listener bound on 0.0.0.0:{port}");
+        Ok(())
+    }
+
+    /// Accept loop for TCP clients.
+    async fn accept_tcp_loop(
+        &self,
+        listener: TcpListener,
+        req_tx: mpsc::UnboundedSender<ClientRequest>,
+    ) {
+        loop {
+            match listener.accept().await {
+                Ok((stream, addr)) => {
+                    info!("TUI client connected (tcp: {addr})");
+                    let req_tx = req_tx.clone();
+                    let activity_rx = self.activity_tx.subscribe();
+                    tokio::spawn(async move {
+                        let (reader, writer) = stream.into_split();
+                        if let Err(e) = handle_client(reader, writer, req_tx, activity_rx).await {
+                            warn!("TUI TCP client disconnected ({addr}): {e}");
+                        } else {
+                            info!("TUI TCP client disconnected ({addr})");
+                        }
+                    });
+                }
+                Err(e) => {
+                    error!("TCP accept error: {e}");
                     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                 }
             }
@@ -138,13 +199,17 @@ impl Drop for DaemonSocketServer {
     }
 }
 
-/// Handle a single TUI client connection.
-async fn handle_client(
-    stream: UnixStream,
+/// Handle a single TUI client connection (Unix or TCP).
+async fn handle_client<R, W>(
+    reader: R,
+    mut writer: W,
     req_tx: mpsc::UnboundedSender<ClientRequest>,
     mut activity_rx: broadcast::Receiver<DaemonResponse>,
-) -> std::io::Result<()> {
-    let (reader, mut writer) = stream.into_split();
+) -> std::io::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
     let mut lines = BufReader::new(reader).lines();
 
     // Per-client unicast channel (daemon sends Token/Done/Error here)
@@ -259,6 +324,138 @@ mod tests {
         let json = serde_json::to_string(&resp).unwrap();
         let parsed: DaemonResponse = serde_json::from_str(&json).unwrap();
         assert!(matches!(parsed, DaemonResponse::Error { text } if text == "oops"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_client_request_response() {
+        // Simulate a client connection with in-memory pipes
+        let (client_reader, mut server_writer) = tokio::io::duplex(1024);
+        let (mut server_reader, client_writer) = tokio::io::duplex(1024);
+
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel::<ClientRequest>();
+        let (_activity_tx, activity_rx) = broadcast::channel::<DaemonResponse>(16);
+
+        // Spawn the client handler
+        let handle = tokio::spawn(async move {
+            handle_client(client_reader, client_writer, req_tx, activity_rx).await
+        });
+
+        // Write a chat request from the "client" side
+        let req = DaemonRequest::Chat {
+            workspace: "test".into(),
+            text: "hello".into(),
+        };
+        let mut json = serde_json::to_string(&req).unwrap();
+        json.push('\n');
+        tokio::io::AsyncWriteExt::write_all(&mut server_writer, json.as_bytes())
+            .await
+            .unwrap();
+
+        // Read it from the request channel
+        let client_req = req_rx.recv().await.unwrap();
+        match &client_req.request {
+            DaemonRequest::Chat { workspace, text } => {
+                assert_eq!(workspace, "test");
+                assert_eq!(text, "hello");
+            }
+        }
+
+        // Send a response back via the responder
+        client_req
+            .responder
+            .send(DaemonResponse::Token {
+                text: "world".into(),
+            })
+            .unwrap();
+
+        // Read the response from the "client" side
+        let mut buf = String::new();
+        let mut reader = tokio::io::BufReader::new(&mut server_reader);
+        tokio::io::AsyncBufReadExt::read_line(&mut reader, &mut buf)
+            .await
+            .unwrap();
+        let resp: DaemonResponse = serde_json::from_str(buf.trim()).unwrap();
+        assert!(matches!(resp, DaemonResponse::Token { text } if text == "world"));
+
+        // Drop the writer to close the connection
+        drop(server_writer);
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_handle_client_invalid_json() {
+        let (client_reader, mut server_writer) = tokio::io::duplex(1024);
+        let (mut server_reader, client_writer) = tokio::io::duplex(1024);
+
+        let (req_tx, _req_rx) = mpsc::unbounded_channel::<ClientRequest>();
+        let (_activity_tx, activity_rx) = broadcast::channel::<DaemonResponse>(16);
+
+        let handle = tokio::spawn(async move {
+            handle_client(client_reader, client_writer, req_tx, activity_rx).await
+        });
+
+        // Send invalid JSON
+        tokio::io::AsyncWriteExt::write_all(&mut server_writer, b"not json\n")
+            .await
+            .unwrap();
+
+        // Should get an error response back
+        let mut buf = String::new();
+        let mut reader = tokio::io::BufReader::new(&mut server_reader);
+        tokio::io::AsyncBufReadExt::read_line(&mut reader, &mut buf)
+            .await
+            .unwrap();
+        let resp: DaemonResponse = serde_json::from_str(buf.trim()).unwrap();
+        match resp {
+            DaemonResponse::Error { text } => {
+                assert!(text.contains("invalid request"));
+            }
+            _ => panic!("expected Error response"),
+        }
+
+        drop(server_writer);
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_handle_client_broadcast_activity() {
+        let (client_reader, server_writer) = tokio::io::duplex(1024);
+        let (mut server_reader, client_writer) = tokio::io::duplex(1024);
+
+        let (req_tx, _req_rx) = mpsc::unbounded_channel::<ClientRequest>();
+        let (activity_tx, activity_rx) = broadcast::channel::<DaemonResponse>(16);
+
+        let handle = tokio::spawn(async move {
+            handle_client(client_reader, client_writer, req_tx, activity_rx).await
+        });
+
+        // Broadcast an activity event
+        let _ = activity_tx.send(DaemonResponse::Activity {
+            source: "telegram".into(),
+            workspace: "ws".into(),
+            kind: "user_message".into(),
+            text: "hello from tg".into(),
+        });
+
+        // Read it from the client side
+        let mut buf = String::new();
+        let mut reader = tokio::io::BufReader::new(&mut server_reader);
+        tokio::io::AsyncBufReadExt::read_line(&mut reader, &mut buf)
+            .await
+            .unwrap();
+        let resp: DaemonResponse = serde_json::from_str(buf.trim()).unwrap();
+        match resp {
+            DaemonResponse::Activity {
+                source, workspace, ..
+            } => {
+                assert_eq!(source, "telegram");
+                assert_eq!(workspace, "ws");
+            }
+            _ => panic!("expected Activity"),
+        }
+
+        drop(server_writer);
+        let _ = handle.await;
     }
 
     #[test]

--- a/crates/apiari/src/daemon/socket.rs
+++ b/crates/apiari/src/daemon/socket.rs
@@ -125,13 +125,18 @@ impl DaemonSocketServer {
 
     /// Start a TCP listener on the given port, reusing the same protocol and request channel.
     ///
+    /// `bind_addr` defaults to `127.0.0.1` (loopback only) for safety.
+    /// Set to `0.0.0.0` to listen on all interfaces.
     /// Each TCP client gets the same per-client handler as Unix socket clients.
     pub fn start_tcp(
         self: &Arc<Self>,
         port: u16,
+        bind_addr: &str,
         req_tx: mpsc::UnboundedSender<ClientRequest>,
     ) -> std::io::Result<()> {
-        let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+        let addr: std::net::SocketAddr = format!("{bind_addr}:{port}")
+            .parse()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
         let listener = std::net::TcpListener::bind(addr)?;
         listener.set_nonblocking(true)?;
         let listener = TcpListener::from_std(listener)?;
@@ -141,7 +146,7 @@ impl DaemonSocketServer {
             server.accept_tcp_loop(listener, req_tx).await;
         });
 
-        info!("[daemon] TCP listener bound on 0.0.0.0:{port}");
+        info!("[daemon] TCP listener bound on {bind_addr}:{port}");
         Ok(())
     }
 

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -225,6 +225,7 @@ pub struct App {
     // Daemon / extras
     pub daemon_alive: bool,
     pub daemon_connected: bool, // true if TUI is connected to daemon via socket
+    pub daemon_remote: bool,    // true if connected via TCP (remote)
     pub daemon_uptime_secs: Option<u64>,
     pub last_extras_refresh: Instant,
     // Terminal size (updated each frame)
@@ -340,6 +341,7 @@ impl App {
             pr_list_selection: 0,
             daemon_alive: false,
             daemon_connected: false,
+            daemon_remote: false,
             daemon_uptime_secs: None,
             last_extras_refresh: Instant::now(),
             terminal_width: 80,

--- a/crates/apiari/src/ui/daemon_client.rs
+++ b/crates/apiari/src/ui/daemon_client.rs
@@ -1,23 +1,60 @@
-//! TUI-side daemon client — connects to daemon Unix socket.
+//! TUI-side daemon client — connects to daemon via Unix socket or TCP.
 
 use std::path::Path;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::UnixStream;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::net::{TcpStream, UnixStream};
+use tracing::info;
 
 use crate::daemon::socket::{DaemonRequest, DaemonResponse};
 
+/// Transport-agnostic line reader + writer.
+enum Transport {
+    Unix {
+        lines: Lines<BufReader<tokio::net::unix::OwnedReadHalf>>,
+        writer: tokio::net::unix::OwnedWriteHalf,
+    },
+    Tcp {
+        lines: Lines<BufReader<tokio::net::tcp::OwnedReadHalf>>,
+        writer: tokio::net::tcp::OwnedWriteHalf,
+    },
+}
+
 pub struct DaemonClient {
-    lines: tokio::io::Lines<BufReader<tokio::net::unix::OwnedReadHalf>>,
-    writer: tokio::net::unix::OwnedWriteHalf,
+    transport: Transport,
+    /// Whether this client is connected via TCP (remote).
+    #[allow(dead_code)]
+    pub is_remote: bool,
 }
 
 impl DaemonClient {
-    /// Connect to the daemon socket.
+    /// Connect to the daemon via Unix socket.
     pub async fn connect(socket_path: &Path) -> std::io::Result<Self> {
         let stream = UnixStream::connect(socket_path).await?;
         let (reader, writer) = stream.into_split();
         let lines = BufReader::new(reader).lines();
-        Ok(Self { lines, writer })
+        info!("[tui] connected to daemon via Unix socket");
+        Ok(Self {
+            transport: Transport::Unix { lines, writer },
+            is_remote: false,
+        })
+    }
+
+    /// Connect to a remote daemon via TCP with a 2-second timeout.
+    pub async fn connect_tcp(host: &str, port: u16) -> std::io::Result<Self> {
+        let addr = format!("{host}:{port}");
+        let stream =
+            tokio::time::timeout(std::time::Duration::from_secs(2), TcpStream::connect(&addr))
+                .await
+                .map_err(|_| {
+                    std::io::Error::new(std::io::ErrorKind::TimedOut, "TCP connect timed out")
+                })??;
+        let (reader, writer) = stream.into_split();
+        let lines = BufReader::new(reader).lines();
+        info!("[tui] connected to daemon via TCP at {addr}");
+        Ok(Self {
+            transport: Transport::Tcp { lines, writer },
+            is_remote: true,
+        })
     }
 
     /// Send a chat message to the daemon.
@@ -27,14 +64,27 @@ impl DaemonClient {
             text: text.to_string(),
         };
         let json = serde_json::to_string(&req).map_err(std::io::Error::other)?;
-        self.writer.write_all(json.as_bytes()).await?;
-        self.writer.write_all(b"\n").await?;
-        self.writer.flush().await
+        match &mut self.transport {
+            Transport::Unix { writer, .. } => {
+                writer.write_all(json.as_bytes()).await?;
+                writer.write_all(b"\n").await?;
+                writer.flush().await
+            }
+            Transport::Tcp { writer, .. } => {
+                writer.write_all(json.as_bytes()).await?;
+                writer.write_all(b"\n").await?;
+                writer.flush().await
+            }
+        }
     }
 
     /// Read the next response from the daemon.
     pub async fn next_response(&mut self) -> std::io::Result<Option<DaemonResponse>> {
-        match self.lines.next_line().await? {
+        let line = match &mut self.transport {
+            Transport::Unix { lines, .. } => lines.next_line().await?,
+            Transport::Tcp { lines, .. } => lines.next_line().await?,
+        };
+        match line {
             Some(line) => {
                 let resp: DaemonResponse =
                     serde_json::from_str(&line).map_err(std::io::Error::other)?;

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -102,8 +102,17 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
     let (user_tx, user_rx) = mpsc::channel::<UserMessage>(32);
     let (coord_tx, coord_rx) = mpsc::channel::<CoordResponse>(64);
 
-    // Auto-start daemon if not running
-    if !crate::daemon::is_daemon_running() {
+    // Detect remote workspace before auto-start so we skip local daemon spawn.
+    let focused = app.current_ws();
+    let remote_target = focused.and_then(|ws| {
+        let host = ws.config.daemon_host.as_deref()?;
+        let port = ws.config.daemon_port?;
+        Some((host.to_string(), port))
+    });
+
+    // Auto-start daemon if not running (skip for remote workspaces — they
+    // connect to a daemon running on the remote host).
+    if remote_target.is_none() && !crate::daemon::is_daemon_running() {
         eprintln!("Starting daemon in the background...");
         if let Err(e) = crate::daemon::spawn_background() {
             eprintln!("Warning: failed to start daemon: {e}");
@@ -119,14 +128,6 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
     }
 
     // Choose daemon client (shared session) or local coordinator (standalone).
-    // Remote workspaces with daemon_host + daemon_port connect via TCP.
-    let focused = app.current_ws();
-    let remote_target = focused.and_then(|ws| {
-        let host = ws.config.daemon_host.as_deref()?;
-        let port = ws.config.daemon_port?;
-        Some((host.to_string(), port))
-    });
-
     let use_daemon = if remote_target.is_some() {
         true // remote always uses daemon client
     } else {

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -118,11 +118,28 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
         }
     }
 
-    // Choose daemon client (shared session) or local coordinator (standalone)
-    let use_daemon = daemon_client::socket_exists() && crate::daemon::is_daemon_running();
-    app.daemon_connected = use_daemon;
+    // Choose daemon client (shared session) or local coordinator (standalone).
+    // Remote workspaces with daemon_host + daemon_port connect via TCP.
+    let focused = app.current_ws();
+    let remote_target = focused.and_then(|ws| {
+        let host = ws.config.daemon_host.as_deref()?;
+        let port = ws.config.daemon_port?;
+        Some((host.to_string(), port))
+    });
 
-    if use_daemon {
+    let use_daemon = if remote_target.is_some() {
+        true // remote always uses daemon client
+    } else {
+        daemon_client::socket_exists() && crate::daemon::is_daemon_running()
+    };
+    app.daemon_connected = use_daemon;
+    app.daemon_remote = remote_target.is_some();
+
+    if let Some((host, port)) = remote_target {
+        // Remote daemon — connect via TCP
+        let coord_tx_clone = coord_tx.clone();
+        tokio::spawn(daemon_client_task_tcp(host, port, user_rx, coord_tx_clone));
+    } else if use_daemon {
         // Spawn daemon client task (tokio task — the daemon handles coordinator)
         let coord_tx_clone = coord_tx.clone();
         tokio::spawn(daemon_client_task(user_rx, coord_tx_clone));
@@ -1286,6 +1303,76 @@ async fn daemon_client_task(
     }
 }
 
+/// Daemon client task connecting via TCP (remote workspace).
+async fn daemon_client_task_tcp(
+    host: String,
+    port: u16,
+    mut user_rx: mpsc::Receiver<UserMessage>,
+    coord_tx: mpsc::Sender<CoordResponse>,
+) {
+    let mut client = match daemon_client::DaemonClient::connect_tcp(&host, port).await {
+        Ok(c) => c,
+        Err(e) => {
+            let _ = coord_tx
+                .send(CoordResponse::Error(format!(
+                    "Failed to connect to remote daemon at {host}:{port}: {e}"
+                )))
+                .await;
+            return;
+        }
+    };
+
+    loop {
+        tokio::select! {
+            Some(msg) = user_rx.recv() => {
+                match msg {
+                    UserMessage::Chat { workspace_name, text } => {
+                        if let Err(e) = client.send_chat(&workspace_name, &text).await {
+                            let _ = coord_tx
+                                .send(CoordResponse::Error(format!("TCP send error: {e}")))
+                                .await;
+                        }
+                    }
+                }
+            }
+
+            resp = client.next_response() => {
+                match resp {
+                    Ok(Some(crate::daemon::socket::DaemonResponse::Token { text })) => {
+                        let _ = coord_tx.send(CoordResponse::Token(text)).await;
+                    }
+                    Ok(Some(crate::daemon::socket::DaemonResponse::Done)) => {
+                        let _ = coord_tx.send(CoordResponse::Done).await;
+                    }
+                    Ok(Some(crate::daemon::socket::DaemonResponse::Error { text })) => {
+                        let _ = coord_tx.send(CoordResponse::Error(text)).await;
+                    }
+                    Ok(Some(crate::daemon::socket::DaemonResponse::Activity { source, workspace, kind, text })) => {
+                        if source == "tui" {
+                            continue;
+                        }
+                        let _ = coord_tx
+                            .send(CoordResponse::Activity { source, workspace, kind, text })
+                            .await;
+                    }
+                    Ok(None) => {
+                        let _ = coord_tx
+                            .send(CoordResponse::Error("Remote daemon disconnected".into()))
+                            .await;
+                        break;
+                    }
+                    Err(e) => {
+                        let _ = coord_tx
+                            .send(CoordResponse::Error(format!("TCP read error: {e}")))
+                            .await;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
 // ── Coordinator task ─────────────────────────────────────
 
 async fn coordinator_task(
@@ -1458,6 +1545,7 @@ mod tests {
             pr_list_selection: 0,
             daemon_alive: false,
             daemon_connected: false,
+            daemon_remote: false,
             daemon_uptime_secs: None,
             last_extras_refresh: std::time::Instant::now(),
             terminal_width: 120,

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -2247,12 +2247,19 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         "\u{25cb}" // ○ local fallback
     };
-    let conn_label = if app.daemon_connected {
+    let conn_label = if app.daemon_remote {
+        "remote"
+    } else if app.daemon_connected {
         "daemon"
     } else {
         "local"
     };
-    let daemon_spans: Vec<Span> = if app.daemon_alive {
+    let conn_style = if app.daemon_remote {
+        Style::default().fg(theme::FROST) // cyan for remote
+    } else {
+        theme::muted()
+    };
+    let daemon_spans: Vec<Span> = if app.daemon_alive || app.daemon_remote {
         let uptime_str = match app.daemon_uptime_secs {
             Some(s) if s >= 3600 => format!("{}h{}m", s / 3600, (s % 3600) / 60),
             Some(s) if s >= 60 => format!("{}m", s / 60),
@@ -2268,7 +2275,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled(ecg, Style::default().fg(ecg_color)),
             Span::styled(
                 format!(" {conn_indicator} {conn_label} {uptime_str}{watcher_str} "),
-                theme::muted(),
+                conn_style,
             ),
         ]
     } else {
@@ -2276,7 +2283,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled(ecg, Style::default().fg(ecg_color)),
             Span::styled(
                 format!(" {conn_indicator} {conn_label} offline "),
-                theme::muted(),
+                conn_style,
             ),
         ]
     };


### PR DESCRIPTION
## Summary
- Add TCP listener to `DaemonSocketServer` alongside Unix socket, configurable via `daemon_tcp_port` in workspace config
- Add `daemon_host` + `daemon_port` config fields for TUI to connect to remote daemons (e.g. over Tailscale)
- Update `DaemonClient` with `connect_tcp()` method using a 2-second connection timeout
- Show "remote" (cyan) vs "daemon" vs "local" in TUI status bar based on connection type
- Add 10 new tests: config parsing (6), client handler request/response, invalid JSON handling, broadcast activity forwarding

## Test plan
- [x] `cargo check -p apiari` — clean (0 warnings)
- [x] `cargo test -p apiari` — 297 tests pass
- [x] `cargo fmt -p apiari -- --check` — clean
- [ ] Manual: add `daemon_tcp_port = 7474` to a workspace config, verify TCP listener starts
- [ ] Manual: add `daemon_host`/`daemon_port` to a workspace config, verify TUI connects via TCP
- [ ] Manual: verify status bar shows "remote" in cyan when connected via TCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)