### PR TITLE
feat: use workspace-level repos as fallback for GitHub watcher

### DIFF
--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -545,10 +545,12 @@ pub fn to_buzz_config(ws: &WorkspaceConfig) -> crate::buzz::config::BuzzConfig {
                 .map(|g| crate::buzz::config::GithubWatcherConfig {
                     enabled: true,
                     interval_secs: g.interval_secs,
-                    repos: if g.repos.is_empty() {
-                        discover_repos(&ws.root)
-                    } else {
+                    repos: if !g.repos.is_empty() {
                         g.repos.clone()
+                    } else if !ws.repos.is_empty() {
+                        ws.repos.clone()
+                    } else {
+                        discover_repos(&ws.root)
                     },
                     watch_labels: vec![],
                     review_queue: g

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -547,10 +547,8 @@ pub fn to_buzz_config(ws: &WorkspaceConfig) -> crate::buzz::config::BuzzConfig {
                     interval_secs: g.interval_secs,
                     repos: if !g.repos.is_empty() {
                         g.repos.clone()
-                    } else if !ws.repos.is_empty() {
-                        ws.repos.clone()
                     } else {
-                        discover_repos(&ws.root)
+                        resolve_repos(ws)
                     },
                     watch_labels: vec![],
                     review_queue: g
@@ -1146,5 +1144,53 @@ root = "/tmp/test"
         let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
         // Legacy requires both host AND port
         assert!(config.resolved_daemon_endpoints().is_empty());
+    }
+
+    /// Helper to build a minimal WorkspaceConfig with a GitHub watcher for repo resolution tests.
+    fn ws_with_github(ws_repos: Vec<String>, gh_repos: Vec<String>) -> WorkspaceConfig {
+        WorkspaceConfig {
+            root: "/nonexistent".into(),
+            repos: ws_repos,
+            telegram: None,
+            coordinator: CoordinatorConfig::default(),
+            watchers: WatchersConfig {
+                github: Some(GithubWatcherConfig {
+                    repos: gh_repos,
+                    interval_secs: default_watcher_interval(),
+                    review_queue: vec![],
+                }),
+                ..Default::default()
+            },
+            pipeline: PipelineConfig::default(),
+            commands: vec![],
+            morning_brief: None,
+            daemon_tcp_port: None,
+            daemon_tcp_bind: None,
+            daemon_host: None,
+            daemon_port: None,
+            daemon_endpoints: vec![],
+        }
+    }
+
+    #[test]
+    fn test_buzz_github_repos_watcher_override() {
+        let ws = ws_with_github(vec!["Org/Workspace".into()], vec!["Org/Override".into()]);
+        let gh = to_buzz_config(&ws).watchers.github.unwrap();
+        assert_eq!(gh.repos, vec!["Org/Override"]);
+    }
+
+    #[test]
+    fn test_buzz_github_repos_workspace_fallback() {
+        let ws = ws_with_github(vec!["Org/Workspace".into()], vec![]);
+        let gh = to_buzz_config(&ws).watchers.github.unwrap();
+        assert_eq!(gh.repos, vec!["Org/Workspace"]);
+    }
+
+    #[test]
+    fn test_buzz_github_repos_discovery_fallback() {
+        let ws = ws_with_github(vec![], vec![]);
+        let gh = to_buzz_config(&ws).watchers.github.unwrap();
+        // Nonexistent root means discover_repos returns empty
+        assert!(gh.repos.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Adds workspace-level `repos` list as a fallback tier in GitHub watcher repo resolution
- Resolution order: watcher-level repos → workspace-level repos → filesystem discovery

## Test plan
- [ ] Verify watcher-level `repos` still takes priority when set
- [ ] Verify workspace-level `repos` is used when watcher-level is empty
- [ ] Verify `discover_repos` is called when both are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)