### PR TITLE
feat: TUI slash commands + auto-compact coordinator session

### DIFF
--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -157,6 +157,10 @@ pub struct CoordinatorConfig {
     /// Signals, repos, and skills are still auto-appended.
     #[serde(default)]
     pub prompt: Option<String>,
+    /// Clear the coordinator session after this many turns (default: 50).
+    /// Set to 0 to disable auto-compaction.
+    #[serde(default = "default_max_session_turns")]
+    pub max_session_turns: u32,
 }
 
 impl Default for CoordinatorConfig {
@@ -166,6 +170,7 @@ impl Default for CoordinatorConfig {
             model: default_model(),
             max_turns: default_max_turns(),
             prompt: None,
+            max_session_turns: default_max_session_turns(),
         }
     }
 }
@@ -762,6 +767,10 @@ fn default_model() -> String {
 
 fn default_max_turns() -> u32 {
     20
+}
+
+fn default_max_session_turns() -> u32 {
+    50
 }
 
 fn default_watcher_interval() -> u64 {

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -828,6 +828,29 @@ root = "/tmp/test"
         assert!(config.telegram.is_none());
         assert_eq!(config.coordinator.model, "sonnet");
         assert_eq!(config.coordinator.max_turns, 20);
+        assert_eq!(config.coordinator.max_session_turns, 50);
+    }
+
+    #[test]
+    fn test_max_session_turns_explicit() {
+        let toml_str = r#"
+root = "/tmp/test"
+[coordinator]
+max_session_turns = 100
+"#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.coordinator.max_session_turns, 100);
+    }
+
+    #[test]
+    fn test_max_session_turns_zero_disables() {
+        let toml_str = r#"
+root = "/tmp/test"
+[coordinator]
+max_session_turns = 0
+"#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.coordinator.max_session_turns, 0);
     }
 
     #[test]

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -90,6 +90,15 @@ enum CoordinatorJob {
     },
     /// Reset the coordinator session.
     ResetSession,
+    /// Compact the coordinator session (reset + respond with confirmation).
+    Compact {
+        /// If Some, send confirmation via Telegram.
+        telegram: Option<(TelegramChannel, i64, Option<i64>)>,
+        /// If Some, send confirmation via TUI responder.
+        tui_responder: Option<mpsc::UnboundedSender<socket::DaemonResponse>>,
+        socket_server: Option<Arc<socket::DaemonSocketServer>>,
+        slot_name: String,
+    },
     /// Coordinator follow-through for swarm events.
     SwarmFollowThrough {
         events: Vec<String>,
@@ -115,7 +124,10 @@ async fn run_coordinator_task(
     mut coordinator: Coordinator,
     store: SignalStore,
     mut job_rx: mpsc::UnboundedReceiver<CoordinatorJob>,
+    max_session_turns: u32,
 ) {
+    let mut turn_count: u32 = 0;
+
     while let Some(job) = job_rx.recv().await {
         match job {
             CoordinatorJob::TelegramMessage {
@@ -215,6 +227,8 @@ async fn run_coordinator_task(
 
                 match result {
                     Ok(response) => {
+                        turn_count += 1;
+
                         if let Some(ref server) = socket_server {
                             server.broadcast_activity(
                                 "telegram",
@@ -251,6 +265,13 @@ async fn run_coordinator_task(
                         if let Err(e) = channel.send_message(&msg).await {
                             error!("[{slot_name}] failed to send response: {e}");
                         }
+
+                        // Auto-compact if turn limit exceeded
+                        if max_session_turns > 0 && turn_count >= max_session_turns {
+                            info!("[coordinator] session compacted after {turn_count} turns");
+                            coordinator.reset_session();
+                            turn_count = 0;
+                        }
                     }
                     Err(e) => {
                         error!("[{slot_name}] coordinator error: {e}");
@@ -260,6 +281,7 @@ async fn run_coordinator_task(
                                 "[{slot_name}] resetting session after error (possible expired resume token)"
                             );
                             coordinator.reset_session();
+                            turn_count = 0;
                         }
                         let msg = OutboundMessage {
                             chat_id,
@@ -341,6 +363,7 @@ async fn run_coordinator_task(
 
                 match result {
                     Ok(response) => {
+                        turn_count += 1;
                         let _ = responder.send(socket::DaemonResponse::Done);
                         if let Some(ref server) = socket_server {
                             server.broadcast_activity(
@@ -350,6 +373,13 @@ async fn run_coordinator_task(
                                 &response,
                             );
                         }
+
+                        // Auto-compact if turn limit exceeded
+                        if max_session_turns > 0 && turn_count >= max_session_turns {
+                            info!("[coordinator] session compacted after {turn_count} turns");
+                            coordinator.reset_session();
+                            turn_count = 0;
+                        }
                     }
                     Err(e) => {
                         // If session resume failed, reset and try fresh next time
@@ -358,6 +388,7 @@ async fn run_coordinator_task(
                                 "[{ws_name}] resetting session after error (possible expired resume token)"
                             );
                             coordinator.reset_session();
+                            turn_count = 0;
                         }
                         let _ = responder.send(socket::DaemonResponse::Error {
                             text: format!("{e}"),
@@ -368,6 +399,38 @@ async fn run_coordinator_task(
 
             CoordinatorJob::ResetSession => {
                 coordinator.reset_session();
+                turn_count = 0;
+            }
+
+            CoordinatorJob::Compact {
+                telegram,
+                tui_responder,
+                socket_server,
+                slot_name,
+            } => {
+                coordinator.reset_session();
+                turn_count = 0;
+                info!("[{slot_name}] session compacted via /compact command");
+
+                let msg_text = "\u{1f5dc}\u{fe0f} Session compacted. Starting fresh.";
+                if let Some(ref server) = socket_server {
+                    server.broadcast_activity("system", &slot_name, "assistant_message", msg_text);
+                }
+                if let Some((channel, chat_id, topic_id)) = telegram {
+                    let msg = OutboundMessage {
+                        chat_id,
+                        text: msg_text.to_string(),
+                        buttons: vec![],
+                        topic_id,
+                    };
+                    let _ = channel.send_message(&msg).await;
+                }
+                if let Some(responder) = tui_responder {
+                    let _ = responder.send(socket::DaemonResponse::Token {
+                        text: msg_text.to_string(),
+                    });
+                    let _ = responder.send(socket::DaemonResponse::Done);
+                }
             }
 
             CoordinatorJob::SwarmFollowThrough {
@@ -766,7 +829,13 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             Err(e) => return ExitReason::Error(e),
         };
         let (coord_tx, coord_rx) = mpsc::unbounded_channel::<CoordinatorJob>();
-        tokio::spawn(run_coordinator_task(coordinator, coord_store, coord_rx));
+        let max_session_turns = ws.config.coordinator.max_session_turns;
+        tokio::spawn(run_coordinator_task(
+            coordinator,
+            coord_store,
+            coord_rx,
+            max_session_turns,
+        ));
 
         // Morning brief scheduler
         let morning_brief_scheduler = ws
@@ -1092,11 +1161,30 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                         let user_text = text.clone();
 
                         if let Some(&idx) = name_map.get(&ws_name) {
-                            let slot = &slots[idx];
+                            let slot = &mut slots[idx];
                             info!("[{}] TUI chat: {user_text}", slot.name);
 
                             if let Some(ref server) = socket_server {
                                 server.broadcast_activity("tui", &ws_name, "user_message", &user_text);
+                            }
+
+                            // Check for slash commands in TUI chat
+                            if let Some(rest) = user_text.strip_prefix('/') {
+                                let (command, _args) = match rest.split_once(' ') {
+                                    Some((cmd, args)) => (cmd, args.trim()),
+                                    None => (rest, ""),
+                                };
+                                let handled = handle_tui_command(
+                                    command,
+                                    slot,
+                                    &client_req.responder,
+                                    &socket_server,
+                                    &telegram_channels,
+                                ).await;
+                                if handled {
+                                    continue;
+                                }
+                                // Not a built-in command — fall through to coordinator
                             }
 
                             let job = CoordinatorJob::TuiChat {
@@ -1196,6 +1284,14 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                         };
                                         let _ = channel.send_message(&msg).await;
                                     }
+                                    "compact" => {
+                                        let _ = slot.coord_tx.send(CoordinatorJob::Compact {
+                                            telegram: Some((channel.clone(), chat_id, topic_id)),
+                                            tui_responder: None,
+                                            socket_server: socket_server.clone(),
+                                            slot_name: slot.name.clone(),
+                                        });
+                                    }
                                     "update" => {
                                         info!("[{}] running /update", slot.name);
                                         let updating_msg = OutboundMessage {
@@ -1280,7 +1376,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                         tokio::spawn(morning_brief::execute_brief(params));
                                     }
                                     "help" => {
-                                        let mut text = "Built-in commands:\n/status — show open signals\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/update — install latest apiari + swarm from crates.io\n/help — this message".to_string();
+                                        let mut text = "Built-in commands:\n/status — show open signals\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/compact — compact coordinator session (clear context, start fresh)\n/update — install latest apiari + swarm from crates.io\n/help — this message".to_string();
                                         if !slot.config.commands.is_empty() {
                                             text.push_str("\n\nCustom commands:");
                                             for cmd in &slot.config.commands {
@@ -1598,6 +1694,217 @@ fn write_pid() -> Result<()> {
 
 fn remove_pid() {
     let _ = std::fs::remove_file(pid_path());
+}
+
+/// Handle a TUI slash command. Returns `true` if the command was handled.
+async fn handle_tui_command(
+    command: &str,
+    slot: &mut WorkspaceSlot,
+    responder: &mpsc::UnboundedSender<socket::DaemonResponse>,
+    socket_server: &Option<Arc<socket::DaemonSocketServer>>,
+    telegram_channels: &HashMap<String, TelegramChannel>,
+) -> bool {
+    /// Send a text response back to the TUI client.
+    fn reply(
+        responder: &mpsc::UnboundedSender<socket::DaemonResponse>,
+        socket_server: &Option<Arc<socket::DaemonSocketServer>>,
+        ws_name: &str,
+        text: &str,
+    ) {
+        let _ = responder.send(socket::DaemonResponse::Token {
+            text: text.to_string(),
+        });
+        let _ = responder.send(socket::DaemonResponse::Done);
+        if let Some(server) = socket_server {
+            server.broadcast_activity("tui", ws_name, "assistant_message", text);
+        }
+    }
+
+    match command {
+        "status" => {
+            let signals = slot.store.get_open_signals().unwrap_or_default();
+            let summary = format_signal_summary(&signals);
+            reply(responder, socket_server, &slot.name, &summary);
+            true
+        }
+        "reset" => {
+            let _ = slot.coord_tx.send(CoordinatorJob::ResetSession);
+            reply(responder, socket_server, &slot.name, "Session reset.");
+            true
+        }
+        "compact" => {
+            let _ = slot.coord_tx.send(CoordinatorJob::Compact {
+                telegram: None,
+                tui_responder: Some(responder.clone()),
+                socket_server: socket_server.clone(),
+                slot_name: slot.name.clone(),
+            });
+            true
+        }
+        "brief" => {
+            let channel = slot
+                .config
+                .telegram
+                .as_ref()
+                .and_then(|tg| telegram_channels.get(&tg.bot_token));
+            if let Some(channel) = channel {
+                if let Some(tg) = &slot.config.telegram {
+                    let params = morning_brief::BriefParams {
+                        model: slot.config.coordinator.model.clone(),
+                        signals: slot.store.get_open_signals().unwrap_or_default(),
+                        swarm_state_path: slot
+                            .config
+                            .watchers
+                            .swarm
+                            .as_ref()
+                            .map(|s| s.state_path.clone()),
+                        workspace: slot.name.clone(),
+                        channel: channel.clone(),
+                        chat_id: tg.chat_id,
+                        topic_id: tg.topic_id,
+                        socket_server: socket_server.clone(),
+                    };
+                    tokio::spawn(morning_brief::execute_brief(params));
+                    reply(
+                        responder,
+                        socket_server,
+                        &slot.name,
+                        "Generating morning brief...",
+                    );
+                } else {
+                    reply(
+                        responder,
+                        socket_server,
+                        &slot.name,
+                        "No Telegram channel configured for briefs.",
+                    );
+                }
+            } else {
+                reply(
+                    responder,
+                    socket_server,
+                    &slot.name,
+                    "No Telegram channel configured for briefs.",
+                );
+            }
+            true
+        }
+        "help" => {
+            let mut text = "Built-in commands:\n/status — show open signals\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/compact — compact coordinator session (clear context, start fresh)\n/update — install latest apiari + swarm from crates.io\n/help — this message"
+                .to_string();
+            if !slot.config.commands.is_empty() {
+                text.push_str("\n\nCustom commands:");
+                for cmd in &slot.config.commands {
+                    let desc = cmd.description.as_deref().unwrap_or("(no description)");
+                    text.push_str(&format!("\n/{} — {}", cmd.name, desc));
+                }
+            }
+            reply(responder, socket_server, &slot.name, &text);
+            true
+        }
+        "update" => {
+            reply(
+                responder,
+                socket_server,
+                &slot.name,
+                "Updating apiari + swarm from crates.io...",
+            );
+
+            let script = "source /Users/josh/.cargo/env 2>/dev/null; \
+                /Users/josh/.cargo/bin/cargo install --force apiari 2>&1 && \
+                codesign -f -s - /Users/josh/.cargo/bin/apiari 2>&1 && \
+                /Users/josh/.cargo/bin/cargo install --force swarm 2>&1 && \
+                codesign -f -s - /Users/josh/.cargo/bin/swarm 2>&1";
+
+            let output = tokio::process::Command::new("sh")
+                .arg("-c")
+                .arg(script)
+                .output()
+                .await;
+
+            match output {
+                Ok(out) => {
+                    let stdout = String::from_utf8_lossy(&out.stdout);
+                    let stderr = String::from_utf8_lossy(&out.stderr);
+                    let status_icon = if out.status.success() { "✅" } else { "❌" };
+                    let mut text = format!("{status_icon} /update");
+                    let combined = format!("{stdout}{stderr}");
+                    let tail: String = combined
+                        .lines()
+                        .rev()
+                        .take(20)
+                        .collect::<Vec<_>>()
+                        .into_iter()
+                        .rev()
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    if !tail.is_empty() {
+                        text.push_str(&format!("\n```\n{tail}\n```"));
+                    }
+                    if let Some(server) = socket_server {
+                        server.broadcast_activity("tui", &slot.name, "assistant_message", &text);
+                    }
+                }
+                Err(e) => {
+                    if let Some(server) = socket_server {
+                        server.broadcast_activity(
+                            "tui",
+                            &slot.name,
+                            "assistant_message",
+                            &format!("❌ /update failed: {e}"),
+                        );
+                    }
+                }
+            }
+            true
+        }
+        _ => {
+            // Check custom commands
+            if let Some(cmd_cfg) = slot.config.commands.iter().find(|c| c.name == command) {
+                info!("[{}] running custom command: /{}", slot.name, command);
+                let output = tokio::process::Command::new("sh")
+                    .arg("-c")
+                    .arg(&cmd_cfg.script)
+                    .output()
+                    .await;
+
+                match output {
+                    Ok(out) => {
+                        let stdout = String::from_utf8_lossy(&out.stdout);
+                        let stderr = String::from_utf8_lossy(&out.stderr);
+                        let status_icon = if out.status.success() { "✅" } else { "❌" };
+                        let mut text = format!("{status_icon} /{command}");
+                        let combined = format!("{stdout}{stderr}");
+                        let tail: String = combined
+                            .lines()
+                            .rev()
+                            .take(20)
+                            .collect::<Vec<_>>()
+                            .into_iter()
+                            .rev()
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        if !tail.is_empty() {
+                            text.push_str(&format!("\n```\n{tail}\n```"));
+                        }
+                        reply(responder, socket_server, &slot.name, &text);
+                    }
+                    Err(e) => {
+                        reply(
+                            responder,
+                            socket_server,
+                            &slot.name,
+                            &format!("❌ /{command} failed: {e}"),
+                        );
+                    }
+                }
+                true
+            } else {
+                // Not a known command — let the coordinator handle it
+                false
+            }
+        }
+    }
 }
 
 /// Format swarm events into a system notification for the coordinator.

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -268,7 +268,7 @@ async fn run_coordinator_task(
 
                         // Auto-compact if turn limit exceeded
                         if max_session_turns > 0 && turn_count >= max_session_turns {
-                            info!("[coordinator] session compacted after {turn_count} turns");
+                            info!("[{slot_name}] session compacted after {turn_count} turns");
                             coordinator.reset_session();
                             turn_count = 0;
                         }
@@ -376,7 +376,7 @@ async fn run_coordinator_task(
 
                         // Auto-compact if turn limit exceeded
                         if max_session_turns > 0 && turn_count >= max_session_turns {
-                            info!("[coordinator] session compacted after {turn_count} turns");
+                            info!("[{ws_name}] session compacted after {turn_count} turns");
                             coordinator.reset_session();
                             turn_count = 0;
                         }
@@ -423,7 +423,9 @@ async fn run_coordinator_task(
                         buttons: vec![],
                         topic_id,
                     };
-                    let _ = channel.send_message(&msg).await;
+                    if let Err(e) = channel.send_message(&msg).await {
+                        error!("[{slot_name}] failed to send /compact confirmation: {e}");
+                    }
                 }
                 if let Some(responder) = tui_responder {
                     let _ = responder.send(socket::DaemonResponse::Token {
@@ -1285,12 +1287,20 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                         let _ = channel.send_message(&msg).await;
                                     }
                                     "compact" => {
-                                        let _ = slot.coord_tx.send(CoordinatorJob::Compact {
+                                        if slot.coord_tx.send(CoordinatorJob::Compact {
                                             telegram: Some((channel.clone(), chat_id, topic_id)),
                                             tui_responder: None,
                                             socket_server: socket_server.clone(),
                                             slot_name: slot.name.clone(),
-                                        });
+                                        }).is_err() {
+                                            let msg = OutboundMessage {
+                                                chat_id,
+                                                text: "Error: coordinator task shut down".to_string(),
+                                                buttons: vec![],
+                                                topic_id,
+                                            };
+                                            let _ = channel.send_message(&msg).await;
+                                        }
                                     }
                                     "update" => {
                                         info!("[{}] running /update", slot.name);
@@ -1733,12 +1743,23 @@ async fn handle_tui_command(
             true
         }
         "compact" => {
-            let _ = slot.coord_tx.send(CoordinatorJob::Compact {
-                telegram: None,
-                tui_responder: Some(responder.clone()),
-                socket_server: socket_server.clone(),
-                slot_name: slot.name.clone(),
-            });
+            if slot
+                .coord_tx
+                .send(CoordinatorJob::Compact {
+                    telegram: None,
+                    tui_responder: Some(responder.clone()),
+                    socket_server: socket_server.clone(),
+                    slot_name: slot.name.clone(),
+                })
+                .is_err()
+            {
+                reply(
+                    responder,
+                    socket_server,
+                    &slot.name,
+                    "Error: coordinator task shut down",
+                );
+            }
             true
         }
         "brief" => {
@@ -1803,12 +1824,10 @@ async fn handle_tui_command(
             true
         }
         "update" => {
-            reply(
-                responder,
-                socket_server,
-                &slot.name,
-                "Updating apiari + swarm from crates.io...",
-            );
+            // Send initial status as a streaming token (Done sent after completion)
+            let _ = responder.send(socket::DaemonResponse::Token {
+                text: "Updating apiari + swarm from crates.io...\n".to_string(),
+            });
 
             let script = "source /Users/josh/.cargo/env 2>/dev/null; \
                 /Users/josh/.cargo/bin/cargo install --force apiari 2>&1 && \
@@ -1841,18 +1860,18 @@ async fn handle_tui_command(
                     if !tail.is_empty() {
                         text.push_str(&format!("\n```\n{tail}\n```"));
                     }
+                    let _ = responder.send(socket::DaemonResponse::Token { text: text.clone() });
+                    let _ = responder.send(socket::DaemonResponse::Done);
                     if let Some(server) = socket_server {
                         server.broadcast_activity("tui", &slot.name, "assistant_message", &text);
                     }
                 }
                 Err(e) => {
+                    let text = format!("❌ /update failed: {e}");
+                    let _ = responder.send(socket::DaemonResponse::Token { text: text.clone() });
+                    let _ = responder.send(socket::DaemonResponse::Done);
                     if let Some(server) = socket_server {
-                        server.broadcast_activity(
-                            "tui",
-                            &slot.name,
-                            "assistant_message",
-                            &format!("❌ /update failed: {e}"),
-                        );
+                        server.broadcast_activity("tui", &slot.name, "assistant_message", &text);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- **TUI slash commands**: Messages starting with `/` in the TUI chat panel are now parsed and routed through the same command handler used for Telegram (`/status`, `/reset`, `/compact`, `/brief`, `/update`, `/help`, and custom commands)
- **Auto-compact coordinator session**: New `max_session_turns` config field (default: 50) in `[coordinator]` that automatically resets the session when the turn limit is exceeded, preventing unbounded context growth
- **`/compact` command**: New built-in command that immediately clears the coordinator session and starts fresh — works via both Telegram and TUI chat

## Test plan
- [ ] Verify `/help` in TUI chat returns the command list including `/compact`
- [ ] Verify `/status` in TUI chat returns open signals
- [ ] Verify `/compact` in TUI chat resets the session and returns confirmation
- [ ] Verify `/compact` via Telegram resets the session and returns confirmation
- [ ] Verify auto-compact triggers after `max_session_turns` exchanges (set to low value like 3 for testing)
- [ ] Verify `max_session_turns = 0` disables auto-compaction
- [ ] Verify existing Telegram commands still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)