### PR TITLE
feat: add fallback endpoint support to daemon TCP config

### DIFF
--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -85,12 +85,52 @@ pub struct WorkspaceConfig {
 
     /// Remote daemon host (Tailscale/LAN IP). When set with `daemon_port`,
     /// the TUI connects to this workspace via TCP instead of Unix socket.
+    /// **Deprecated**: use `daemon_endpoints` instead.
     #[serde(default)]
     pub daemon_host: Option<String>,
 
     /// Remote daemon TCP port. Used with `daemon_host`.
+    /// **Deprecated**: use `daemon_endpoints` instead.
     #[serde(default)]
     pub daemon_port: Option<u16>,
+
+    /// Ordered list of daemon endpoints to try when connecting.
+    /// The TUI tries each in order, using the first that responds.
+    #[serde(default)]
+    pub daemon_endpoints: Vec<DaemonEndpoint>,
+}
+
+/// A single daemon TCP endpoint (host + port).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DaemonEndpoint {
+    pub host: String,
+    #[serde(default = "default_daemon_port")]
+    pub port: u16,
+}
+
+fn default_daemon_port() -> u16 {
+    7474
+}
+
+impl WorkspaceConfig {
+    /// Resolve the ordered list of daemon endpoints.
+    ///
+    /// If `daemon_endpoints` is non-empty, returns it as-is.
+    /// Otherwise, falls back to legacy `daemon_host` + `daemon_port` as a single entry.
+    /// Returns an empty vec if neither is configured (local-only workspace).
+    pub fn resolved_daemon_endpoints(&self) -> Vec<DaemonEndpoint> {
+        if !self.daemon_endpoints.is_empty() {
+            return self.daemon_endpoints.clone();
+        }
+        // Backward compat: legacy single-host config
+        if let (Some(host), Some(port)) = (&self.daemon_host, self.daemon_port) {
+            return vec![DaemonEndpoint {
+                host: host.clone(),
+                port,
+            }];
+        }
+        Vec::new()
+    }
 }
 
 /// Telegram bot configuration.
@@ -832,6 +872,7 @@ root = "/tmp/test"
             daemon_tcp_bind: None,
             daemon_host: None,
             daemon_port: None,
+            daemon_endpoints: vec![],
         };
         assert_eq!(resolve_repos(&config), vec!["Org/Repo"]);
     }
@@ -852,6 +893,7 @@ root = "/tmp/test"
             daemon_tcp_bind: None,
             daemon_host: None,
             daemon_port: None,
+            daemon_endpoints: vec![],
         };
         assert!(resolve_repos(&config).is_empty());
     }
@@ -876,6 +918,7 @@ root = "/tmp/test"
             daemon_tcp_bind: None,
             daemon_host: None,
             daemon_port: None,
+            daemon_endpoints: vec![],
         };
 
         let buzz = to_buzz_config(&ws);
@@ -992,5 +1035,114 @@ root = "/tmp/test"
         // Both host AND port needed for remote
         let target = config.daemon_host.as_ref().zip(config.daemon_port);
         assert!(target.is_none());
