### PR TITLE
feat: improve TUI chat input box

### DIFF
--- a/crates/hive/src/ui/app.rs
+++ b/crates/hive/src/ui/app.rs
@@ -602,7 +602,7 @@ impl App {
     /// Navigate to the next input history entry, or back to the draft.
     pub fn history_down(&mut self) {
         match self.history_index {
-            None => return,
+            None => (),
             Some(i) if i + 1 >= self.input_history.len() => {
                 self.history_index = None;
                 self.input = std::mem::take(&mut self.history_draft);

--- a/crates/hive/src/ui/app.rs
+++ b/crates/hive/src/ui/app.rs
@@ -142,6 +142,11 @@ pub struct App {
     pub input_cursor: usize,
     pub streaming: bool,
 
+    // Input history (last 50 entries, navigated with Up/Down)
+    pub input_history: Vec<String>,
+    pub history_index: Option<usize>,
+    pub history_draft: String,
+
     // Panel focus
     pub focus: Panel,
 
@@ -225,6 +230,9 @@ impl App {
             input: String::new(),
             input_cursor: 0,
             streaming: false,
+            input_history: Vec::new(),
+            history_index: None,
+            history_draft: String::new(),
             focus: Panel::Workers,
             chat_scroll: 0,
             pane_content: String::new(),
@@ -434,6 +442,8 @@ impl App {
             self.sidebar_selection = item;
             self.input.clear();
             self.input_cursor = 0;
+            self.history_index = None;
+            self.history_draft.clear();
             self.refresh_pane_content();
         }
     }
@@ -515,12 +525,112 @@ impl App {
         }
     }
 
-    /// Take the current input, clearing the buffer.
+    /// Move cursor one character to the left.
+    pub fn move_cursor_left(&mut self) {
+        if self.input_cursor > 0 {
+            let prev = self.input[..self.input_cursor]
+                .char_indices()
+                .next_back()
+                .map(|(i, _)| i)
+                .unwrap_or(0);
+            self.input_cursor = prev;
+        }
+    }
+
+    /// Move cursor one character to the right.
+    pub fn move_cursor_right(&mut self) {
+        if self.input_cursor < self.input.len() {
+            let next = self.input[self.input_cursor..]
+                .char_indices()
+                .nth(1)
+                .map(|(i, _)| self.input_cursor + i)
+                .unwrap_or(self.input.len());
+            self.input_cursor = next;
+        }
+    }
+
+    /// Move cursor to start of input.
+    pub fn cursor_home(&mut self) {
+        self.input_cursor = 0;
+    }
+
+    /// Move cursor to end of input.
+    pub fn cursor_end(&mut self) {
+        self.input_cursor = self.input.len();
+    }
+
+    /// Delete the character after the cursor.
+    pub fn delete_char(&mut self) {
+        if self.input_cursor < self.input.len() {
+            let next = self.input[self.input_cursor..]
+                .char_indices()
+                .nth(1)
+                .map(|(i, _)| self.input_cursor + i)
+                .unwrap_or(self.input.len());
+            self.input.drain(self.input_cursor..next);
+        }
+    }
+
+    /// Insert a string at the cursor position (used for paste).
+    pub fn insert_str(&mut self, s: &str) {
+        self.input
+            .insert_str(self.input.len().min(self.input_cursor), s);
+        self.input_cursor += s.len();
+    }
+
+    /// Navigate to the previous input history entry.
+    pub fn history_up(&mut self) {
+        if self.input_history.is_empty() {
+            return;
+        }
+        match self.history_index {
+            None => {
+                self.history_draft = self.input.clone();
+                self.history_index = Some(self.input_history.len() - 1);
+            }
+            Some(0) => return,
+            Some(i) => {
+                self.history_index = Some(i - 1);
+            }
+        }
+        if let Some(i) = self.history_index {
+            self.input = self.input_history[i].clone();
+            self.input_cursor = self.input.len();
+        }
+    }
+
+    /// Navigate to the next input history entry, or back to the draft.
+    pub fn history_down(&mut self) {
+        match self.history_index {
+            None => return,
+            Some(i) if i + 1 >= self.input_history.len() => {
+                self.history_index = None;
+                self.input = std::mem::take(&mut self.history_draft);
+                self.input_cursor = self.input.len();
+            }
+            Some(i) => {
+                self.history_index = Some(i + 1);
+                self.input = self.input_history[i + 1].clone();
+                self.input_cursor = self.input.len();
+            }
+        }
+    }
+
+    /// Take the current input, clearing the buffer and pushing to history.
     pub fn take_input(&mut self) -> String {
         let text = self.input.clone();
         self.input.clear();
         self.input_cursor = 0;
         self.chat_scroll = 0;
+        // Push to input history (max 50 entries).
+        if !text.trim().is_empty() {
+            self.input_history.push(text.clone());
+            if self.input_history.len() > 50 {
+                self.input_history.remove(0);
+            }
+        }
+        self.history_index = None;
+        self.history_draft.clear();
         text
     }
 

--- a/crates/hive/src/ui/mod.rs
+++ b/crates/hive/src/ui/mod.rs
@@ -464,14 +464,14 @@ async fn event_loop(
                     app.insert_str(text);
                 }
                 // Also handle paste in dispatch prompt mode.
-                if let Some(ref d) = app.dispatch {
-                    if matches!(d.phase, app::DispatchPhase::EnterPrompt) {
-                        // Insert pasted text into dispatch prompt.
-                        if let Some(ref mut d) = app.dispatch {
-                            d.prompt
-                                .insert_str(d.prompt.len().min(d.prompt_cursor), text);
-                            d.prompt_cursor += text.len();
-                        }
+                if let Some(ref d) = app.dispatch
+                    && matches!(d.phase, app::DispatchPhase::EnterPrompt)
+                {
+                    // Insert pasted text into dispatch prompt.
+                    if let Some(ref mut d) = app.dispatch {
+                        d.prompt
+                            .insert_str(d.prompt.len().min(d.prompt_cursor), text);
+                        d.prompt_cursor += text.len();
                     }
                 }
                 continue;
@@ -830,6 +830,9 @@ async fn event_loop(
                                     KeyCode::Char('u') => app.scroll_chat_half_up(viewport_height),
                                     KeyCode::Char('d') => {
                                         app.scroll_chat_half_down(viewport_height)
+                                    }
+                                    KeyCode::Char('g') => {
+                                        app.scroll_chat_to_top(u16::MAX, viewport_height)
                                     }
                                     KeyCode::Char('G') => app.scroll_chat_to_bottom(),
                                     KeyCode::PageUp => app.scroll_chat_page_up(viewport_height),

--- a/crates/hive/src/ui/mod.rs
+++ b/crates/hive/src/ui/mod.rs
@@ -13,7 +13,7 @@ use app::{
 use color_eyre::Result;
 use crossterm::{
     ExecutableCommand,
-    event::{self, Event, KeyCode, KeyModifiers},
+    event::{self, DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyModifiers},
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use daemon_client::DaemonClient;
@@ -138,6 +138,7 @@ pub async fn run(cwd: &Path) -> Result<()> {
 
     // Terminal setup.
     stdout().execute(EnterAlternateScreen)?;
+    stdout().execute(EnableBracketedPaste)?;
     enable_raw_mode()?;
 
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
@@ -150,6 +151,7 @@ pub async fn run(cwd: &Path) -> Result<()> {
 
     // Terminal teardown.
     disable_raw_mode()?;
+    stdout().execute(DisableBracketedPaste)?;
     stdout().execute(LeaveAlternateScreen)?;
 
     result
@@ -452,10 +454,32 @@ async fn event_loop(
             }
         }
 
-        // Poll keyboard events with 100ms timeout.
-        if event::poll(Duration::from_millis(100))?
-            && let Event::Key(key) = event::read()?
-        {
+        // Poll keyboard/paste events with 100ms timeout.
+        if event::poll(Duration::from_millis(100))? {
+            let raw_event = event::read()?;
+
+            // Handle paste events (bracketed paste).
+            if let Event::Paste(ref text) = raw_event {
+                if app.focus == Panel::Chat && app.is_chat_selected() && !app.streaming {
+                    app.insert_str(text);
+                }
+                // Also handle paste in dispatch prompt mode.
+                if let Some(ref d) = app.dispatch {
+                    if matches!(d.phase, app::DispatchPhase::EnterPrompt) {
+                        // Insert pasted text into dispatch prompt.
+                        if let Some(ref mut d) = app.dispatch {
+                            d.prompt
+                                .insert_str(d.prompt.len().min(d.prompt_cursor), text);
+                            d.prompt_cursor += text.len();
+                        }
+                    }
+                }
+                continue;
+            }
+
+            let Event::Key(key) = raw_event else {
+                continue;
+            };
             // Ctrl+C always quits.
             if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
                 break;
@@ -738,13 +762,14 @@ async fn event_loop(
                                 }
                             } else {
                                 match key.code {
+                                    // UI navigation
                                     KeyCode::Char('z') => {
                                         app.zoomed = !app.zoomed;
                                     }
                                     KeyCode::Char('?') => {
                                         app.show_help = true;
                                     }
-                                    KeyCode::Char('h') | KeyCode::BackTab | KeyCode::Left => {
+                                    KeyCode::Char('h') | KeyCode::BackTab => {
                                         app.focus = Panel::Workers
                                     }
                                     KeyCode::Tab => app.focus = Panel::Workers,
@@ -755,6 +780,15 @@ async fn event_loop(
                                             app.focus = Panel::Workers;
                                         }
                                     }
+                                    // Alt+Enter inserts a newline.
+                                    KeyCode::Enter
+                                        if key.modifiers.intersects(
+                                            KeyModifiers::ALT | KeyModifiers::SHIFT,
+                                        ) =>
+                                    {
+                                        app.insert_char('\n');
+                                    }
+                                    // Enter sends the message.
                                     KeyCode::Enter => {
                                         if !app.input.is_empty() && !app.streaming {
                                             let text = app.take_input();
@@ -780,27 +814,27 @@ async fn event_loop(
                                                 user_tx.send(UserMessage::Chat(send_text)).await;
                                         }
                                     }
+                                    // Input editing
                                     KeyCode::Backspace => app.backspace(),
-                                    // Vim-style scroll
-                                    KeyCode::Char('j') | KeyCode::Down => {
-                                        app.scroll_chat_lines(1, false)
-                                    }
-                                    KeyCode::Char('k') | KeyCode::Up => {
-                                        app.scroll_chat_lines(1, true)
-                                    }
+                                    KeyCode::Delete => app.delete_char(),
+                                    KeyCode::Left => app.move_cursor_left(),
+                                    KeyCode::Right => app.move_cursor_right(),
+                                    KeyCode::Home => app.cursor_home(),
+                                    KeyCode::End => app.cursor_end(),
+                                    // Input history (Up/Down arrows)
+                                    KeyCode::Up => app.history_up(),
+                                    KeyCode::Down => app.history_down(),
+                                    // Vim-style scroll (letter keys)
+                                    KeyCode::Char('j') => app.scroll_chat_lines(1, false),
+                                    KeyCode::Char('k') => app.scroll_chat_lines(1, true),
                                     KeyCode::Char('u') => app.scroll_chat_half_up(viewport_height),
                                     KeyCode::Char('d') => {
                                         app.scroll_chat_half_down(viewport_height)
                                     }
-                                    KeyCode::Char('G') | KeyCode::End => {
-                                        app.scroll_chat_to_bottom()
-                                    }
-                                    KeyCode::Home => {
-                                        // We use a large value; render will clamp.
-                                        app.scroll_chat_to_top(u16::MAX, viewport_height)
-                                    }
+                                    KeyCode::Char('G') => app.scroll_chat_to_bottom(),
                                     KeyCode::PageUp => app.scroll_chat_page_up(viewport_height),
                                     KeyCode::PageDown => app.scroll_chat_page_down(viewport_height),
+                                    // Text input
                                     KeyCode::Char(c) => app.insert_char(c),
                                     _ => {}
                                 }

--- a/crates/hive/src/ui/render.rs
+++ b/crates/hive/src/ui/render.rs
@@ -676,12 +676,9 @@ fn draw_content_panel(frame: &mut Frame, area: Rect, app: &App) {
     match app.sidebar_selection {
         SidebarItem::Chat => {
             // Compute dynamic input height based on content wrapping.
-            let prompt_len = 2u16; // "> "
-            let hint_len = 14u16; // "[h: sidebar]" + pad
-            let input_content_width =
-                (area.width.saturating_sub(prompt_len + hint_len + 1)).max(1) as usize;
-            let visual_line_count = count_visual_lines(&app.input, input_content_width);
-            let cursor_row = cursor_row(&app.input, app.input_cursor, input_content_width);
+            let width = input_content_width(area.width, app);
+            let visual_line_count = count_visual_lines(&app.input, width);
+            let cursor_row = cursor_row(&app.input, app.input_cursor, width);
             let needed_lines = visual_line_count.max(cursor_row + 1);
             let input_height = (needed_lines as u16).clamp(1, 6) + 1; // +1 for Borders::TOP
 
@@ -1490,18 +1487,13 @@ fn draw_input_bar(frame: &mut Frame, area: Rect, app: &App) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let prompt = "> ";
-    let hint = if app.focus == Panel::Chat && app.is_chat_selected() {
-        "[h: sidebar]"
-    } else {
-        "[l: focus]"
-    };
+    let hint = input_hint(app);
 
     // Split inner into prompt + input area + hint.
     let cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(prompt.len() as u16),
+            Constraint::Length(INPUT_PROMPT.len() as u16),
             Constraint::Min(0),
             Constraint::Length((hint.len() as u16).saturating_add(1)),
         ])
@@ -1509,7 +1501,7 @@ fn draw_input_bar(frame: &mut Frame, area: Rect, app: &App) {
 
     // Render prompt.
     frame.render_widget(
-        Paragraph::new(Span::styled(prompt, theme::accent())),
+        Paragraph::new(Span::styled(INPUT_PROMPT, theme::accent())),
         cols[0],
     );
 
@@ -1553,6 +1545,26 @@ fn draw_input_bar(frame: &mut Frame, area: Rect, app: &App) {
     }
 }
 
+// ── Input layout helpers ─────────────────────────────────
+
+const INPUT_PROMPT: &str = "> ";
+
+/// Returns the hint text shown in the input bar (varies by focus state).
+fn input_hint(app: &App) -> &'static str {
+    if app.focus == Panel::Chat && app.is_chat_selected() {
+        "[h: sidebar]"
+    } else {
+        "[l: focus]"
+    }
+}
+
+/// Compute the available content width for the input text area.
+fn input_content_width(area_width: u16, app: &App) -> usize {
+    let hint = input_hint(app);
+    // Layout: prompt | input | hint+pad
+    (area_width.saturating_sub(INPUT_PROMPT.len() as u16 + hint.len() as u16 + 2)).max(1) as usize
+}
+
 // ── Input wrapping helpers ───────────────────────────────
 
 /// Split text into visual lines using character-level wrapping.
@@ -1588,7 +1600,7 @@ fn count_visual_lines(text: &str, width: usize) -> usize {
         lines += if char_count == 0 {
             1
         } else {
-            (char_count + width - 1) / width
+            char_count.div_ceil(width)
         };
     }
     lines.max(1)
@@ -1905,7 +1917,7 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect) {
         key_line("j / k", "Scroll 1 line"),
         key_line("u / d", "Half-page up/down"),
         key_line("PgUp / PgDn", "Full page"),
-        key_line("G", "Scroll to bottom"),
+        key_line("g / G", "Scroll to top/bottom"),
         key_line("h / Tab", "Return to sidebar"),
         key_line("z", "Toggle zoom"),
         Line::from(""),

--- a/crates/hive/src/ui/render.rs
+++ b/crates/hive/src/ui/render.rs
@@ -675,16 +675,26 @@ fn draw_content_panel(frame: &mut Frame, area: Rect, app: &App) {
 
     match app.sidebar_selection {
         SidebarItem::Chat => {
+            // Compute dynamic input height based on content wrapping.
+            let prompt_len = 2u16; // "> "
+            let hint_len = 14u16; // "[h: sidebar]" + pad
+            let input_content_width =
+                (area.width.saturating_sub(prompt_len + hint_len + 1)).max(1) as usize;
+            let visual_line_count = count_visual_lines(&app.input, input_content_width);
+            let cursor_row = cursor_row(&app.input, app.input_cursor, input_content_width);
+            let needed_lines = visual_line_count.max(cursor_row + 1);
+            let input_height = (needed_lines as u16).clamp(1, 6) + 1; // +1 for Borders::TOP
+
             let right = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Min(0),    // chat
-                    Constraint::Length(3), // input bar
+                    Constraint::Min(0),               // chat
+                    Constraint::Length(input_height), // input bar (dynamic)
                 ])
                 .split(area);
 
             draw_chat_panel(frame, right[0], app);
-            draw_input_bar(frame, right[1], app, "> ");
+            draw_input_bar(frame, right[1], app);
         }
         SidebarItem::Dispatch => {
             draw_dispatch_review(frame, area, app);
@@ -1472,7 +1482,7 @@ fn draw_chat_panel(frame: &mut Frame, area: Rect, app: &App) {
 
 // ── Input Bar ────────────────────────────────────────────
 
-fn draw_input_bar(frame: &mut Frame, area: Rect, app: &App, prompt: &str) {
+fn draw_input_bar(frame: &mut Frame, area: Rect, app: &App) {
     let block = Block::default()
         .borders(Borders::TOP)
         .border_style(theme::border());
@@ -1480,43 +1490,141 @@ fn draw_input_bar(frame: &mut Frame, area: Rect, app: &App, prompt: &str) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let prompt_spans = vec![
-        Span::styled(prompt, theme::accent()),
-        Span::styled(app.input.as_str(), theme::text()),
-    ];
-
-    // Focus hint on the right.
-    let hint = if app.focus == Panel::Chat {
+    let prompt = "> ";
+    let hint = if app.focus == Panel::Chat && app.is_chat_selected() {
         "[h: sidebar]"
     } else {
         "[l: focus]"
     };
 
-    let input_line = Line::from(prompt_spans);
-    let hint_line = Line::from(Span::styled(hint, theme::subtitle()));
-
-    // Split inner into input area + hint.
+    // Split inner into prompt + input area + hint.
     let cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
+            Constraint::Length(prompt.len() as u16),
             Constraint::Min(0),
             Constraint::Length((hint.len() as u16).saturating_add(1)),
         ])
         .split(inner);
 
-    let input_widget = Paragraph::new(input_line);
-    frame.render_widget(input_widget, cols[0]);
+    // Render prompt.
+    frame.render_widget(
+        Paragraph::new(Span::styled(prompt, theme::accent())),
+        cols[0],
+    );
 
-    let hint_widget = Paragraph::new(hint_line);
-    frame.render_widget(hint_widget, cols[1]);
+    // Render hint.
+    frame.render_widget(
+        Paragraph::new(Span::styled(hint, theme::subtitle())),
+        cols[2],
+    );
 
-    // Place the cursor.
-    if app.focus == Panel::Chat {
-        let prompt_width = prompt.len() as u16;
-        let cursor_x = cols[0].x + prompt_width + app.input_cursor as u16;
-        let cursor_y = cols[0].y;
-        frame.set_cursor_position((cursor_x.min(cols[0].right().saturating_sub(1)), cursor_y));
+    // Render input text with character wrapping.
+    let input_width = cols[1].width as usize;
+    let max_visible = cols[1].height as usize;
+    let wrapped = wrap_text(&app.input, input_width);
+
+    // Determine cursor position and scroll offset.
+    let (cur_row, cur_col) = cursor_position(&app.input, app.input_cursor, input_width);
+    let scroll = if cur_row >= max_visible {
+        cur_row - max_visible + 1
+    } else {
+        0
+    };
+
+    // Build visible lines.
+    let visible_lines: Vec<Line> = wrapped
+        .iter()
+        .skip(scroll)
+        .take(max_visible)
+        .map(|line_text| Line::from(Span::styled(line_text.clone(), theme::text())))
+        .collect();
+
+    frame.render_widget(Paragraph::new(visible_lines), cols[1]);
+
+    // Place the terminal cursor.
+    if app.focus == Panel::Chat && app.is_chat_selected() {
+        let visible_row = cur_row.saturating_sub(scroll);
+        let cursor_x = cols[1].x + cur_col as u16;
+        let cursor_y = cols[1].y + visible_row as u16;
+        if cursor_y < cols[1].bottom() && cursor_x < cols[1].right() {
+            frame.set_cursor_position((cursor_x, cursor_y));
+        }
     }
+}
+
+// ── Input wrapping helpers ───────────────────────────────
+
+/// Split text into visual lines using character-level wrapping.
+fn wrap_text(text: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return vec![text.to_string()];
+    }
+    let mut result = Vec::new();
+    for line in text.split('\n') {
+        if line.is_empty() {
+            result.push(String::new());
+            continue;
+        }
+        let chars: Vec<char> = line.chars().collect();
+        for chunk in chars.chunks(width) {
+            result.push(chunk.iter().collect());
+        }
+    }
+    if result.is_empty() {
+        result.push(String::new());
+    }
+    result
+}
+
+/// Count the number of visual lines after character wrapping.
+fn count_visual_lines(text: &str, width: usize) -> usize {
+    if width == 0 {
+        return 1;
+    }
+    let mut lines = 0usize;
+    for line in text.split('\n') {
+        let char_count = line.chars().count();
+        lines += if char_count == 0 {
+            1
+        } else {
+            (char_count + width - 1) / width
+        };
+    }
+    lines.max(1)
+}
+
+/// Calculate the visual row of the cursor in wrapped text.
+fn cursor_row(text: &str, cursor_byte: usize, width: usize) -> usize {
+    cursor_position(text, cursor_byte, width).0
+}
+
+/// Calculate the visual (row, col) of the cursor in wrapped text.
+fn cursor_position(text: &str, cursor_byte: usize, width: usize) -> (usize, usize) {
+    if width == 0 {
+        return (0, 0);
+    }
+    let before = &text[..cursor_byte.min(text.len())];
+    let mut row = 0usize;
+    let mut col = 0usize;
+    for ch in before.chars() {
+        if ch == '\n' {
+            row += 1;
+            col = 0;
+        } else {
+            if col == width {
+                row += 1;
+                col = 0;
+            }
+            col += 1;
+        }
+    }
+    // Cursor exactly at wrap boundary goes to next line.
+    if col == width {
+        row += 1;
+        col = 0;
+    }
+    (row, col)
 }
 
 // ── Worker Output ─────────────────────────────────────────
@@ -1746,7 +1854,7 @@ fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
 // ── Help Overlay ─────────────────────────────────────────
 
 fn draw_help_overlay(frame: &mut Frame, area: Rect) {
-    let popup = centered_rect(54, 32, area);
+    let popup = centered_rect(54, 35, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()
@@ -1790,11 +1898,14 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect) {
         Line::from(""),
         section("Chat"),
         key_line("↵", "Send message"),
+        key_line("alt+↵", "Insert newline"),
+        key_line("←/→", "Move cursor"),
+        key_line("↑/↓", "Input history"),
+        key_line("Home/End", "Start/end of input"),
         key_line("j / k", "Scroll 1 line"),
         key_line("u / d", "Half-page up/down"),
         key_line("PgUp / PgDn", "Full page"),
-        key_line("Home", "Scroll to top"),
-        key_line("G / End", "Scroll to bottom"),
+        key_line("G", "Scroll to bottom"),
         key_line("h / Tab", "Return to sidebar"),
         key_line("z", "Toggle zoom"),
         Line::from(""),


### PR DESCRIPTION
## Summary
- **Text wrapping**: Input now wraps to multiple lines (up to 6 lines tall, then scrolls) instead of running off-screen
- **Paste handling**: Enables bracketed paste mode so pasting multiline text inserts it as one buffer entry (sent as a single message on Enter) instead of sending each line separately
- **Cursor movement**: Left/Right arrow keys move the cursor within the input; Home/End jump to start/end
- **Input history**: Up/Down arrow keys navigate through the last 50 sent messages (like a terminal)
- **Multi-line editing**: Alt+Enter (or Shift+Enter where supported) inserts a newline for composing multi-line messages
- **Dynamic height**: Input bar grows/shrinks based on content (1–6 lines)

## Test plan
- [x] `cargo check -p hive` passes
- [x] `cargo test -p hive` — all 461 tests pass
- [x] `cargo fmt -p hive` and `cargo fmt -p apiari` applied
- [ ] Manual: type a long message and verify it wraps to multiple lines
- [ ] Manual: paste multiline text and verify it inserts as one message
- [ ] Manual: use arrow keys to move cursor within input
- [ ] Manual: press Up/Down to navigate input history
- [ ] Manual: press Alt+Enter to insert a newline, then Enter to send

🤖 Generated with [Claude Code](https://claude.com/claude-code)