### PR TITLE
feat: add TUI onboarding wizard and settings screen

### DIFF
--- a/crates/apiari/src/main.rs
+++ b/crates/apiari/src/main.rs
@@ -95,6 +95,23 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Command::Init { name } => {
+            // Launch TUI wizard when stdin is a TTY and no workspace exists yet
+            if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+                let cwd = std::env::current_dir()?;
+                let ws_name = name.as_deref().unwrap_or_else(|| {
+                    cwd.file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("workspace")
+                });
+                let config_path = config::workspaces_dir().join(format!("{ws_name}.toml"));
+                if !config_path.exists() {
+                    let result = ui::wizard::run_wizard().await?;
+                    if result.launch_ui {
+                        ui::run(result.workspace_name.as_deref()).await?;
+                    }
+                    return Ok(());
+                }
+            }
             init::run_init(name.as_deref())?;
         }
         Command::Daemon {

--- a/crates/apiari/src/main.rs
+++ b/crates/apiari/src/main.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<()> {
                 });
                 let config_path = config::workspaces_dir().join(format!("{ws_name}.toml"));
                 if !config_path.exists() {
-                    let result = ui::wizard::run_wizard().await?;
+                    let result = ui::wizard::run_wizard(name.as_deref()).await?;
                     if result.launch_ui {
                         ui::run(result.workspace_name.as_deref()).await?;
                     }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -89,7 +89,7 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
     let mut workspaces = config::discover_workspaces()?;
     if workspaces.is_empty() {
         // Launch the onboarding wizard instead of printing instructions
-        let result = wizard::run_wizard().await?;
+        let result = wizard::run_wizard(None).await?;
         if !result.launch_ui {
             return Ok(());
         }
@@ -269,6 +269,9 @@ async fn event_loop(
                         }
                     }
                     Some(Ok(Event::Mouse(mouse))) => {
+                        if settings_state.is_some() {
+                            continue;
+                        }
                         use crossterm::event::MouseEventKind;
                         match mouse.kind {
                             MouseEventKind::ScrollUp => {
@@ -1660,6 +1663,26 @@ mod tests {
 
         assert_eq!(app.focused_panel, Panel::Chat);
         assert!(app.chat_focused, "chat should be focused for input");
+    }
+
+    #[test]
+    fn test_s_key_opens_settings() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Home;
+        let action = handle_dashboard_key(&mut app, key(KeyCode::Char('s')));
+        assert!(matches!(action, KeyAction::OpenSettings));
+    }
+
+    #[test]
+    fn test_settings_chat_command() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Chat;
+        app.chat_focused = true;
+        // Type "/settings" into the input
+        app.workspaces[0].input = "/settings".to_string();
+        // Simulate Enter key
+        let action = handle_dashboard_chat_key(&mut app, key(KeyCode::Enter));
+        assert!(matches!(action, KeyAction::OpenSettings));
     }
 
     #[test]

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -4,7 +4,9 @@ pub mod app;
 pub mod daemon_client;
 pub mod history;
 pub mod render;
+pub mod settings;
 pub mod theme;
+pub mod wizard;
 
 use app::{App, Mode, Panel, PendingAction, View, review_signal_target};
 use color_eyre::Result;
@@ -15,6 +17,7 @@ use crossterm::terminal::{
 };
 use futures::StreamExt;
 use ratatui::prelude::*;
+use settings::SettingsState;
 use std::io::stdout;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -75,6 +78,7 @@ enum KeyAction {
         body: String,
     },
     SnoozeSignal(i64, chrono::DateTime<chrono::Utc>),
+    OpenSettings,
     Redraw,
 }
 
@@ -82,18 +86,19 @@ enum KeyAction {
 
 /// Launch the TUI.
 pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
-    let workspaces = config::discover_workspaces()?;
+    let mut workspaces = config::discover_workspaces()?;
     if workspaces.is_empty() {
-        eprintln!(
-            "No workspace configs found in {}",
-            config::workspaces_dir().display()
-        );
-        eprintln!("Run `apiari init` in a project directory to get started.");
-        eprintln!();
-        eprintln!("Get a Telegram bot token from @BotFather (https://t.me/BotFather)");
-        eprintln!("and your chat ID from @userinfobot (https://t.me/userinfobot).");
-        eprintln!("Then edit the config and run: apiari daemon start");
-        return Ok(());
+        // Launch the onboarding wizard instead of printing instructions
+        let result = wizard::run_wizard().await?;
+        if !result.launch_ui {
+            return Ok(());
+        }
+        // Re-discover workspaces after wizard wrote the config
+        workspaces = config::discover_workspaces()?;
+        if workspaces.is_empty() {
+            eprintln!("No workspace configs found after setup.");
+            return Ok(());
+        }
     }
 
     let mut app = App::new(workspaces, focus_workspace);
@@ -216,13 +221,19 @@ async fn event_loop(
     let mut events = EventStream::new();
     let mut tick = tokio::time::interval(Duration::from_millis(250));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut settings_state: Option<SettingsState> = None;
 
     loop {
         if app.needs_redraw {
             if let Ok(size) = crossterm::terminal::size() {
                 app.terminal_width = size.0;
             }
-            terminal.draw(|f| render::draw(f, &app))?;
+            terminal.draw(|f| {
+                render::draw(f, &app);
+                if let Some(ref ss) = settings_state {
+                    settings::draw_settings(f, ss, f.area());
+                }
+            })?;
             app.needs_redraw = false;
         }
 
@@ -230,7 +241,29 @@ async fn event_loop(
             maybe_event = events.next() => {
                 match maybe_event {
                     Some(Ok(Event::Key(key))) => {
+                        // Settings overlay intercepts all keys when active
+                        if let Some(ref mut ss) = settings_state {
+                            let closed = ss.handle_key(key);
+                            if closed {
+                                settings_state = None;
+                            }
+                            app.needs_redraw = true;
+                            continue;
+                        }
+
                         let action = handle_key(&mut app, key);
+
+                        // Check for settings trigger
+                        if let KeyAction::OpenSettings = action {
+                            if let Some(ws) = app.current_ws() {
+                                settings_state = Some(SettingsState::from_workspace(
+                                    &ws.name, &ws.config,
+                                ));
+                            }
+                            app.needs_redraw = true;
+                            continue;
+                        }
+
                         if let Some(true) = handle_action(&mut app, action, user_tx).await {
                             break;
                         }
@@ -592,6 +625,9 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
                 ws.chat_scroll.scroll_to_bottom();
             }
         }
+        KeyCode::Char('s') => {
+            return KeyAction::OpenSettings;
+        }
         KeyCode::Char('?') => {
             app.mode = Mode::Help;
         }
@@ -635,6 +671,9 @@ fn handle_dashboard_chat_key(app: &mut App, key: crossterm::event::KeyEvent) -> 
                 app.insert_char('\n');
             } else {
                 let input = app.take_input();
+                if input.trim() == "/settings" {
+                    return KeyAction::OpenSettings;
+                }
                 if !input.trim().is_empty() {
                     return KeyAction::SendChat(input);
                 }
@@ -1246,7 +1285,7 @@ async fn handle_action(
                 }
             }
         }
-        KeyAction::None | KeyAction::Redraw => {}
+        KeyAction::OpenSettings | KeyAction::None | KeyAction::Redraw => {}
     }
     app.needs_redraw = true;
     None

--- a/crates/apiari/src/ui/settings.rs
+++ b/crates/apiari/src/ui/settings.rs
@@ -18,6 +18,7 @@ pub struct SettingsState {
     pub dirty: bool,
     pub focused_field: usize,
     pub confirm_save: bool,
+    pub save_error: Option<String>,
     // Fields
     pub workspace_name: String,
     pub root: String,
@@ -47,7 +48,7 @@ pub struct SettingsState {
     pub swarm_state_path: String,
 }
 
-const FIELD_COUNT: usize = 17;
+const FIELD_COUNT: usize = 13;
 
 impl SettingsState {
     /// Create settings from current workspace config.
@@ -57,6 +58,7 @@ impl SettingsState {
             dirty: false,
             focused_field: 0,
             confirm_save: false,
+            save_error: None,
             workspace_name: name.to_string(),
             root: config.root.to_string_lossy().to_string(),
             bot_token: config
@@ -131,13 +133,16 @@ impl SettingsState {
 
         if self.confirm_save {
             match key.code {
-                KeyCode::Char('y') => {
-                    if let Err(e) = self.save() {
-                        tracing::error!("failed to save settings: {e}");
+                KeyCode::Char('y') => match self.save() {
+                    Ok(()) => {
+                        self.active = false;
+                        return true;
                     }
-                    self.active = false;
-                    return true;
-                }
+                    Err(e) => {
+                        self.save_error = Some(format!("{e}"));
+                        self.confirm_save = false;
+                    }
+                },
                 KeyCode::Char('n') => {
                     self.active = false;
                     return true;
@@ -218,14 +223,25 @@ impl SettingsState {
 
         // Telegram
         if !self.bot_token.trim().is_empty() && !self.chat_id.trim().is_empty() {
+            let chat_id: i64 = self
+                .chat_id
+                .trim()
+                .parse()
+                .map_err(|_| color_eyre::eyre::eyre!("chat_id must be a number"))?;
+            let topic_id = if self.topic_id.trim().is_empty() {
+                None
+            } else {
+                Some(
+                    self.topic_id
+                        .trim()
+                        .parse::<i64>()
+                        .map_err(|_| color_eyre::eyre::eyre!("topic_id must be a number"))?,
+                )
+            };
             config.telegram = Some(config::TelegramConfig {
                 bot_token: self.bot_token.trim().to_string(),
-                chat_id: self.chat_id.trim().parse().unwrap_or(0),
-                topic_id: if self.topic_id.trim().is_empty() {
-                    None
-                } else {
-                    self.topic_id.trim().parse().ok()
-                },
+                chat_id,
+                topic_id,
                 allowed_user_ids: config
                     .telegram
                     .as_ref()
@@ -240,6 +256,73 @@ impl SettingsState {
         config.coordinator.model = self.coordinator_model.trim().to_string();
         if let Ok(turns) = self.coordinator_max_turns.trim().parse() {
             config.coordinator.max_turns = turns;
+        }
+
+        // GitHub
+        if !self.github_repos.trim().is_empty() {
+            let repos: Vec<String> = self
+                .github_repos
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            let existing = config
+                .watchers
+                .github
+                .take()
+                .unwrap_or(config::GithubWatcherConfig {
+                    repos: vec![],
+                    interval_secs: 120,
+                    review_queue: vec![],
+                });
+            config.watchers.github = Some(config::GithubWatcherConfig { repos, ..existing });
+        } else {
+            config.watchers.github = None;
+        }
+
+        // Sentry
+        if !self.sentry_org.trim().is_empty()
+            && !self.sentry_project.trim().is_empty()
+            && !self.sentry_token.trim().is_empty()
+        {
+            let existing = config.watchers.sentry.take();
+            config.watchers.sentry = Some(config::SentryWatcherConfig {
+                org: self.sentry_org.trim().to_string(),
+                project: self.sentry_project.trim().to_string(),
+                token: self.sentry_token.trim().to_string(),
+                interval_secs: existing.map(|s| s.interval_secs).unwrap_or(120),
+            });
+        } else {
+            config.watchers.sentry = None;
+        }
+
+        // Linear
+        if !self.linear_api_key.trim().is_empty() {
+            let existing = config.watchers.linear.first().cloned();
+            config.watchers.linear = vec![config::LinearWatcherConfig {
+                name: self.linear_name.trim().to_string(),
+                api_key: self.linear_api_key.trim().to_string(),
+                poll_interval_secs: existing.map(|l| l.poll_interval_secs).unwrap_or(60),
+                review_queue: config
+                    .watchers
+                    .linear
+                    .first()
+                    .map(|l| l.review_queue.clone())
+                    .unwrap_or_default(),
+            }];
+        } else {
+            config.watchers.linear = vec![];
+        }
+
+        // Swarm
+        if !self.swarm_state_path.trim().is_empty() {
+            let existing = config.watchers.swarm.take();
+            config.watchers.swarm = Some(config::SwarmWatcherConfig {
+                state_path: self.swarm_state_path.trim().into(),
+                interval_secs: existing.map(|s| s.interval_secs).unwrap_or(15),
+            });
+        } else {
+            config.watchers.swarm = None;
         }
 
         // Serialize with toml
@@ -309,12 +392,21 @@ pub fn draw_settings(frame: &mut Frame, state: &SettingsState, area: Rect) {
     // Hint at bottom
     let hint_idx = fields.len() + 2;
     if hint_idx < chunks.len() {
-        let hint = Paragraph::new(Line::from(Span::styled(
-            "[Tab/\u{2191}\u{2193}] navigate  [Esc] close  Changes save on exit",
-            theme::key_desc(),
-        )))
-        .alignment(Alignment::Center);
-        frame.render_widget(hint, chunks[hint_idx]);
+        if let Some(ref err) = state.save_error {
+            let hint = Paragraph::new(Line::from(Span::styled(
+                format!("Save failed: {err}"),
+                theme::error(),
+            )))
+            .alignment(Alignment::Center);
+            frame.render_widget(hint, chunks[hint_idx]);
+        } else {
+            let hint = Paragraph::new(Line::from(Span::styled(
+                "[Tab/\u{2191}\u{2193}] navigate  [Esc] close  Changes save on exit",
+                theme::key_desc(),
+            )))
+            .alignment(Alignment::Center);
+            frame.render_widget(hint, chunks[hint_idx]);
+        }
     }
 
     // Save confirmation overlay

--- a/crates/apiari/src/ui/settings.rs
+++ b/crates/apiari/src/ui/settings.rs
@@ -1,0 +1,374 @@
+//! In-TUI settings screen — editable workspace config form.
+//!
+//! Accessible via `/settings` chat command or `s` key when not typing.
+
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::prelude::*;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use super::theme;
+use crate::config::{self, WorkspaceConfig};
+
+// ── Settings state ───────────────────────────────────────
+
+/// Editable settings fields extracted from WorkspaceConfig.
+pub struct SettingsState {
+    pub active: bool,
+    pub dirty: bool,
+    pub focused_field: usize,
+    pub confirm_save: bool,
+    // Fields
+    pub workspace_name: String,
+    pub root: String,
+    pub bot_token: String,
+    pub chat_id: String,
+    pub topic_id: String,
+    pub coordinator_model: String,
+    pub coordinator_max_turns: String,
+    // GitHub
+    #[allow(dead_code)]
+    pub github_enabled: bool,
+    pub github_repos: String,
+    // Sentry
+    #[allow(dead_code)]
+    pub sentry_enabled: bool,
+    pub sentry_org: String,
+    pub sentry_project: String,
+    pub sentry_token: String,
+    // Linear
+    #[allow(dead_code)]
+    pub linear_enabled: bool,
+    pub linear_name: String,
+    pub linear_api_key: String,
+    // Swarm
+    #[allow(dead_code)]
+    pub swarm_enabled: bool,
+    pub swarm_state_path: String,
+}
+
+const FIELD_COUNT: usize = 17;
+
+impl SettingsState {
+    /// Create settings from current workspace config.
+    pub fn from_workspace(name: &str, config: &WorkspaceConfig) -> Self {
+        Self {
+            active: true,
+            dirty: false,
+            focused_field: 0,
+            confirm_save: false,
+            workspace_name: name.to_string(),
+            root: config.root.to_string_lossy().to_string(),
+            bot_token: config
+                .telegram
+                .as_ref()
+                .map(|t| t.bot_token.clone())
+                .unwrap_or_default(),
+            chat_id: config
+                .telegram
+                .as_ref()
+                .map(|t| t.chat_id.to_string())
+                .unwrap_or_default(),
+            topic_id: config
+                .telegram
+                .as_ref()
+                .and_then(|t| t.topic_id.map(|id| id.to_string()))
+                .unwrap_or_default(),
+            coordinator_model: config.coordinator.model.clone(),
+            coordinator_max_turns: config.coordinator.max_turns.to_string(),
+            github_enabled: config.watchers.github.is_some(),
+            github_repos: config
+                .watchers
+                .github
+                .as_ref()
+                .map(|g| g.repos.join(", "))
+                .unwrap_or_default(),
+            sentry_enabled: config.watchers.sentry.is_some(),
+            sentry_org: config
+                .watchers
+                .sentry
+                .as_ref()
+                .map(|s| s.org.clone())
+                .unwrap_or_default(),
+            sentry_project: config
+                .watchers
+                .sentry
+                .as_ref()
+                .map(|s| s.project.clone())
+                .unwrap_or_default(),
+            sentry_token: config
+                .watchers
+                .sentry
+                .as_ref()
+                .map(|s| s.token.clone())
+                .unwrap_or_default(),
+            linear_enabled: !config.watchers.linear.is_empty(),
+            linear_name: config
+                .watchers
+                .linear
+                .first()
+                .map(|l| l.name.clone())
+                .unwrap_or_default(),
+            linear_api_key: config
+                .watchers
+                .linear
+                .first()
+                .map(|l| l.api_key.clone())
+                .unwrap_or_default(),
+            swarm_enabled: config.watchers.swarm.is_some(),
+            swarm_state_path: config
+                .watchers
+                .swarm
+                .as_ref()
+                .map(|s| s.state_path.to_string_lossy().to_string())
+                .unwrap_or_default(),
+        }
+    }
+
+    /// Handle a key event. Returns true if the settings screen should close.
+    pub fn handle_key(&mut self, key: crossterm::event::KeyEvent) -> bool {
+        use crossterm::event::KeyCode;
+
+        if self.confirm_save {
+            match key.code {
+                KeyCode::Char('y') => {
+                    if let Err(e) = self.save() {
+                        tracing::error!("failed to save settings: {e}");
+                    }
+                    self.active = false;
+                    return true;
+                }
+                KeyCode::Char('n') => {
+                    self.active = false;
+                    return true;
+                }
+                KeyCode::Esc => {
+                    self.confirm_save = false;
+                }
+                _ => {}
+            }
+            return false;
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                if self.dirty {
+                    self.confirm_save = true;
+                } else {
+                    self.active = false;
+                    return true;
+                }
+            }
+            KeyCode::Tab | KeyCode::Down => {
+                self.focused_field = (self.focused_field + 1) % FIELD_COUNT;
+            }
+            KeyCode::BackTab | KeyCode::Up => {
+                self.focused_field = if self.focused_field == 0 {
+                    FIELD_COUNT - 1
+                } else {
+                    self.focused_field - 1
+                };
+            }
+            KeyCode::Backspace => {
+                let field = self.current_field_mut();
+                field.pop();
+                self.dirty = true;
+            }
+            KeyCode::Char(c) => {
+                let field = self.current_field_mut();
+                field.push(c);
+                self.dirty = true;
+            }
+            _ => {}
+        }
+        false
+    }
+
+    fn current_field_mut(&mut self) -> &mut String {
+        match self.focused_field {
+            0 => &mut self.root,
+            1 => &mut self.bot_token,
+            2 => &mut self.chat_id,
+            3 => &mut self.topic_id,
+            4 => &mut self.coordinator_model,
+            5 => &mut self.coordinator_max_turns,
+            6 => &mut self.github_repos,
+            7 => &mut self.sentry_org,
+            8 => &mut self.sentry_project,
+            9 => &mut self.sentry_token,
+            10 => &mut self.linear_name,
+            11 => &mut self.linear_api_key,
+            12 => &mut self.swarm_state_path,
+            _ => &mut self.root, // fallback
+        }
+    }
+
+    /// Save settings back to TOML.
+    fn save(&self) -> color_eyre::Result<()> {
+        let config_path = config::workspaces_dir().join(format!("{}.toml", self.workspace_name));
+        if !config_path.exists() {
+            return Ok(());
+        }
+
+        // Read existing config, update fields, write back
+        let contents = std::fs::read_to_string(&config_path)?;
+        let mut config: WorkspaceConfig = toml::from_str(&contents)?;
+
+        config.root = self.root.trim().into();
+
+        // Telegram
+        if !self.bot_token.trim().is_empty() && !self.chat_id.trim().is_empty() {
+            config.telegram = Some(config::TelegramConfig {
+                bot_token: self.bot_token.trim().to_string(),
+                chat_id: self.chat_id.trim().parse().unwrap_or(0),
+                topic_id: if self.topic_id.trim().is_empty() {
+                    None
+                } else {
+                    self.topic_id.trim().parse().ok()
+                },
+                allowed_user_ids: config
+                    .telegram
+                    .as_ref()
+                    .map(|t| t.allowed_user_ids.clone())
+                    .unwrap_or_default(),
+            });
+        } else {
+            config.telegram = None;
+        }
+
+        // Coordinator
+        config.coordinator.model = self.coordinator_model.trim().to_string();
+        if let Ok(turns) = self.coordinator_max_turns.trim().parse() {
+            config.coordinator.max_turns = turns;
+        }
+
+        // Serialize with toml
+        let toml_str = toml::to_string_pretty(&config)?;
+        std::fs::write(&config_path, toml_str)?;
+
+        Ok(())
+    }
+}
+
+// ── Rendering ────────────────────────────────────────────
+
+/// Draw the settings screen as a full-screen overlay.
+pub fn draw_settings(frame: &mut Frame, state: &SettingsState, area: Rect) {
+    // Center with max width
+    let max_w = 70u16.min(area.width.saturating_sub(4));
+    let h_pad = (area.width.saturating_sub(max_w)) / 2;
+    let content_area = Rect::new(area.x + h_pad, area.y, max_w, area.height);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::border_active())
+        .title(Span::styled(
+            format!(" Settings \u{2014} {} ", state.workspace_name),
+            theme::title(),
+        ));
+
+    let inner = block.inner(content_area);
+    frame.render_widget(ratatui::widgets::Clear, content_area);
+    frame.render_widget(block, content_area);
+
+    // Layout fields
+    let fields: Vec<(&str, &str, usize)> = vec![
+        ("Root directory", &state.root, 0),
+        ("Telegram: bot_token", &state.bot_token, 1),
+        ("Telegram: chat_id", &state.chat_id, 2),
+        ("Telegram: topic_id", &state.topic_id, 3),
+        ("Coordinator: model", &state.coordinator_model, 4),
+        ("Coordinator: max_turns", &state.coordinator_max_turns, 5),
+        ("GitHub: repos", &state.github_repos, 6),
+        ("Sentry: org", &state.sentry_org, 7),
+        ("Sentry: project", &state.sentry_project, 8),
+        ("Sentry: token", &state.sentry_token, 9),
+        ("Linear: name", &state.linear_name, 10),
+        ("Linear: api_key", &state.linear_api_key, 11),
+        ("Swarm: state_path", &state.swarm_state_path, 12),
+    ];
+
+    let mut constraints: Vec<Constraint> = vec![Constraint::Length(1)]; // top pad
+    for _ in &fields {
+        constraints.push(Constraint::Length(3));
+    }
+    constraints.push(Constraint::Length(1)); // spacing
+    constraints.push(Constraint::Length(1)); // hint
+    constraints.push(Constraint::Min(0));
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(inner);
+
+    for (i, (label, value, field_idx)) in fields.iter().enumerate() {
+        let focused = state.focused_field == *field_idx;
+        draw_settings_field(frame, chunks[i + 1], label, value, focused);
+    }
+
+    // Hint at bottom
+    let hint_idx = fields.len() + 2;
+    if hint_idx < chunks.len() {
+        let hint = Paragraph::new(Line::from(Span::styled(
+            "[Tab/\u{2191}\u{2193}] navigate  [Esc] close  Changes save on exit",
+            theme::key_desc(),
+        )))
+        .alignment(Alignment::Center);
+        frame.render_widget(hint, chunks[hint_idx]);
+    }
+
+    // Save confirmation overlay
+    if state.confirm_save {
+        let overlay_w = 40u16.min(area.width);
+        let overlay_h = 5;
+        let ox = area.x + (area.width.saturating_sub(overlay_w)) / 2;
+        let oy = area.y + (area.height.saturating_sub(overlay_h)) / 2;
+        let overlay = Rect::new(ox, oy, overlay_w, overlay_h);
+
+        frame.render_widget(ratatui::widgets::Clear, overlay);
+        let confirm_block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme::border_active())
+            .title(Span::styled(" Unsaved changes ", theme::accent()));
+        let confirm_inner = confirm_block.inner(overlay);
+        frame.render_widget(confirm_block, overlay);
+
+        let confirm_text = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "Save changes? [y]es  [n]o  [Esc] cancel",
+                theme::text(),
+            )),
+        ])
+        .alignment(Alignment::Center);
+        frame.render_widget(confirm_text, confirm_inner);
+    }
+}
+
+fn draw_settings_field(frame: &mut Frame, area: Rect, label: &str, value: &str, focused: bool) {
+    let border_style = if focused {
+        theme::border_active()
+    } else {
+        theme::border()
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style)
+        .title(Span::styled(
+            format!(" {label} "),
+            if focused {
+                theme::accent()
+            } else {
+                theme::muted()
+            },
+        ));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let cursor = if focused { "\u{2588}" } else { "" };
+    let display = format!("{value}{cursor}");
+    let content = Paragraph::new(Line::from(Span::styled(display, theme::text())));
+    frame.render_widget(content, inner);
+}

--- a/crates/apiari/src/ui/wizard.rs
+++ b/crates/apiari/src/ui/wizard.rs
@@ -16,6 +16,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 use std::io::stdout;
 use std::path::PathBuf;
+use std::time::Instant;
 
 use super::theme;
 use crate::config;
@@ -89,6 +90,7 @@ struct WizardState {
     telegram_field: usize, // 0 = token, 1 = chat_id, 2 = topic_id
     token_status: TokenStatus,
     token_status_msg: String,
+    last_token_change: Option<Instant>,
     // Integrations
     integrations: Vec<Integration>,
     integration_selection: usize,
@@ -101,13 +103,14 @@ struct WizardState {
 }
 
 impl WizardState {
-    fn new() -> Self {
+    fn new(initial_name: Option<&str>) -> Self {
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let name = cwd
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("workspace")
-            .to_string();
+        let name = initial_name.map(|s| s.to_string()).unwrap_or_else(|| {
+            cwd.file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("workspace")
+                .to_string()
+        });
         let root = cwd.to_string_lossy().to_string();
 
         // Detect available tools
@@ -138,6 +141,7 @@ impl WizardState {
             telegram_field: 0,
             token_status: TokenStatus::Empty,
             token_status_msg: String::new(),
+            last_token_change: None,
             integrations: vec![
                 Integration {
                     name: "GitHub",
@@ -187,7 +191,8 @@ pub struct WizardResult {
 }
 
 /// Run the onboarding wizard TUI. Returns the workspace name if config was created.
-pub async fn run_wizard() -> Result<WizardResult> {
+/// `initial_name` is an optional override for the workspace name (from `--name` flag).
+pub async fn run_wizard(initial_name: Option<&str>) -> Result<WizardResult> {
     stdout().execute(EnterAlternateScreen)?;
     stdout().execute(crossterm::event::EnableMouseCapture)?;
     enable_raw_mode()?;
@@ -203,7 +208,7 @@ pub async fn run_wizard() -> Result<WizardResult> {
         original_hook(info);
     }));
 
-    let result = wizard_loop(&mut terminal).await;
+    let result = wizard_loop(&mut terminal, initial_name).await;
 
     disable_raw_mode()?;
     stdout().execute(crossterm::event::DisableMouseCapture)?;
@@ -214,9 +219,12 @@ pub async fn run_wizard() -> Result<WizardResult> {
 
 async fn wizard_loop(
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    initial_name: Option<&str>,
 ) -> Result<WizardResult> {
-    let mut state = WizardState::new();
+    let mut state = WizardState::new(initial_name);
     let mut events = EventStream::new();
+    let mut debounce_interval = tokio::time::interval(std::time::Duration::from_millis(200));
+    debounce_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         if state.needs_redraw {
@@ -244,12 +252,23 @@ async fn wizard_loop(
             maybe_event = events.next() => {
                 match maybe_event {
                     Some(Ok(Event::Key(key))) => {
-                        handle_wizard_key(&mut state, key).await;
+                        handle_wizard_key(&mut state, key);
                     }
                     Some(Ok(Event::Resize(_, _))) => {
                         state.needs_redraw = true;
                     }
                     _ => {}
+                }
+            }
+            _ = debounce_interval.tick() => {
+                // Check if we need to fire a debounced token validation
+                if let Some(changed_at) = state.last_token_change
+                    && changed_at.elapsed() >= std::time::Duration::from_millis(500)
+                    && state.token_status == TokenStatus::Validating
+                {
+                    state.last_token_change = None;
+                    validate_bot_token(&mut state).await;
+                    state.needs_redraw = true;
                 }
             }
         }
@@ -258,17 +277,7 @@ async fn wizard_loop(
 
 // ── Key handling ─────────────────────────────────────────
 
-async fn handle_wizard_key(state: &mut WizardState, key: crossterm::event::KeyEvent) {
-    // Global: q to quit (when not editing text)
-    if key.code == KeyCode::Char('q')
-        && !is_text_input_active(state)
-        && state.step != WizardStep::Done
-    {
-        state.quit = true;
-        state.needs_redraw = true;
-        return;
-    }
-
+fn handle_wizard_key(state: &mut WizardState, key: crossterm::event::KeyEvent) {
     // Ctrl+C always quits
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
         state.quit = true;
@@ -278,21 +287,12 @@ async fn handle_wizard_key(state: &mut WizardState, key: crossterm::event::KeyEv
 
     match state.step {
         WizardStep::Welcome => handle_welcome_key(state, key),
-        WizardStep::Telegram => handle_telegram_key(state, key).await,
+        WizardStep::Telegram => handle_telegram_key(state, key),
         WizardStep::Integrations => handle_integrations_key(state, key),
         WizardStep::Done => handle_done_key(state, key),
     }
 
     state.needs_redraw = true;
-}
-
-fn is_text_input_active(state: &WizardState) -> bool {
-    match state.step {
-        WizardStep::Welcome => true, // fields always editable
-        WizardStep::Telegram => true,
-        WizardStep::Integrations => state.integration_editing,
-        WizardStep::Done => false,
-    }
 }
 
 fn handle_welcome_key(state: &mut WizardState, key: crossterm::event::KeyEvent) {
@@ -302,6 +302,9 @@ fn handle_welcome_key(state: &mut WizardState, key: crossterm::event::KeyEvent) 
         }
         KeyCode::BackTab | KeyCode::Up => {
             state.welcome_field = if state.welcome_field == 0 { 1 } else { 0 };
+        }
+        KeyCode::Esc => {
+            state.quit = true;
         }
         KeyCode::Enter | KeyCode::Right => {
             if !state.workspace_name.trim().is_empty() {
@@ -327,7 +330,7 @@ fn current_welcome_field(state: &mut WizardState) -> &mut String {
     }
 }
 
-async fn handle_telegram_key(state: &mut WizardState, key: crossterm::event::KeyEvent) {
+fn handle_telegram_key(state: &mut WizardState, key: crossterm::event::KeyEvent) {
     match key.code {
         KeyCode::Tab | KeyCode::Down => {
             state.telegram_field = (state.telegram_field + 1) % 3;
@@ -360,9 +363,11 @@ async fn handle_telegram_key(state: &mut WizardState, key: crossterm::event::Key
         KeyCode::Char(c) => {
             let field = current_telegram_field(state);
             field.push(c);
-            // Trigger validation after bot_token changes
+            // Debounce token validation: mark pending, actual call fires after 500ms idle
             if state.telegram_field == 0 && state.bot_token.len() > 10 {
-                validate_bot_token(state).await;
+                state.token_status = TokenStatus::Validating;
+                state.token_status_msg = "validating...".into();
+                state.last_token_change = Some(Instant::now());
             }
         }
         _ => {}
@@ -382,20 +387,32 @@ async fn validate_bot_token(state: &mut WizardState) {
     state.token_status = TokenStatus::Validating;
     state.token_status_msg = "validating...".into();
 
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            state.token_status = TokenStatus::Invalid;
+            state.token_status_msg = format!("error: {e}");
+            return;
+        }
+    };
+
     let url = format!("https://api.telegram.org/bot{token}/getMe");
-    match reqwest::get(&url).await {
+    match client.get(&url).send().await {
         Ok(resp) if resp.status().is_success() => {
-            if let Ok(body) = resp.json::<serde_json::Value>().await {
-                if body.get("ok").and_then(|v| v.as_bool()) == Some(true) {
-                    let bot_name = body
-                        .get("result")
-                        .and_then(|r| r.get("username"))
-                        .and_then(|u| u.as_str())
-                        .unwrap_or("bot");
-                    state.token_status = TokenStatus::Valid;
-                    state.token_status_msg = format!("@{bot_name}");
-                    return;
-                }
+            if let Ok(body) = resp.json::<serde_json::Value>().await
+                && body.get("ok").and_then(|v| v.as_bool()) == Some(true)
+            {
+                let bot_name = body
+                    .get("result")
+                    .and_then(|r| r.get("username"))
+                    .and_then(|u| u.as_str())
+                    .unwrap_or("bot");
+                state.token_status = TokenStatus::Valid;
+                state.token_status_msg = format!("@{bot_name}");
+                return;
             }
             state.token_status = TokenStatus::Invalid;
             state.token_status_msg = "invalid response".into();
@@ -517,10 +534,35 @@ fn handle_done_key(state: &mut WizardState, key: crossterm::event::KeyEvent) {
     }
 }
 
+// ── Validation helpers ───────────────────────────────────
+
+/// Sanitize workspace name: reject path separators and dots-only names.
+fn sanitize_workspace_name(name: &str) -> Option<&str> {
+    let name = name.trim();
+    if name.is_empty() {
+        return None;
+    }
+    if name.contains('/') || name.contains('\\') || name.contains('\0') {
+        return None;
+    }
+    // Reject names that are only dots (e.g. ".", "..")
+    if name.chars().all(|c| c == '.') {
+        return None;
+    }
+    Some(name)
+}
+
 // ── Config writing ───────────────────────────────────────
 
 fn write_workspace_config(state: &WizardState) -> Result<String> {
-    let name = state.workspace_name.trim();
+    let name = match sanitize_workspace_name(&state.workspace_name) {
+        Some(n) => n,
+        None => {
+            return Err(color_eyre::eyre::eyre!(
+                "Invalid workspace name: must not contain path separators"
+            ));
+        }
+    };
     let root = state.root_dir.trim();
 
     let dir = config::workspaces_dir();
@@ -528,66 +570,74 @@ fn write_workspace_config(state: &WizardState) -> Result<String> {
 
     let config_path = dir.join(format!("{name}.toml"));
 
-    let mut toml = String::new();
-    toml.push_str(&format!("root = \"{root}\"\n"));
-    toml.push_str("repos = []  # empty = auto-discover from workspace root\n\n");
+    // Build a WorkspaceConfig struct and serialize with toml
+    let telegram = if !state.bot_token.trim().is_empty() && !state.chat_id.trim().is_empty() {
+        let chat_id: i64 = state
+            .chat_id
+            .trim()
+            .parse()
+            .map_err(|_| color_eyre::eyre::eyre!("chat_id must be a number"))?;
+        let topic_id = if state.topic_id.trim().is_empty() {
+            None
+        } else {
+            Some(
+                state
+                    .topic_id
+                    .trim()
+                    .parse::<i64>()
+                    .map_err(|_| color_eyre::eyre::eyre!("topic_id must be a number"))?,
+            )
+        };
+        Some(config::TelegramConfig {
+            bot_token: state.bot_token.trim().to_string(),
+            chat_id,
+            topic_id,
+            allowed_user_ids: vec![],
+        })
+    } else {
+        None
+    };
 
-    // Telegram
-    if !state.bot_token.trim().is_empty() && !state.chat_id.trim().is_empty() {
-        toml.push_str("[telegram]\n");
-        toml.push_str(&format!("bot_token = \"{}\"\n", state.bot_token.trim()));
-        toml.push_str(&format!("chat_id = {}\n", state.chat_id.trim()));
-        if !state.topic_id.trim().is_empty() {
-            toml.push_str(&format!("topic_id = {}\n", state.topic_id.trim()));
-        }
-        toml.push('\n');
-    }
-
-    // Coordinator defaults
-    let coordinator_name = "Bee";
-    let default_prompt = crate::buzz::coordinator::prompt::default_preamble(coordinator_name);
-    toml.push_str("[coordinator]\n");
-    toml.push_str("model = \"sonnet\"\n");
-    toml.push_str("max_turns = 20\n");
-    toml.push_str(&format!("prompt = \"\"\"\n{default_prompt}\"\"\"\n\n"));
-
-    // Integrations
+    // Build watchers from integrations
+    let mut watchers = config::WatchersConfig::default();
     for int in &state.integrations {
         if !int.enabled {
             continue;
         }
         match int.name {
             "GitHub" => {
-                toml.push_str("[watchers.github]\n");
-                toml.push_str("repos = []  # auto-discover from workspace root\n");
-                toml.push_str("interval_secs = 120\n\n");
+                watchers.github = Some(config::GithubWatcherConfig {
+                    repos: vec![],
+                    interval_secs: 120,
+                    review_queue: vec![],
+                });
             }
             "Sentry" => {
                 let org = int
                     .fields
                     .iter()
                     .find(|f| f.0 == "org")
-                    .map(|f| f.1.as_str())
-                    .unwrap_or("");
+                    .map(|f| f.1.trim().to_string())
+                    .unwrap_or_default();
                 let project = int
                     .fields
                     .iter()
                     .find(|f| f.0 == "project")
-                    .map(|f| f.1.as_str())
-                    .unwrap_or("");
+                    .map(|f| f.1.trim().to_string())
+                    .unwrap_or_default();
                 let token = int
                     .fields
                     .iter()
                     .find(|f| f.0 == "token")
-                    .map(|f| f.1.as_str())
-                    .unwrap_or("");
-                if !org.trim().is_empty() && !project.trim().is_empty() && !token.trim().is_empty()
-                {
-                    toml.push_str("[watchers.sentry]\n");
-                    toml.push_str(&format!("org = \"{}\"\n", org.trim()));
-                    toml.push_str(&format!("project = \"{}\"\n", project.trim()));
-                    toml.push_str(&format!("token = \"{}\"\n", token.trim()));
-                    toml.push_str("interval_secs = 120\n\n");
+                    .map(|f| f.1.trim().to_string())
+                    .unwrap_or_default();
+                if !org.is_empty() && !project.is_empty() && !token.is_empty() {
+                    watchers.sentry = Some(config::SentryWatcherConfig {
+                        org,
+                        project,
+                        token,
+                        interval_secs: 120,
+                    });
                 }
             }
             "Linear" => {
@@ -595,32 +645,61 @@ fn write_workspace_config(state: &WizardState) -> Result<String> {
                     .fields
                     .iter()
                     .find(|f| f.0 == "api_key")
-                    .map(|f| f.1.as_str())
-                    .unwrap_or("");
+                    .map(|f| f.1.trim().to_string())
+                    .unwrap_or_default();
                 let lname = int
                     .fields
                     .iter()
                     .find(|f| f.0 == "name")
-                    .map(|f| f.1.as_str())
-                    .unwrap_or("");
-                if !api_key.trim().is_empty() {
-                    toml.push_str("[[watchers.linear]]\n");
-                    toml.push_str(&format!("name = \"{}\"\n", lname.trim()));
-                    toml.push_str(&format!("api_key = \"{}\"\n", api_key.trim()));
-                    toml.push_str("poll_interval_secs = 60\n\n");
+                    .map(|f| f.1.trim().to_string())
+                    .unwrap_or_default();
+                if !api_key.is_empty() {
+                    watchers.linear = vec![config::LinearWatcherConfig {
+                        name: lname,
+                        api_key,
+                        poll_interval_secs: 60,
+                        review_queue: vec![],
+                    }];
                 }
             }
             "Swarm" => {
                 let state_path = format!("{root}/.swarm/state.json");
-                toml.push_str("[watchers.swarm]\n");
-                toml.push_str(&format!("state_path = \"{state_path}\"\n"));
-                toml.push_str("interval_secs = 15\n\n");
+                watchers.swarm = Some(config::SwarmWatcherConfig {
+                    state_path: state_path.into(),
+                    interval_secs: 15,
+                });
             }
             _ => {}
         }
     }
 
-    std::fs::write(&config_path, &toml)?;
+    let coordinator_name = "Bee";
+    let default_prompt = crate::buzz::coordinator::prompt::default_preamble(coordinator_name);
+
+    let ws_config = config::WorkspaceConfig {
+        root: root.into(),
+        repos: vec![],
+        telegram,
+        coordinator: config::CoordinatorConfig {
+            name: coordinator_name.to_string(),
+            model: "sonnet".to_string(),
+            max_turns: 20,
+            prompt: Some(default_prompt),
+            max_session_turns: 50,
+        },
+        watchers,
+        pipeline: config::PipelineConfig::default(),
+        commands: vec![],
+        morning_brief: None,
+        daemon_tcp_port: None,
+        daemon_tcp_bind: None,
+        daemon_host: None,
+        daemon_port: None,
+        daemon_endpoints: vec![],
+    };
+
+    let toml_str = toml::to_string_pretty(&ws_config)?;
+    std::fs::write(&config_path, toml_str)?;
     Ok(name.to_string())
 }
 
@@ -681,7 +760,7 @@ fn draw_wizard_header(frame: &mut Frame, state: &WizardState, area: Rect) {
 
 fn draw_wizard_footer(frame: &mut Frame, state: &WizardState, area: Rect) {
     let hints = match state.step {
-        WizardStep::Welcome => "[Tab] next field  [Enter/\u{2192}] continue  [q] quit",
+        WizardStep::Welcome => "[Tab] next field  [Enter/\u{2192}] continue  [Esc] quit",
         WizardStep::Telegram => {
             "[Tab] next field  [Enter/\u{2192}] continue  [\u{2190}/Esc] back  [^S] skip"
         }
@@ -738,12 +817,20 @@ fn draw_welcome(frame: &mut Frame, state: &WizardState, area: Rect) {
     frame.render_widget(desc, chunks[1]);
 
     // Workspace name field
-    draw_text_field(
+    let name_valid = sanitize_workspace_name(&state.workspace_name).is_some();
+    let name_suffix = if !name_valid && !state.workspace_name.trim().is_empty() {
+        " \u{2717} invalid name"
+    } else {
+        ""
+    };
+    draw_text_field_with_suffix(
         frame,
         chunks[3],
         "Workspace name",
         &state.workspace_name,
         state.welcome_field == 0,
+        name_suffix,
+        theme::error(),
     );
 
     // Root directory field
@@ -828,20 +915,40 @@ fn draw_telegram(frame: &mut Frame, state: &WizardState, area: Rect) {
         token_style,
     );
 
-    draw_text_field(
+    // Chat ID with inline validation
+    let chat_id_valid =
+        state.chat_id.trim().is_empty() || state.chat_id.trim().parse::<i64>().is_ok();
+    let chat_suffix = if !chat_id_valid {
+        " \u{2717} must be a number"
+    } else {
+        ""
+    };
+    draw_text_field_with_suffix(
         frame,
         chunks[7],
         "Chat ID",
         &state.chat_id,
         state.telegram_field == 1,
+        chat_suffix,
+        theme::error(),
     );
 
-    draw_text_field(
+    // Topic ID with inline validation
+    let topic_id_valid =
+        state.topic_id.trim().is_empty() || state.topic_id.trim().parse::<i64>().is_ok();
+    let topic_suffix = if !topic_id_valid {
+        " \u{2717} must be a number"
+    } else {
+        ""
+    };
+    draw_text_field_with_suffix(
         frame,
         chunks[9],
         "Topic ID (optional)",
         &state.topic_id,
         state.telegram_field == 2,
+        topic_suffix,
+        theme::error(),
     );
 }
 

--- a/crates/apiari/src/ui/wizard.rs
+++ b/crates/apiari/src/ui/wizard.rs
@@ -1,0 +1,1073 @@
+//! TUI onboarding wizard — runs when no workspace config exists.
+//!
+//! Four-screen flow: Welcome → Telegram → Integrations → Done.
+
+use color_eyre::Result;
+use crossterm::ExecutableCommand;
+use crossterm::event::{Event, EventStream, KeyCode, KeyModifiers};
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use futures::StreamExt;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::prelude::*;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use std::io::stdout;
+use std::path::PathBuf;
+
+use super::theme;
+use crate::config;
+
+// ── Wizard state ─────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WizardStep {
+    Welcome,
+    Telegram,
+    Integrations,
+    Done,
+}
+
+impl WizardStep {
+    fn index(&self) -> usize {
+        match self {
+            Self::Welcome => 1,
+            Self::Telegram => 2,
+            Self::Integrations => 3,
+            Self::Done => 4,
+        }
+    }
+
+    fn next(&self) -> Self {
+        match self {
+            Self::Welcome => Self::Telegram,
+            Self::Telegram => Self::Integrations,
+            Self::Integrations => Self::Done,
+            Self::Done => Self::Done,
+        }
+    }
+
+    fn prev(&self) -> Self {
+        match self {
+            Self::Welcome => Self::Welcome,
+            Self::Telegram => Self::Welcome,
+            Self::Integrations => Self::Telegram,
+            Self::Done => Self::Integrations,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TokenStatus {
+    Empty,
+    Validating,
+    Valid,
+    Invalid,
+}
+
+#[derive(Debug, Clone)]
+struct Integration {
+    name: &'static str,
+    description: &'static str,
+    enabled: bool,
+    /// Fields: (label, value)
+    fields: Vec<(&'static str, String)>,
+}
+
+struct WizardState {
+    step: WizardStep,
+    // Welcome
+    workspace_name: String,
+    root_dir: String,
+    welcome_field: usize, // 0 = name, 1 = root
+    // Telegram
+    bot_token: String,
+    chat_id: String,
+    topic_id: String,
+    telegram_field: usize, // 0 = token, 1 = chat_id, 2 = topic_id
+    token_status: TokenStatus,
+    token_status_msg: String,
+    // Integrations
+    integrations: Vec<Integration>,
+    integration_selection: usize,
+    integration_field: usize,  // which sub-field is focused
+    integration_editing: bool, // editing a sub-field
+    // Common
+    needs_redraw: bool,
+    quit: bool,
+    launch_ui: bool,
+}
+
+impl WizardState {
+    fn new() -> Self {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let name = cwd
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("workspace")
+            .to_string();
+        let root = cwd.to_string_lossy().to_string();
+
+        // Detect available tools
+        let gh_available = std::process::Command::new("gh")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        let swarm_available = std::process::Command::new("which")
+            .arg("swarm")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        Self {
+            step: WizardStep::Welcome,
+            workspace_name: name,
+            root_dir: root,
+            welcome_field: 0,
+            bot_token: String::new(),
+            chat_id: String::new(),
+            topic_id: String::new(),
+            telegram_field: 0,
+            token_status: TokenStatus::Empty,
+            token_status_msg: String::new(),
+            integrations: vec![
+                Integration {
+                    name: "GitHub",
+                    description: "PR reviews, CI notifications",
+                    enabled: gh_available,
+                    fields: vec![],
+                },
+                Integration {
+                    name: "Sentry",
+                    description: "Error monitoring",
+                    enabled: false,
+                    fields: vec![
+                        ("org", String::new()),
+                        ("project", String::new()),
+                        ("token", String::new()),
+                    ],
+                },
+                Integration {
+                    name: "Linear",
+                    description: "Issues & assignments",
+                    enabled: false,
+                    fields: vec![("api_key", String::new()), ("name", String::new())],
+                },
+                Integration {
+                    name: "Swarm",
+                    description: "AI coding agents",
+                    enabled: swarm_available,
+                    fields: vec![],
+                },
+            ],
+            integration_selection: 0,
+            integration_field: 0,
+            integration_editing: false,
+            needs_redraw: true,
+            quit: false,
+            launch_ui: false,
+        }
+    }
+}
+
+// ── Public entry point ───────────────────────────────────
+
+/// Result of the wizard: the name of the created workspace config, or None if quit.
+pub struct WizardResult {
+    pub workspace_name: Option<String>,
+    pub launch_ui: bool,
+}
+
+/// Run the onboarding wizard TUI. Returns the workspace name if config was created.
+pub async fn run_wizard() -> Result<WizardResult> {
+    stdout().execute(EnterAlternateScreen)?;
+    stdout().execute(crossterm::event::EnableMouseCapture)?;
+    enable_raw_mode()?;
+
+    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+    terminal.clear()?;
+
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = stdout().execute(crossterm::event::DisableMouseCapture);
+        let _ = stdout().execute(LeaveAlternateScreen);
+        original_hook(info);
+    }));
+
+    let result = wizard_loop(&mut terminal).await;
+
+    disable_raw_mode()?;
+    stdout().execute(crossterm::event::DisableMouseCapture)?;
+    stdout().execute(LeaveAlternateScreen)?;
+
+    result
+}
+
+async fn wizard_loop(
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+) -> Result<WizardResult> {
+    let mut state = WizardState::new();
+    let mut events = EventStream::new();
+
+    loop {
+        if state.needs_redraw {
+            terminal.draw(|f| draw_wizard(f, &state))?;
+            state.needs_redraw = false;
+        }
+
+        if state.quit {
+            return Ok(WizardResult {
+                workspace_name: None,
+                launch_ui: false,
+            });
+        }
+
+        if state.launch_ui {
+            // Write config and return
+            let name = write_workspace_config(&state)?;
+            return Ok(WizardResult {
+                workspace_name: Some(name),
+                launch_ui: true,
+            });
+        }
+
+        tokio::select! {
+            maybe_event = events.next() => {
+                match maybe_event {
+                    Some(Ok(Event::Key(key))) => {
+                        handle_wizard_key(&mut state, key).await;
+                    }
+                    Some(Ok(Event::Resize(_, _))) => {
+                        state.needs_redraw = true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+// ── Key handling ─────────────────────────────────────────
+
+async fn handle_wizard_key(state: &mut WizardState, key: crossterm::event::KeyEvent) {
+    // Global: q to quit (when not editing text)
+    if key.code == KeyCode::Char('q')
+        && !is_text_input_active(state)
+        && state.step != WizardStep::Done
+    {
+        state.quit = true;
+        state.needs_redraw = true;
+        return;
+    }
+
+    // Ctrl+C always quits
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        state.quit = true;
+        state.needs_redraw = true;
+        return;
+    }
+
+    match state.step {
+        WizardStep::Welcome => handle_welcome_key(state, key),
+        WizardStep::Telegram => handle_telegram_key(state, key).await,
+        WizardStep::Integrations => handle_integrations_key(state, key),
+        WizardStep::Done => handle_done_key(state, key),
+    }
+
+    state.needs_redraw = true;
+}
+
+fn is_text_input_active(state: &WizardState) -> bool {
+    match state.step {
+        WizardStep::Welcome => true, // fields always editable
+        WizardStep::Telegram => true,
+        WizardStep::Integrations => state.integration_editing,
+        WizardStep::Done => false,
+    }
+}
+
+fn handle_welcome_key(state: &mut WizardState, key: crossterm::event::KeyEvent) {
+    match key.code {
+        KeyCode::Tab | KeyCode::Down => {
+            state.welcome_field = (state.welcome_field + 1) % 2;
+        }
+        KeyCode::BackTab | KeyCode::Up => {
+            state.welcome_field = if state.welcome_field == 0 { 1 } else { 0 };
+        }
+        KeyCode::Enter | KeyCode::Right => {
+            if !state.workspace_name.trim().is_empty() {
+                state.step = state.step.next();
+            }
+        }
+        KeyCode::Backspace => {
+            let field = current_welcome_field(state);
+            field.pop();
+        }
+        KeyCode::Char(c) => {
+            let field = current_welcome_field(state);
+            field.push(c);
+        }
+        _ => {}
+    }
+}
+
+fn current_welcome_field(state: &mut WizardState) -> &mut String {
+    match state.welcome_field {
+        0 => &mut state.workspace_name,
+        _ => &mut state.root_dir,
+    }
+}
+
+async fn handle_telegram_key(state: &mut WizardState, key: crossterm::event::KeyEvent) {
+    match key.code {
+        KeyCode::Tab | KeyCode::Down => {
+            state.telegram_field = (state.telegram_field + 1) % 3;
+        }
+        KeyCode::BackTab | KeyCode::Up => {
+            state.telegram_field = if state.telegram_field == 0 {
+                2
+            } else {
+                state.telegram_field - 1
+            };
+        }
+        KeyCode::Enter | KeyCode::Right => {
+            state.step = state.step.next();
+        }
+        KeyCode::Left | KeyCode::Esc => {
+            state.step = state.step.prev();
+        }
+        KeyCode::Backspace => {
+            let field = current_telegram_field(state);
+            field.pop();
+            if state.telegram_field == 0 {
+                state.token_status = TokenStatus::Empty;
+                state.token_status_msg.clear();
+            }
+        }
+        KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            // Skip telegram
+            state.step = state.step.next();
+        }
+        KeyCode::Char(c) => {
+            let field = current_telegram_field(state);
+            field.push(c);
+            // Trigger validation after bot_token changes
+            if state.telegram_field == 0 && state.bot_token.len() > 10 {
+                validate_bot_token(state).await;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn current_telegram_field(state: &mut WizardState) -> &mut String {
+    match state.telegram_field {
+        0 => &mut state.bot_token,
+        1 => &mut state.chat_id,
+        _ => &mut state.topic_id,
+    }
+}
+
+async fn validate_bot_token(state: &mut WizardState) {
+    let token = state.bot_token.clone();
+    state.token_status = TokenStatus::Validating;
+    state.token_status_msg = "validating...".into();
+
+    let url = format!("https://api.telegram.org/bot{token}/getMe");
+    match reqwest::get(&url).await {
+        Ok(resp) if resp.status().is_success() => {
+            if let Ok(body) = resp.json::<serde_json::Value>().await {
+                if body.get("ok").and_then(|v| v.as_bool()) == Some(true) {
+                    let bot_name = body
+                        .get("result")
+                        .and_then(|r| r.get("username"))
+                        .and_then(|u| u.as_str())
+                        .unwrap_or("bot");
+                    state.token_status = TokenStatus::Valid;
+                    state.token_status_msg = format!("@{bot_name}");
+                    return;
+                }
+            }
+            state.token_status = TokenStatus::Invalid;
+            state.token_status_msg = "invalid response".into();
+        }
+        Ok(resp) => {
+            state.token_status = TokenStatus::Invalid;
+            state.token_status_msg = format!("HTTP {}", resp.status());
+        }
+        Err(e) => {
+            state.token_status = TokenStatus::Invalid;
+            state.token_status_msg = format!("error: {e}");
+        }
+    }
+}
+
+fn handle_integrations_key(state: &mut WizardState, key: crossterm::event::KeyEvent) {
+    let int_count = state.integrations.len();
+
+    // If editing a sub-field, handle text input
+    if state.integration_editing {
+        match key.code {
+            KeyCode::Esc => {
+                state.integration_editing = false;
+            }
+            KeyCode::Tab | KeyCode::Down => {
+                let fields_len = state.integrations[state.integration_selection].fields.len();
+                if fields_len > 0 {
+                    state.integration_field = (state.integration_field + 1) % fields_len;
+                }
+            }
+            KeyCode::BackTab | KeyCode::Up => {
+                let fields_len = state.integrations[state.integration_selection].fields.len();
+                if fields_len > 0 {
+                    state.integration_field = if state.integration_field == 0 {
+                        fields_len - 1
+                    } else {
+                        state.integration_field - 1
+                    };
+                }
+            }
+            KeyCode::Enter => {
+                state.integration_editing = false;
+            }
+            KeyCode::Backspace => {
+                let sel = state.integration_selection;
+                let fi = state.integration_field;
+                if fi < state.integrations[sel].fields.len() {
+                    state.integrations[sel].fields[fi].1.pop();
+                }
+            }
+            KeyCode::Char(c) => {
+                let sel = state.integration_selection;
+                let fi = state.integration_field;
+                if fi < state.integrations[sel].fields.len() {
+                    state.integrations[sel].fields[fi].1.push(c);
+                }
+            }
+            _ => {}
+        }
+        return;
+    }
+
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            if int_count > 0 {
+                state.integration_selection = (state.integration_selection + 1) % int_count;
+            }
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            if int_count > 0 {
+                state.integration_selection = if state.integration_selection == 0 {
+                    int_count - 1
+                } else {
+                    state.integration_selection - 1
+                };
+            }
+        }
+        KeyCode::Char(' ') => {
+            let sel = state.integration_selection;
+            state.integrations[sel].enabled = !state.integrations[sel].enabled;
+            // If enabling and has fields, enter editing mode
+            if state.integrations[sel].enabled && !state.integrations[sel].fields.is_empty() {
+                state.integration_editing = true;
+                state.integration_field = 0;
+            }
+        }
+        KeyCode::Enter | KeyCode::Right => {
+            // If current integration is enabled and has fields, edit them
+            let sel = state.integration_selection;
+            if state.integrations[sel].enabled && !state.integrations[sel].fields.is_empty() {
+                state.integration_editing = true;
+                state.integration_field = 0;
+            } else {
+                state.step = state.step.next();
+            }
+        }
+        KeyCode::Tab => {
+            state.step = state.step.next();
+        }
+        KeyCode::Left | KeyCode::Esc => {
+            state.step = state.step.prev();
+        }
+        _ => {}
+    }
+}
+
+fn handle_done_key(state: &mut WizardState, key: crossterm::event::KeyEvent) {
+    match key.code {
+        KeyCode::Enter => {
+            state.launch_ui = true;
+        }
+        KeyCode::Left | KeyCode::Esc => {
+            state.step = state.step.prev();
+        }
+        KeyCode::Char('q') => {
+            state.quit = true;
+        }
+        _ => {}
+    }
+}
+
+// ── Config writing ───────────────────────────────────────
+
+fn write_workspace_config(state: &WizardState) -> Result<String> {
+    let name = state.workspace_name.trim();
+    let root = state.root_dir.trim();
+
+    let dir = config::workspaces_dir();
+    std::fs::create_dir_all(&dir)?;
+
+    let config_path = dir.join(format!("{name}.toml"));
+
+    let mut toml = String::new();
+    toml.push_str(&format!("root = \"{root}\"\n"));
+    toml.push_str("repos = []  # empty = auto-discover from workspace root\n\n");
+
+    // Telegram
+    if !state.bot_token.trim().is_empty() && !state.chat_id.trim().is_empty() {
+        toml.push_str("[telegram]\n");
+        toml.push_str(&format!("bot_token = \"{}\"\n", state.bot_token.trim()));
+        toml.push_str(&format!("chat_id = {}\n", state.chat_id.trim()));
+        if !state.topic_id.trim().is_empty() {
+            toml.push_str(&format!("topic_id = {}\n", state.topic_id.trim()));
+        }
+        toml.push('\n');
+    }
+
+    // Coordinator defaults
+    let coordinator_name = "Bee";
+    let default_prompt = crate::buzz::coordinator::prompt::default_preamble(coordinator_name);
+    toml.push_str("[coordinator]\n");
+    toml.push_str("model = \"sonnet\"\n");
+    toml.push_str("max_turns = 20\n");
+    toml.push_str(&format!("prompt = \"\"\"\n{default_prompt}\"\"\"\n\n"));
+
+    // Integrations
+    for int in &state.integrations {
+        if !int.enabled {
+            continue;
+        }
+        match int.name {
+            "GitHub" => {
+                toml.push_str("[watchers.github]\n");
+                toml.push_str("repos = []  # auto-discover from workspace root\n");
+                toml.push_str("interval_secs = 120\n\n");
+            }
+            "Sentry" => {
+                let org = int
+                    .fields
+                    .iter()
+                    .find(|f| f.0 == "org")
+                    .map(|f| f.1.as_str())
+                    .unwrap_or("");
+                let project = int
+                    .fields
+                    .iter()
+                    .find(|f| f.0 == "project")
+                    .map(|f| f.1.as_str())
+                    .unwrap_or("");
+                let token = int
+                    .fields
+                    .iter()
+                    .find(|f| f.0 == "token")
+                    .map(|f| f.1.as_str())
+                    .unwrap_or("");
+                if !org.trim().is_empty() && !project.trim().is_empty() && !token.trim().is_empty()
+                {
+                    toml.push_str("[watchers.sentry]\n");
+                    toml.push_str(&format!("org = \"{}\"\n", org.trim()));
+                    toml.push_str(&format!("project = \"{}\"\n", project.trim()));
+                    toml.push_str(&format!("token = \"{}\"\n", token.trim()));
+                    toml.push_str("interval_secs = 120\n\n");
+                }
+            }
+            "Linear" => {
+                let api_key = int
+                    .fields
+                    .iter()
+                    .find(|f| f.0 == "api_key")
+                    .map(|f| f.1.as_str())
+                    .unwrap_or("");
+                let lname = int
+                    .fields
+                    .iter()
+                    .find(|f| f.0 == "name")
+                    .map(|f| f.1.as_str())
+                    .unwrap_or("");
+                if !api_key.trim().is_empty() {
+                    toml.push_str("[[watchers.linear]]\n");
+                    toml.push_str(&format!("name = \"{}\"\n", lname.trim()));
+                    toml.push_str(&format!("api_key = \"{}\"\n", api_key.trim()));
+                    toml.push_str("poll_interval_secs = 60\n\n");
+                }
+            }
+            "Swarm" => {
+                let state_path = format!("{root}/.swarm/state.json");
+                toml.push_str("[watchers.swarm]\n");
+                toml.push_str(&format!("state_path = \"{state_path}\"\n"));
+                toml.push_str("interval_secs = 15\n\n");
+            }
+            _ => {}
+        }
+    }
+
+    std::fs::write(&config_path, &toml)?;
+    Ok(name.to_string())
+}
+
+// ── Rendering ────────────────────────────────────────────
+
+fn draw_wizard(frame: &mut Frame, state: &WizardState) {
+    let size = frame.area();
+
+    // Center content with max width ~70
+    let max_w = 70u16.min(size.width.saturating_sub(4));
+    let h_pad = (size.width.saturating_sub(max_w)) / 2;
+    let content_area = Rect::new(h_pad, 0, max_w, size.height);
+
+    // Vertical: header(3) + body(rest) + footer(2)
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(1),
+            Constraint::Length(2),
+        ])
+        .split(content_area);
+
+    draw_wizard_header(frame, state, layout[0]);
+
+    match state.step {
+        WizardStep::Welcome => draw_welcome(frame, state, layout[1]),
+        WizardStep::Telegram => draw_telegram(frame, state, layout[1]),
+        WizardStep::Integrations => draw_integrations(frame, state, layout[1]),
+        WizardStep::Done => draw_done(frame, state, layout[1]),
+    }
+
+    draw_wizard_footer(frame, state, layout[2]);
+}
+
+fn draw_wizard_header(frame: &mut Frame, state: &WizardState, area: Rect) {
+    let step = state.step.index();
+    let mut spans = vec![
+        Span::styled(" * ", theme::logo()),
+        Span::styled("apiari ", theme::title()),
+        Span::styled("setup", theme::muted()),
+    ];
+
+    // Right-aligned step indicator
+    let indicator = format!("[{step}/4]");
+    let used: usize = spans.iter().map(|s| s.content.len()).sum();
+    let padding = (area.width as usize)
+        .saturating_sub(used)
+        .saturating_sub(indicator.len());
+    if padding > 0 {
+        spans.push(Span::raw(" ".repeat(padding)));
+    }
+    spans.push(Span::styled(indicator, theme::accent()));
+
+    let header = Paragraph::new(Line::from(spans)).style(Style::default().bg(theme::COMB));
+    frame.render_widget(header, Rect::new(area.x, area.y, area.width, 1));
+}
+
+fn draw_wizard_footer(frame: &mut Frame, state: &WizardState, area: Rect) {
+    let hints = match state.step {
+        WizardStep::Welcome => "[Tab] next field  [Enter/\u{2192}] continue  [q] quit",
+        WizardStep::Telegram => {
+            "[Tab] next field  [Enter/\u{2192}] continue  [\u{2190}/Esc] back  [^S] skip"
+        }
+        WizardStep::Integrations => {
+            if state.integration_editing {
+                "[Tab] next field  [Enter/Esc] done editing  [\u{2190}] back"
+            } else {
+                "[j/k] select  [Space] toggle  [Tab/Enter] continue  [\u{2190}/Esc] back"
+            }
+        }
+        WizardStep::Done => "[Enter] launch dashboard  [\u{2190}/Esc] back  [q] quit",
+    };
+
+    let footer = Paragraph::new(Line::from(Span::styled(hints, theme::key_desc())))
+        .alignment(Alignment::Center);
+    frame.render_widget(footer, Rect::new(area.x, area.y + 1, area.width, 1));
+}
+
+// ── Step 1: Welcome ──────────────────────────────────────
+
+fn draw_welcome(frame: &mut Frame, state: &WizardState, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // top pad
+            Constraint::Length(5), // description
+            Constraint::Length(2), // spacing
+            Constraint::Length(3), // workspace name field
+            Constraint::Length(1), // spacing
+            Constraint::Length(3), // root dir field
+            Constraint::Min(0),    // fill
+        ])
+        .split(area);
+
+    // Description
+    let desc = Paragraph::new(vec![
+        Line::from(Span::styled(
+            "Welcome to Apiari",
+            Style::default()
+                .fg(theme::HONEY)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Apiari is your AI ops coordinator. It watches your repos,",
+            theme::text(),
+        )),
+        Line::from(Span::styled(
+            "routes signals, and manages coding agents from one dashboard.",
+            theme::text(),
+        )),
+    ])
+    .alignment(Alignment::Center);
+    frame.render_widget(desc, chunks[1]);
+
+    // Workspace name field
+    draw_text_field(
+        frame,
+        chunks[3],
+        "Workspace name",
+        &state.workspace_name,
+        state.welcome_field == 0,
+    );
+
+    // Root directory field
+    draw_text_field(
+        frame,
+        chunks[5],
+        "Root directory",
+        &state.root_dir,
+        state.welcome_field == 1,
+    );
+}
+
+// ── Step 2: Telegram ─────────────────────────────────────
+
+fn draw_telegram(frame: &mut Frame, state: &WizardState, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // top pad
+            Constraint::Length(3), // title + desc
+            Constraint::Length(1), // spacing
+            Constraint::Length(5), // instructions
+            Constraint::Length(1), // spacing
+            Constraint::Length(3), // bot_token
+            Constraint::Length(1), // spacing
+            Constraint::Length(3), // chat_id
+            Constraint::Length(1), // spacing
+            Constraint::Length(3), // topic_id
+            Constraint::Min(0),    // fill
+        ])
+        .split(area);
+
+    let desc = Paragraph::new(vec![
+        Line::from(Span::styled("Telegram", theme::title())),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Bee sends notifications and responds to your messages via Telegram.",
+            theme::text(),
+        )),
+    ]);
+    frame.render_widget(desc, chunks[1]);
+
+    let instructions = Paragraph::new(vec![
+        Line::from(Span::styled(
+            "  1. Message @BotFather on Telegram \u{2192} /newbot",
+            theme::muted(),
+        )),
+        Line::from(Span::styled(
+            "  2. Copy the bot token below",
+            theme::muted(),
+        )),
+        Line::from(Span::styled(
+            "  3. Get your chat ID from @userinfobot",
+            theme::muted(),
+        )),
+        Line::from(Span::styled(
+            "  (optional \u{2014} press ^S to skip Telegram setup)",
+            theme::muted(),
+        )),
+    ]);
+    frame.render_widget(instructions, chunks[3]);
+
+    // Token field with validation indicator
+    let token_suffix = match state.token_status {
+        TokenStatus::Empty => String::new(),
+        TokenStatus::Validating => " \u{2026}".into(),
+        TokenStatus::Valid => format!(" \u{2713} {}", state.token_status_msg),
+        TokenStatus::Invalid => format!(" \u{2717} {}", state.token_status_msg),
+    };
+    let token_style = match state.token_status {
+        TokenStatus::Valid => theme::success(),
+        TokenStatus::Invalid => theme::error(),
+        _ => theme::muted(),
+    };
+    draw_text_field_with_suffix(
+        frame,
+        chunks[5],
+        "Bot token",
+        &state.bot_token,
+        state.telegram_field == 0,
+        &token_suffix,
+        token_style,
+    );
+
+    draw_text_field(
+        frame,
+        chunks[7],
+        "Chat ID",
+        &state.chat_id,
+        state.telegram_field == 1,
+    );
+
+    draw_text_field(
+        frame,
+        chunks[9],
+        "Topic ID (optional)",
+        &state.topic_id,
+        state.telegram_field == 2,
+    );
+}
+
+// ── Step 3: Integrations ─────────────────────────────────
+
+fn draw_integrations(frame: &mut Frame, state: &WizardState, area: Rect) {
+    let mut constraints = vec![
+        Constraint::Length(1), // top pad
+        Constraint::Length(2), // title
+        Constraint::Length(1), // spacing
+    ];
+    // Each integration: 2 lines (checkbox + desc) + sub-fields if enabled
+    for int in &state.integrations {
+        constraints.push(Constraint::Length(2)); // checkbox line
+        if int.enabled && !int.fields.is_empty() {
+            for _ in &int.fields {
+                constraints.push(Constraint::Length(3)); // each sub-field
+            }
+            constraints.push(Constraint::Length(1)); // spacing after fields
+        }
+    }
+    constraints.push(Constraint::Min(0));
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(area);
+
+    let title = Paragraph::new(vec![
+        Line::from(Span::styled("Integrations", theme::title())),
+        Line::from(Span::styled(
+            "Select which services to connect:",
+            theme::text(),
+        )),
+    ]);
+    frame.render_widget(title, chunks[1]);
+
+    let mut chunk_idx = 3; // start after title + spacing
+    for (i, int) in state.integrations.iter().enumerate() {
+        let selected = i == state.integration_selection && !state.integration_editing;
+        let check = if int.enabled { "\u{2713}" } else { " " };
+        let marker = if selected { "\u{25b6} " } else { "  " };
+
+        let style = if selected {
+            theme::highlight()
+        } else if int.enabled {
+            theme::text()
+        } else {
+            theme::muted()
+        };
+
+        let line = Paragraph::new(vec![Line::from(vec![
+            Span::styled(marker, style),
+            Span::styled(format!("[{check}] "), style),
+            Span::styled(
+                int.name,
+                if int.enabled {
+                    Style::default()
+                        .fg(theme::HONEY)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    style
+                },
+            ),
+            Span::styled(format!(" \u{2014} {}", int.description), theme::muted()),
+        ])]);
+        if chunk_idx < chunks.len() {
+            frame.render_widget(line, chunks[chunk_idx]);
+        }
+        chunk_idx += 1;
+
+        // Sub-fields if enabled
+        if int.enabled && !int.fields.is_empty() {
+            for (fi, (label, value)) in int.fields.iter().enumerate() {
+                let focused = state.integration_editing
+                    && i == state.integration_selection
+                    && fi == state.integration_field;
+                if chunk_idx < chunks.len() {
+                    draw_text_field(
+                        frame,
+                        chunks[chunk_idx],
+                        &format!("    {label}"),
+                        value,
+                        focused,
+                    );
+                }
+                chunk_idx += 1;
+            }
+            chunk_idx += 1; // spacing
+        }
+    }
+}
+
+// ── Step 4: Done ─────────────────────────────────────────
+
+fn draw_done(frame: &mut Frame, state: &WizardState, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2),  // top pad
+            Constraint::Length(2),  // title
+            Constraint::Length(1),  // spacing
+            Constraint::Length(12), // summary
+            Constraint::Length(2),  // spacing
+            Constraint::Length(3),  // launch button
+            Constraint::Min(0),     // fill
+        ])
+        .split(area);
+
+    let title = Paragraph::new(vec![
+        Line::from(Span::styled("Setup complete!", theme::title())),
+        Line::from(""),
+    ])
+    .alignment(Alignment::Center);
+    frame.render_widget(title, chunks[1]);
+
+    // Summary
+    let mut summary_lines = vec![
+        Line::from(vec![
+            Span::styled("  \u{2713} ", theme::success()),
+            Span::styled("Workspace: ", theme::muted()),
+            Span::styled(&state.workspace_name, theme::text()),
+        ]),
+        Line::from(vec![
+            Span::styled("  \u{2713} ", theme::success()),
+            Span::styled("Root: ", theme::muted()),
+            Span::styled(&state.root_dir, theme::text()),
+        ]),
+    ];
+
+    if !state.bot_token.trim().is_empty() {
+        let status_icon = match state.token_status {
+            TokenStatus::Valid => ("\u{2713} ", theme::success()),
+            _ => ("~ ", theme::muted()),
+        };
+        summary_lines.push(Line::from(vec![
+            Span::styled(format!("  {} ", status_icon.0), status_icon.1),
+            Span::styled("Telegram: ", theme::muted()),
+            Span::styled("configured", theme::text()),
+        ]));
+    } else {
+        summary_lines.push(Line::from(vec![
+            Span::styled("  - ", theme::muted()),
+            Span::styled("Telegram: ", theme::muted()),
+            Span::styled("skipped", theme::muted()),
+        ]));
+    }
+
+    for int in &state.integrations {
+        let (icon, style) = if int.enabled {
+            ("\u{2713} ", theme::success())
+        } else {
+            ("- ", theme::muted())
+        };
+        summary_lines.push(Line::from(vec![
+            Span::styled(format!("  {icon}"), style),
+            Span::styled(format!("{}: ", int.name), theme::muted()),
+            Span::styled(
+                if int.enabled { "enabled" } else { "disabled" },
+                if int.enabled {
+                    theme::text()
+                } else {
+                    theme::muted()
+                },
+            ),
+        ]));
+    }
+
+    let summary = Paragraph::new(summary_lines);
+    frame.render_widget(summary, chunks[3]);
+
+    // Launch button
+    let button = Paragraph::new(Line::from(vec![Span::styled(
+        "  [ Launch Dashboard ]  ",
+        Style::default()
+            .fg(theme::COMB)
+            .bg(theme::HONEY)
+            .add_modifier(Modifier::BOLD),
+    )]))
+    .alignment(Alignment::Center);
+    frame.render_widget(button, chunks[5]);
+}
+
+// ── Field widgets ────────────────────────────────────────
+
+fn draw_text_field(frame: &mut Frame, area: Rect, label: &str, value: &str, focused: bool) {
+    draw_text_field_with_suffix(frame, area, label, value, focused, "", theme::muted());
+}
+
+fn draw_text_field_with_suffix(
+    frame: &mut Frame,
+    area: Rect,
+    label: &str,
+    value: &str,
+    focused: bool,
+    suffix: &str,
+    suffix_style: Style,
+) {
+    let border_style = if focused {
+        theme::border_active()
+    } else {
+        theme::border()
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style)
+        .title(Span::styled(
+            format!(" {label} "),
+            if focused {
+                theme::accent()
+            } else {
+                theme::muted()
+            },
+        ));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let cursor = if focused { "\u{2588}" } else { "" };
+    let display = format!("{value}{cursor}");
+    let mut spans = vec![Span::styled(display, theme::text())];
+    if !suffix.is_empty() {
+        spans.push(Span::styled(suffix, suffix_style));
+    }
+
+    let content = Paragraph::new(Line::from(spans));
+    frame.render_widget(content, inner);
+}


### PR DESCRIPTION
## Summary
- Adds a 4-screen TUI onboarding wizard that runs when `apiari ui` has no workspace config or when `apiari init` is run in a TTY
- Wizard collects workspace name, Telegram config (with live bot token validation), and integration selections (GitHub, Sentry, Linear, Swarm)
- Writes the workspace TOML config and can immediately launch the dashboard
- Adds an in-TUI settings screen accessible via `s` key or `/settings` chat command

## Wizard Flow
1. **Welcome** — workspace name (from cwd), root directory
2. **Telegram** — bot_token (live validated via Telegram API), chat_id, topic_id; skip with ^S
3. **Integrations** — checklist with inline sub-fields (Sentry org/project/token, Linear api_key/name); GitHub/Swarm auto-detected
4. **Done** — summary with ✓ marks, "Launch Dashboard" button

## Settings Screen
- Full-screen overlay showing editable workspace config fields
- Tab/arrow navigation between fields
- Save confirmation on exit if changes detected

## Test plan
- [x] `cargo build -p apiari` — clean build, no warnings
- [x] `cargo test -p apiari` — 324 tests pass
- [x] `cargo fmt -p apiari` — formatted
- [ ] Manual: run `apiari init` in a new directory with TTY
- [ ] Manual: run `apiari ui` with no workspace configs
- [ ] Manual: press `s` in dashboard to open settings
- [ ] Manual: type `/settings` in chat to open settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)