+    }
+
+    #[test]
+    fn test_daemon_endpoints_array_parsing() {
+        let toml_str = r#"
+            root = "/tmp/test"
+
+            [[daemon_endpoints]]
+            host = "localhost"
+            port = 7474
+
+            [[daemon_endpoints]]
+            host = "100.64.0.1"
+            port = 7474
+
+            [[daemon_endpoints]]
+            host = "192.168.1.50"
+            port = 7474
+        "#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.daemon_endpoints.len(), 3);
+        assert_eq!(config.daemon_endpoints[0].host, "localhost");
+        assert_eq!(config.daemon_endpoints[0].port, 7474);
+        assert_eq!(config.daemon_endpoints[1].host, "100.64.0.1");
+        assert_eq!(config.daemon_endpoints[2].host, "192.168.1.50");
+    }
+
+    #[test]
+    fn test_daemon_endpoints_default_port() {
+        let toml_str = r#"
+            root = "/tmp/test"
+
+            [[daemon_endpoints]]
+            host = "localhost"
+        "#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.daemon_endpoints.len(), 1);
+        assert_eq!(config.daemon_endpoints[0].port, 7474);
+    }
+
+    #[test]
+    fn test_resolved_endpoints_from_array() {
+        let toml_str = r#"
+            root = "/tmp/test"
+
+            [[daemon_endpoints]]
+            host = "localhost"
+            port = 7474
+
+            [[daemon_endpoints]]
+            host = "100.64.0.1"
+            port = 7474
+        "#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        let eps = config.resolved_daemon_endpoints();
+        assert_eq!(eps.len(), 2);
+        assert_eq!(eps[0].host, "localhost");
+        assert_eq!(eps[1].host, "100.64.0.1");
+    }
+
+    #[test]
+    fn test_resolved_endpoints_backward_compat() {
+        let toml_str = r#"
+            root = "/tmp/test"
+            daemon_host = "10.0.0.1"
+            daemon_port = 7474
+        "#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.daemon_endpoints.is_empty());
+        let eps = config.resolved_daemon_endpoints();
+        assert_eq!(eps.len(), 1);
+        assert_eq!(eps[0].host, "10.0.0.1");
+        assert_eq!(eps[0].port, 7474);
+    }
+
+    #[test]
+    fn test_resolved_endpoints_array_takes_precedence() {
+        let toml_str = r#"
+            root = "/tmp/test"
+            daemon_host = "10.0.0.1"
+            daemon_port = 7474
+
+            [[daemon_endpoints]]
+            host = "localhost"
+            port = 8080
+        "#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        let eps = config.resolved_daemon_endpoints();
+        // daemon_endpoints takes precedence over legacy fields
+        assert_eq!(eps.len(), 1);
+        assert_eq!(eps[0].host, "localhost");
+        assert_eq!(eps[0].port, 8080);
+    }
+
+    #[test]
+    fn test_resolved_endpoints_empty_when_no_remote() {
+        let config: WorkspaceConfig = toml::from_str(r#"root = "/tmp""#).unwrap();
+        assert!(config.resolved_daemon_endpoints().is_empty());
+    }
+
+    #[test]
+    fn test_resolved_endpoints_host_without_port_empty() {
+        let toml_str = r#"
+            root = "/tmp"
+            daemon_host = "10.0.0.1"
+        "#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        // Legacy requires both host AND port
+        assert!(config.resolved_daemon_endpoints().is_empty());
     }
 }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -226,6 +226,7 @@ pub struct App {
     pub daemon_alive: bool,
     pub daemon_connected: bool, // true if TUI is connected to daemon via socket
     pub daemon_remote: bool,    // true if connected via TCP (remote)
+    pub remote_host: Option<String>, // which endpoint host we connected to
     pub daemon_uptime_secs: Option<u64>,
     pub last_extras_refresh: Instant,
     // Terminal size (updated each frame)
@@ -342,6 +343,7 @@ impl App {
             daemon_alive: false,
             daemon_connected: false,
             daemon_remote: false,
+            remote_host: None,
             daemon_uptime_secs: None,
             last_extras_refresh: Instant::now(),
             terminal_width: 80,

--- a/crates/apiari/src/ui/daemon_client.rs
+++ b/crates/apiari/src/ui/daemon_client.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::net::{TcpStream, UnixStream};
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::config::DaemonEndpoint;
 use crate::daemon::socket::{DaemonRequest, DaemonResponse};
@@ -46,8 +46,12 @@ impl DaemonClient {
     /// Try connecting to each endpoint in order with a 500ms timeout per endpoint.
     /// Returns the first successful connection.
     pub async fn connect_tcp_fallback(endpoints: &[DaemonEndpoint]) -> std::io::Result<Self> {
+        let mut last_err = std::io::Error::new(
+            std::io::ErrorKind::NotConnected,
+            "no daemon endpoints configured",
+        );
         for ep in endpoints {
-            info!("[ui] trying endpoint {}:{}...", ep.host, ep.port);
+            debug!("[ui] trying endpoint {}:{}...", ep.host, ep.port);
             let addr = format!("{}:{}", ep.host, ep.port);
             match tokio::time::timeout(
                 std::time::Duration::from_millis(500),
@@ -66,17 +70,19 @@ impl DaemonClient {
                     });
                 }
                 Ok(Err(e)) => {
-                    info!("[ui] endpoint {}:{} failed: {e}", ep.host, ep.port);
+                    debug!("[ui] endpoint {}:{} failed: {e}", ep.host, ep.port);
+                    last_err = e;
                 }
                 Err(_) => {
-                    info!("[ui] endpoint {}:{} timed out", ep.host, ep.port);
+                    debug!("[ui] endpoint {}:{} timed out", ep.host, ep.port);
+                    last_err = std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        format!("{}:{} timed out", ep.host, ep.port),
+                    );
                 }
             }
         }
-        Err(std::io::Error::new(
-            std::io::ErrorKind::ConnectionRefused,
-            "all daemon endpoints failed",
-        ))
+        Err(last_err)
     }
 
     /// Send a chat message to the daemon.

