### PR TITLE
Tune GitHub notification pipeline to reduce Telegram spam

### DIFF
--- a/crates/apiari/src/buzz/watcher/github.rs
+++ b/crates/apiari/src/buzz/watcher/github.rs
@@ -322,6 +322,26 @@ impl GithubWatcher {
                 continue;
             }
 
+            // Always mark as seen to prevent future re-emission
+            new_seen.insert(number);
+
+            // On first run (empty cursor), only emit for recently merged PRs
+            // to avoid flooding with old already-merged PRs.
+            if seen_prs.is_empty() {
+                let is_recent = pr
+                    .get("mergedAt")
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                    .is_some_and(|merged_at| {
+                        let cutoff = chrono::Utc::now()
+                            - chrono::Duration::seconds((self.config.interval_secs * 2) as i64);
+                        merged_at >= cutoff
+                    });
+                if !is_recent {
+                    continue;
+                }
+            }
+
             let title = pr.get("title").and_then(|v| v.as_str()).unwrap_or("");
             let url = pr.get("url").and_then(|v| v.as_str()).unwrap_or("");
 
@@ -332,8 +352,6 @@ impl GithubWatcher {
                 signal = signal.with_url(url);
             }
             signals.push(signal);
-
-            new_seen.insert(number);
         }
 
         if new_seen != *seen_prs {

--- a/crates/apiari/src/buzz/watcher/github.rs
+++ b/crates/apiari/src/buzz/watcher/github.rs
@@ -327,19 +327,13 @@ impl GithubWatcher {
 
             // On first run (empty cursor), only emit for recently merged PRs
             // to avoid flooding with old already-merged PRs.
-            if seen_prs.is_empty() {
-                let is_recent = pr
-                    .get("mergedAt")
-                    .and_then(|v| v.as_str())
-                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                    .is_some_and(|merged_at| {
-                        let cutoff = chrono::Utc::now()
-                            - chrono::Duration::seconds((self.config.interval_secs * 2) as i64);
-                        merged_at >= cutoff
-                    });
-                if !is_recent {
-                    continue;
-                }
+            if seen_prs.is_empty()
+                && !is_recent_merge(
+                    pr.get("mergedAt").and_then(|v| v.as_str()).unwrap_or(""),
+                    self.config.interval_secs,
+                )
+            {
+                continue;
             }
 
             let title = pr.get("title").and_then(|v| v.as_str()).unwrap_or("");
@@ -671,9 +665,33 @@ fn check_run_to_signal(repo: &str, run: &serde_json::Value) -> Option<(String, S
     Some((key, signal))
 }
 
+/// Check if a merged PR is recent enough to emit a signal on first run.
+fn is_recent_merge(merged_at_str: &str, interval_secs: u64) -> bool {
+    chrono::DateTime::parse_from_rfc3339(merged_at_str)
+        .ok()
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .is_some_and(|merged_at| {
+            let cutoff = chrono::Utc::now() - chrono::Duration::seconds((interval_secs * 2) as i64);
+            merged_at >= cutoff
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_first_run_filters_old_merged_prs() {
+        // A PR merged long ago should not be recent
+        assert!(!is_recent_merge("2020-01-01T00:00:00Z", 300));
+
+        // A PR merged just now should be recent
+        let now = chrono::Utc::now().to_rfc3339();
+        assert!(is_recent_merge(&now, 300));
+
+        // Invalid date should not be recent
+        assert!(!is_recent_merge("not-a-date", 300));
+    }
 
     #[test]
     fn test_issue_to_signal() {

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -961,7 +961,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     }
 
                     let mut new_swarm_events: Vec<String> = Vec::new();
-                    let mut ci_pass_titles: Vec<String> = Vec::new();
+                    let mut ci_pass_batch: Vec<(String, String)> = Vec::new(); // (pr_ref, title)
 
                     for throttled in slot.registry.watchers_mut() {
                         if !throttled.should_poll() {
@@ -1008,7 +1008,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                             slot.pipeline.process_force_notify(&record)
                                                         }
                                                         "github_ci_pass" => {
-                                                            ci_pass_titles.push(record.title.clone());
+                                                            // Extract PR # from external_id (ci-pass-{repo}-{pr}-{run})
+                                                            let pr_ref = record
+                                                                .external_id
+                                                                .rsplit('-')
+                                                                .nth(1)
+                                                                .map(|n| format!("#{n}"))
+                                                                .unwrap_or_default();
+                                                            ci_pass_batch
+                                                                .push((pr_ref, record.title.clone()));
                                                             None
                                                         }
                                                         _ => slot.pipeline.process(&record),
@@ -1055,22 +1063,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     }
 
                     // Send batched CI pass notification
-                    if !ci_pass_titles.is_empty() {
-                        let text = if ci_pass_titles.len() == 1 {
-                            ci_pass_titles[0].clone()
+                    if !ci_pass_batch.is_empty() {
+                        let text = if ci_pass_batch.len() == 1 {
+                            ci_pass_batch[0].1.clone()
                         } else {
-                            let pr_refs: Vec<&str> = ci_pass_titles
-                                .iter()
-                                .filter_map(|t| {
-                                    t.find('#').map(|i| {
-                                        let rest = &t[i..];
-                                        rest.split(':').next().unwrap_or(rest).trim()
-                                    })
-                                })
-                                .collect();
+                            let pr_refs: Vec<&str> =
+                                ci_pass_batch.iter().map(|(r, _)| r.as_str()).collect();
                             format!(
                                 "\u{2705} CI passed on {} PRs: {}",
-                                ci_pass_titles.len(),
+                                ci_pass_batch.len(),
                                 pr_refs.join(", ")
                             )
                         };

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -961,6 +961,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     }
 
                     let mut new_swarm_events: Vec<String> = Vec::new();
+                    let mut ci_pass_titles: Vec<String> = Vec::new();
 
                     for throttled in slot.registry.watchers_mut() {
                         if !throttled.should_poll() {
@@ -995,14 +996,20 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                             }
 
                                             // Determine notification text:
-                                            // - Proactive GitHub events (release, merged PR, CI pass)
-                                            //   use force-notify to bypass Info batching
-                                            // - Other new signals go through normal pipeline rules
+                                            // - github_merged_pr: DB-only, no Telegram
+                                            // - github_ci_pass: collected for batched message
+                                            // - github_release: immediate real-time
+                                            // - Other new signals go through pipeline rules
                                             let text = if is_new {
                                                 slot.store.get_signal(id).ok().flatten().and_then(|record| {
                                                     match update.source.as_str() {
-                                                        "github_release" | "github_merged_pr" | "github_ci_pass" => {
+                                                        "github_merged_pr" => None,
+                                                        "github_release" => {
                                                             slot.pipeline.process_force_notify(&record)
+                                                        }
+                                                        "github_ci_pass" => {
+                                                            ci_pass_titles.push(record.title.clone());
+                                                            None
                                                         }
                                                         _ => slot.pipeline.process(&record),
                                                     }
@@ -1043,6 +1050,41 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                 error!("[{}] [{}] poll failed: {e}", slot.name, watcher_name);
                                 // Still mark polled on error to avoid hammering a failing source
                                 throttled.mark_polled();
+                            }
+                        }
+                    }
+
+                    // Send batched CI pass notification
+                    if !ci_pass_titles.is_empty() {
+                        let text = if ci_pass_titles.len() == 1 {
+                            ci_pass_titles[0].clone()
+                        } else {
+                            let pr_refs: Vec<&str> = ci_pass_titles
+                                .iter()
+                                .filter_map(|t| {
+                                    t.find('#').map(|i| {
+                                        let rest = &t[i..];
+                                        rest.split(':').next().unwrap_or(rest).trim()
+                                    })
+                                })
+                                .collect();
+                            format!(
+                                "\u{2705} CI passed on {} PRs: {}",
+                                ci_pass_titles.len(),
+                                pr_refs.join(", ")
+                            )
+                        };
+                        if let Some(tg) = &slot.config.telegram
+                            && let Some(channel) = telegram_channels.get(&tg.bot_token)
+                        {
+                            let msg = OutboundMessage {
+                                chat_id: tg.chat_id,
+                                text,
+                                buttons: vec![],
+                                topic_id: tg.topic_id,
+                            };
+                            if let Err(e) = channel.send_message(&msg).await {
+                                error!("[{}] failed to send CI pass notification: {e}", slot.name);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- **Suppress Telegram for `github_merged_pr`**: Signal still written to DB (dashboard visible), but no Telegram ping. Merged PRs are low-signal noise.
- **Batch `github_ci_pass` notifications**: Instead of one message per passing PR, a single poll cycle sends one combined message. Single PR: `✅ CI passed on PR #54: feat: add proactive GitHub notifications`. Multiple PRs: `✅ CI passed on 3 PRs: #52, #53, #54`.
- **Fix first-run merged PR flood**: On first poll (empty cursor), `poll_merged_prs()` now filters by `mergedAt` — only PRs merged within `interval_secs * 2` emit signals. Old PRs are still marked as seen to prevent future re-emission.
- **`github_release` unchanged**: Release pass/fail remains an immediate real-time notification.

## Test plan
- [ ] Verify `cargo build` and `cargo fmt` pass (done locally)
- [ ] Deploy daemon and confirm merged PR notifications no longer appear in Telegram
- [ ] Trigger multiple CI passes in one poll cycle and verify single combined message
- [ ] Fresh start (delete cursor DB): confirm no flood of old merged PRs
- [ ] Verify release workflow notifications still arrive immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)