--- a/crates/apiari/src/ui/daemon_client.rs
+++ b/crates/apiari/src/ui/daemon_client.rs
@@ -5,6 +5,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::net::{TcpStream, UnixStream};
 use tracing::info;
 
+use crate::config::DaemonEndpoint;
 use crate::daemon::socket::{DaemonRequest, DaemonResponse};
 
 /// Transport-agnostic line reader + writer.
@@ -24,6 +25,8 @@ pub struct DaemonClient {
     /// Whether this client is connected via TCP (remote).
     #[allow(dead_code)]
     pub is_remote: bool,
+    /// The host we connected to (for status bar display).
+    pub connected_host: Option<String>,
 }
 
 impl DaemonClient {
@@ -36,25 +39,44 @@ impl DaemonClient {
         Ok(Self {
             transport: Transport::Unix { lines, writer },
             is_remote: false,
+            connected_host: None,
         })
     }
 
-    /// Connect to a remote daemon via TCP with a 2-second timeout.
-    pub async fn connect_tcp(host: &str, port: u16) -> std::io::Result<Self> {
-        let addr = format!("{host}:{port}");
-        let stream =
-            tokio::time::timeout(std::time::Duration::from_secs(2), TcpStream::connect(&addr))
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(std::io::ErrorKind::TimedOut, "TCP connect timed out")
-                })??;
-        let (reader, writer) = stream.into_split();
-        let lines = BufReader::new(reader).lines();
-        info!("[tui] connected to daemon via TCP at {addr}");
-        Ok(Self {
-            transport: Transport::Tcp { lines, writer },
-            is_remote: true,
-        })
+    /// Try connecting to each endpoint in order with a 500ms timeout per endpoint.
+    /// Returns the first successful connection.
+    pub async fn connect_tcp_fallback(endpoints: &[DaemonEndpoint]) -> std::io::Result<Self> {
+        for ep in endpoints {
+            info!("[ui] trying endpoint {}:{}...", ep.host, ep.port);
+            let addr = format!("{}:{}", ep.host, ep.port);
+            match tokio::time::timeout(
+                std::time::Duration::from_millis(500),
+                TcpStream::connect(&addr),
+            )
+            .await
+            {
+                Ok(Ok(stream)) => {
+                    let (reader, writer) = stream.into_split();
+                    let lines = BufReader::new(reader).lines();
+                    info!("[ui] connected to {}:{}", ep.host, ep.port);
+                    return Ok(Self {
+                        transport: Transport::Tcp { lines, writer },
+                        is_remote: true,
+                        connected_host: Some(ep.host.clone()),
+                    });
+                }
+                Ok(Err(e)) => {
+                    info!("[ui] endpoint {}:{} failed: {e}", ep.host, ep.port);
+                }
+                Err(_) => {
+                    info!("[ui] endpoint {}:{} timed out", ep.host, ep.port);
+                }
+            }
+        }
+        Err(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "all daemon endpoints failed",
+        ))
     }
 
     /// Send a chat message to the daemon.

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -104,15 +104,14 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
 
     // Detect remote workspace before auto-start so we skip local daemon spawn.
     let focused = app.current_ws();
-    let remote_target = focused.and_then(|ws| {
-        let host = ws.config.daemon_host.as_deref()?;
-        let port = ws.config.daemon_port?;
-        Some((host.to_string(), port))
-    });
+    let remote_endpoints = focused
+        .map(|ws| ws.config.resolved_daemon_endpoints())
+        .unwrap_or_default();
+    let is_remote = !remote_endpoints.is_empty();
 
     // Auto-start daemon if not running (skip for remote workspaces — they
     // connect to a daemon running on the remote host).
-    if remote_target.is_none() && !crate::daemon::is_daemon_running() {
+    if !is_remote && !crate::daemon::is_daemon_running() {
         eprintln!("Starting daemon in the background...");
         if let Err(e) = crate::daemon::spawn_background() {
             eprintln!("Warning: failed to start daemon: {e}");
@@ -128,18 +127,28 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
     }
 
     // Choose daemon client (shared session) or local coordinator (standalone).
-    let use_daemon = if remote_target.is_some() {
+    let use_daemon = if is_remote {
         true // remote always uses daemon client
     } else {
         daemon_client::socket_exists() && crate::daemon::is_daemon_running()
     };
     app.daemon_connected = use_daemon;
-    app.daemon_remote = remote_target.is_some();
+    app.daemon_remote = is_remote;
 
-    if let Some((host, port)) = remote_target {
-        // Remote daemon — connect via TCP
+    if is_remote {
+        // Remote daemon — connect via TCP with endpoint fallback
         let coord_tx_clone = coord_tx.clone();
-        tokio::spawn(daemon_client_task_tcp(host, port, user_rx, coord_tx_clone));
+        let (host_tx, host_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(daemon_client_task_tcp(
+            remote_endpoints,
+            user_rx,
+            coord_tx_clone,
+            host_tx,
+        ));
+        // Capture connected host for status bar display (non-blocking).
+        if let Ok(host) = host_rx.await {
+            app.remote_host = host;
+        }
     } else if use_daemon {
         // Spawn daemon client task (tokio task — the daemon handles coordinator)
         let coord_tx_clone = coord_tx.clone();
@@ -1304,19 +1313,24 @@ async fn daemon_client_task(
     }
 }
 
-/// Daemon client task connecting via TCP (remote workspace).
+/// Daemon client task connecting via TCP (remote workspace) with endpoint fallback.
 async fn daemon_client_task_tcp(
-    host: String,
-    port: u16,
+    endpoints: Vec<config::DaemonEndpoint>,
     mut user_rx: mpsc::Receiver<UserMessage>,
     coord_tx: mpsc::Sender<CoordResponse>,
+    connected_host_tx: tokio::sync::oneshot::Sender<Option<String>>,
 ) {
-    let mut client = match daemon_client::DaemonClient::connect_tcp(&host, port).await {
-        Ok(c) => c,
+    let mut client = match daemon_client::DaemonClient::connect_tcp_fallback(&endpoints).await {
+        Ok(c) => {
+            let _ = connected_host_tx.send(c.connected_host.clone());
+            c
+        }
         Err(e) => {
+            let _ = connected_host_tx.send(None);
             let _ = coord_tx
                 .send(CoordResponse::Error(format!(
-                    "Failed to connect to remote daemon at {host}:{port}: {e}"
+                    "Failed to connect to remote daemon (tried {} endpoints): {e}",
+                    endpoints.len()
                 )))
                 .await;
             return;
@@ -1547,6 +1561,7 @@ mod tests {
             daemon_alive: false,
             daemon_connected: false,
             daemon_remote: false,
+            remote_host: None,
             daemon_uptime_secs: None,
             last_extras_refresh: std::time::Instant::now(),
             terminal_width: 120,

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -132,11 +132,15 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
     } else {
         daemon_client::socket_exists() && crate::daemon::is_daemon_running()
     };
-    app.daemon_connected = use_daemon;
+    // For remote: daemon_connected starts false until TCP actually succeeds.
+    app.daemon_connected = if is_remote { false } else { use_daemon };
     app.daemon_remote = is_remote;
 
     if is_remote {
-        // Remote daemon — connect via TCP with endpoint fallback
+        // Remote daemon — connect via TCP with endpoint fallback.
+        // The oneshot reports the connected host (or None on failure).
+        // We update daemon_connected + remote_host once the result arrives,
+        // but cap the wait so the TUI isn't blocked indefinitely.
         let coord_tx_clone = coord_tx.clone();
         let (host_tx, host_rx) = tokio::sync::oneshot::channel();
         tokio::spawn(daemon_client_task_tcp(
@@ -145,9 +149,19 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
             coord_tx_clone,
             host_tx,
         ));
-        // Capture connected host for status bar display (non-blocking).
-        if let Ok(host) = host_rx.await {
-            app.remote_host = host;
+        // Wait up to 3s for the connection result so the status bar is accurate
+        // on first render, but don't block startup forever.
+        match tokio::time::timeout(Duration::from_secs(3), host_rx).await {
+            Ok(Ok(Some(host))) => {
+                app.daemon_connected = true;
+                app.remote_host = Some(host);
+            }
+            Ok(Ok(None)) => {
+                // All endpoints failed — daemon_connected stays false.
+            }
+            _ => {
+                // Timeout or channel dropped — proceed without host info.
+            }
         }
     } else if use_daemon {
         // Spawn daemon client task (tokio task — the daemon handles coordinator)

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -2248,11 +2248,14 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         "\u{25cb}" // ○ local fallback
     };
     let conn_label = if app.daemon_remote {
-        "remote"
+        match &app.remote_host {
+            Some(host) => format!("remote ({host})"),
+            None => "remote".to_string(),
+        }
     } else if app.daemon_connected {
-        "daemon"
+        "daemon".to_string()
     } else {
-        "local"
+        "local".to_string()
     };
     let conn_style = if app.daemon_remote {
         Style::default().fg(theme::FROST) // cyan for remote

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -1,5 +1,7 @@
 //! All ratatui rendering for the apiari TUI.
 
+use std::borrow::Cow;
+
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
@@ -2247,15 +2249,15 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         "\u{25cb}" // ○ local fallback
     };
-    let conn_label = if app.daemon_remote {
+    let conn_label: Cow<'_, str> = if app.daemon_remote {
         match &app.remote_host {
-            Some(host) => format!("remote ({host})"),
-            None => "remote".to_string(),
+            Some(host) => format!("remote ({host})").into(),
+            None => "remote".into(),
         }
     } else if app.daemon_connected {
-        "daemon".to_string()
+        "daemon".into()
     } else {
-        "local".to_string()
+        "local".into()
     };
     let conn_style = if app.daemon_remote {
         Style::default().fg(theme::FROST) // cyan for remote


### PR DESCRIPTION
## Summary
- Adds `[[daemon_endpoints]]` array to workspace config, replacing the single `daemon_host` + `daemon_port` fields for remote daemon connections
- TUI tries each endpoint in order with a 500ms timeout, connecting to the first that responds
- Status bar shows which endpoint is connected: `● remote (100.64.x.x)` in cyan
- Full backward compatibility: legacy `daemon_host` + `daemon_port` still work as a single-entry endpoint list

## Config example
```toml
[[daemon_endpoints]]
host = "localhost"
port = 7474

[[daemon_endpoints]]
host = "100.64.x.x"   # Tailscale
port = 7474

[[daemon_endpoints]]
host = "192.168.1.x"  # LAN
port = 7474
```

## Test plan
- [x] Config parses `[[daemon_endpoints]]` array correctly
- [x] Default port (7474) applied when omitted
- [x] Backward compat: `daemon_host` + `daemon_port` still works via `resolved_daemon_endpoints()`
- [x] `daemon_endpoints` array takes precedence over legacy fields
- [x] Empty config returns empty endpoints (local-only workspace)
- [x] Host-without-port in legacy config returns empty (not remote)
- [x] All 47 config tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)