### PR TITLE
feat: redesign heartbeat panel with grouped signals

### DIFF
--- a/crates/hive/src/daemon/mod.rs
+++ b/crates/hive/src/daemon/mod.rs
@@ -2488,6 +2488,8 @@ impl DaemonRunner {
     ///
     /// Iterates all workspaces. For each: if it has a buzz_slot, polls inline
     /// watchers; otherwise reads new signals from the JSONL file.
+    ///
+    /// Also builds heartbeat entries grouped by source and pushes them to the TUI.
     async fn poll_buzz(&mut self) -> Result<()> {
         // Collect (ws_idx, signal, topic) tuples across all workspaces.
         struct TaggedSignal {
@@ -2554,26 +2556,48 @@ impl DaemonRunner {
             }
         }
 
+        if tagged.is_empty() {
+            return Ok(());
+        }
+
+        // Build heartbeat entries grouped by source.
+        let mut heartbeat_entries =
+            build_heartbeat_entries(&tagged.iter().map(|t| &t.signal).collect::<Vec<_>>());
+
         // Filter for important signals.
         let important: Vec<&TaggedSignal> = tagged
             .iter()
             .filter(|t| matches!(t.signal.severity, Severity::Critical | Severity::Warning))
             .collect();
 
-        if important.is_empty() {
-            return Ok(());
+        if !important.is_empty() {
+            tracing::info!(count = important.len(), "New buzz signals to triage");
+
+            for t in &important {
+                self.active_workspace = Some(t.ws_idx);
+                let alert_chat_id = self.active_ws().config.telegram.alert_chat_id;
+                let assessment = self.triage_signal(&t.signal).await;
+                let alert = format_triage_alert(&t.signal, &assessment);
+                self.send(alert_chat_id, &alert).await?;
+
+                // Store bee's response in the matching heartbeat entry.
+                let source = capitalize_source(&t.signal.source);
+                for entry in &mut heartbeat_entries {
+                    if entry.source == source && entry.bee_response.is_none() {
+                        entry.bee_response = Some(assessment.clone());
+                        break;
+                    }
+                }
+            }
+            self.active_workspace = None;
         }
 
-        tracing::info!(count = important.len(), "New buzz signals to triage");
-
-        for t in important {
-            self.active_workspace = Some(t.ws_idx);
-            let alert_chat_id = self.active_ws().config.telegram.alert_chat_id;
-            let assessment = self.triage_signal(&t.signal).await;
-            let alert = format_triage_alert(&t.signal, &assessment);
-            self.send(alert_chat_id, &alert).await?;
+        // Push heartbeat entries to TUI.
+        if let Some(ref socket) = self.tui_socket {
+            socket.push_response(TuiResponse::HeartbeatUpdate {
+                entries: heartbeat_entries,
+            });
         }
-        self.active_workspace = None;
 
         Ok(())
     }
@@ -4088,6 +4112,101 @@ fn format_triage_alert(signal: &Signal, assessment: &str) -> String {
     }
 
     alert
+}
+
+/// Capitalize a watcher source name for display (e.g. "github" → "GitHub").
+fn capitalize_source(source: &str) -> String {
+    match source.to_lowercase().as_str() {
+        "github" => "GitHub".to_string(),
+        "sentry" => "Sentry".to_string(),
+        "linear" => "Linear".to_string(),
+        "webhook" => "Webhook".to_string(),
+        "reminder" => "Reminder".to_string(),
+        "swarm" => "Swarm".to_string(),
+        _ => {
+            let mut s = source.to_string();
+            if let Some(first) = s.get_mut(0..1) {
+                first.make_ascii_uppercase();
+            }
+            s
+        }
+    }
+}
+
+/// Build heartbeat entries by grouping signals by source for this poll cycle.
+fn build_heartbeat_entries(signals: &[&Signal]) -> Vec<tui_socket::HeartbeatEntry> {
+    use std::collections::BTreeMap;
+
+    // Group signals by source.
+    let mut by_source: BTreeMap<String, Vec<&Signal>> = BTreeMap::new();
+    for signal in signals {
+        let source = capitalize_source(&signal.source);
+        by_source.entry(source).or_default().push(signal);
+    }
+
+    let now = chrono::Local::now();
+    let ts = now.format("%-H:%M").to_string();
+
+    by_source
+        .into_iter()
+        .map(|(source, sigs)| {
+            let summary = build_signal_summary(&sigs);
+            let heartbeat_signals = sigs
+                .iter()
+                .map(|s| tui_socket::HeartbeatSignal {
+                    source: s.source.clone(),
+                    title: s.title.clone(),
+                })
+                .collect();
+
+            tui_socket::HeartbeatEntry {
+                poll_cycle_id: uuid::Uuid::new_v4().to_string(),
+                timestamp: ts.clone(),
+                source,
+                summary,
+                event_count: sigs.len(),
+                bee_response: None,
+                signals: heartbeat_signals,
+            }
+        })
+        .collect()
+}
+
+/// Build a human-readable summary from a group of signals.
+///
+/// E.g. "CI failed on apiari", "2 CI passes, 1 merged PR", "PR opened: apiari-1569"
+fn build_signal_summary(signals: &[&Signal]) -> String {
+    if signals.len() == 1 {
+        return signals[0].title.clone();
+    }
+
+    // Count by title prefix patterns for grouping.
+    let mut counts: Vec<(String, usize)> = Vec::new();
+    for sig in signals {
+        let label = &sig.title;
+        if let Some(existing) = counts.iter_mut().find(|(l, _)| l == label) {
+            existing.1 += 1;
+        } else {
+            counts.push((label.clone(), 1));
+        }
+    }
+
+    let parts: Vec<String> = counts
+        .iter()
+        .map(|(label, count)| {
+            if *count == 1 {
+                label.clone()
+            } else {
+                format!("{count} {label}")
+            }
+        })
+        .collect();
+
+    if parts.len() <= 3 {
+        parts.join(", ")
+    } else {
+        format!("{}, +{} more", parts[..2].join(", "), parts.len() - 2)
+    }
 }
 
 /// Split text into chunks of at most `limit` characters, preferring to break at newlines.

--- a/crates/hive/src/daemon/tui_socket.rs
+++ b/crates/hive/src/daemon/tui_socket.rs
@@ -52,6 +52,32 @@ fn default_stage() -> String {
     "pending".into()
 }
 
+/// A single signal within a heartbeat entry (for the expanded view).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeartbeatSignal {
+    pub source: String,
+    pub title: String,
+}
+
+/// A heartbeat entry representing one poll cycle's grouped signals.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeartbeatEntry {
+    /// Unique ID for this poll cycle.
+    pub poll_cycle_id: String,
+    /// Timestamp of the poll cycle.
+    pub timestamp: String,
+    /// Watcher source (e.g. "GitHub", "Swarm", "Sentry").
+    pub source: String,
+    /// Pre-computed grouped summary (e.g. "2 CI passes, 1 merged PR").
+    pub summary: String,
+    /// Number of signals in this cycle.
+    pub event_count: usize,
+    /// Bee's coordinator response, if a signal hook fired.
+    pub bee_response: Option<String>,
+    /// Individual signals for the expanded view.
+    pub signals: Vec<HeartbeatSignal>,
+}
+
 /// Messages from daemon to TUI.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -82,6 +108,8 @@ pub enum TuiResponse {
         user_name: String,
         text: String,
     },
+    /// Heartbeat entries (poll cycle summaries) pushed to TUI.
+    HeartbeatUpdate { entries: Vec<HeartbeatEntry> },
 }
 
 /// A handle to a connected TUI client's write channel.

--- a/crates/hive/src/ui/app.rs
+++ b/crates/hive/src/ui/app.rs
@@ -1,5 +1,6 @@
 //! Application state for the unified hive TUI.
 
+use crate::daemon::tui_socket::HeartbeatEntry;
 use crate::keeper::discovery::{self, SwarmSession, WorktreeInfo};
 use crate::workspace::RegistryEntry;
 use std::cell::Cell;
@@ -84,6 +85,7 @@ pub enum Panel {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SidebarItem {
     Chat,
+    Heartbeat,
     Dispatch,
     Worker(usize), // index into flat_workers()
 }
@@ -191,6 +193,13 @@ pub struct App {
     // PR detail overlay.
     pub pr_detail: Option<PrDetailInfo>,
 
+    // Heartbeat panel state.
+    pub heartbeat_entries: Vec<HeartbeatEntry>,
+    /// Which heartbeat entry is selected (index into heartbeat_entries).
+    pub heartbeat_cursor: usize,
+    /// Which heartbeat entries are expanded (by index).
+    pub heartbeat_expanded: std::collections::HashSet<usize>,
+
     // Periodic refresh
     last_worker_refresh: Instant,
 }
@@ -248,6 +257,9 @@ impl App {
             zoomed: false,
             show_help: false,
             pr_detail: None,
+            heartbeat_entries: Vec::new(),
+            heartbeat_cursor: 0,
+            heartbeat_expanded: std::collections::HashSet::new(),
             last_worker_refresh: Instant::now(),
         }
     }
@@ -384,9 +396,16 @@ impl App {
         self.active_dispatch.is_some()
     }
 
-    /// Total sidebar item count (Chat + optional Dispatch + workers).
+    /// Whether the heartbeat item is showing in the sidebar.
+    fn has_heartbeat(&self) -> bool {
+        !self.heartbeat_entries.is_empty()
+    }
+
+    /// Total sidebar item count (Chat + optional Heartbeat + optional Dispatch + workers).
     fn sidebar_count(&self) -> usize {
-        1 + usize::from(self.has_dispatch()) + self.total_workers()
+        1 + usize::from(self.has_heartbeat())
+            + usize::from(self.has_dispatch())
+            + self.total_workers()
     }
 
     /// Total flat worker count across all sessions.
@@ -395,13 +414,15 @@ impl App {
     }
 
     /// Current sidebar selection as a numeric index.
-    /// Chat=0, Dispatch=1 (when present), Workers=1+has_dispatch+i.
+    /// Chat=0, Heartbeat=1 (when present), Dispatch=next (when present), Workers=rest.
     fn sidebar_index(&self) -> usize {
+        let h = usize::from(self.has_heartbeat());
         let d = usize::from(self.has_dispatch());
         match self.sidebar_selection {
             SidebarItem::Chat => 0,
-            SidebarItem::Dispatch => 1,
-            SidebarItem::Worker(i) => 1 + d + i,
+            SidebarItem::Heartbeat => 1,
+            SidebarItem::Dispatch => 1 + h,
+            SidebarItem::Worker(i) => 1 + h + d + i,
         }
     }
 
@@ -410,11 +431,20 @@ impl App {
         if index == 0 {
             return SidebarItem::Chat;
         }
-        if self.has_dispatch() && index == 1 {
-            return SidebarItem::Dispatch;
+        let mut offset = 1;
+        if self.has_heartbeat() {
+            if index == offset {
+                return SidebarItem::Heartbeat;
+            }
+            offset += 1;
         }
-        let worker_offset = 1 + usize::from(self.has_dispatch());
-        SidebarItem::Worker(index - worker_offset)
+        if self.has_dispatch() {
+            if index == offset {
+                return SidebarItem::Dispatch;
+            }
+            offset += 1;
+        }
+        SidebarItem::Worker(index - offset)
     }
 
     /// Select next sidebar item.
@@ -657,6 +687,11 @@ impl App {
         let total = self.total_workers();
         match self.sidebar_selection {
             SidebarItem::Chat => {} // always valid
+            SidebarItem::Heartbeat => {
+                if !self.has_heartbeat() {
+                    self.sidebar_selection = SidebarItem::Chat;
+                }
+            }
             SidebarItem::Dispatch => {
                 if !self.has_dispatch() {
                     self.sidebar_selection = SidebarItem::Chat;
@@ -883,6 +918,34 @@ impl App {
     pub fn dispatch_prev_section(&mut self) {
         if let Some(ref mut d) = self.active_dispatch {
             d.focused_section = d.focused_section.saturating_sub(1);
+        }
+    }
+
+    /// Whether heartbeat is the active sidebar item.
+    pub fn is_heartbeat_selected(&self) -> bool {
+        self.sidebar_selection == SidebarItem::Heartbeat
+    }
+
+    /// Move heartbeat cursor down.
+    pub fn heartbeat_next(&mut self) {
+        if self.heartbeat_cursor + 1 < self.heartbeat_entries.len() {
+            self.heartbeat_cursor += 1;
+        }
+    }
+
+    /// Move heartbeat cursor up.
+    pub fn heartbeat_prev(&mut self) {
+        self.heartbeat_cursor = self.heartbeat_cursor.saturating_sub(1);
+    }
+
+    /// Toggle expand/collapse of the currently selected heartbeat entry.
+    pub fn heartbeat_toggle(&mut self) {
+        if self.heartbeat_cursor < self.heartbeat_entries.len() {
+            if self.heartbeat_expanded.contains(&self.heartbeat_cursor) {
+                self.heartbeat_expanded.remove(&self.heartbeat_cursor);
+            } else {
+                self.heartbeat_expanded.insert(self.heartbeat_cursor);
+            }
         }
     }
 

--- a/crates/hive/src/ui/mod.rs
+++ b/crates/hive/src/ui/mod.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
-use crate::daemon::tui_socket::{RepoDispatchInfo, TuiResponse};
+use crate::daemon::tui_socket::{HeartbeatEntry, RepoDispatchInfo, TuiResponse};
 use crate::presence;
 use crate::workspace::{self, load_workspace};
 
@@ -66,6 +66,8 @@ enum CoordResponse {
         user_name: String,
         text: String,
     },
+    /// Heartbeat entries from buzz poll cycles.
+    HeartbeatUpdate { entries: Vec<HeartbeatEntry> },
 }
 
 /// Async action results sent back to the event loop.
@@ -285,6 +287,9 @@ async fn daemon_client_task(
                                 user_name,
                                 text,
                             },
+                            TuiResponse::HeartbeatUpdate { entries } => {
+                                CoordResponse::HeartbeatUpdate { entries }
+                            }
                         };
                         if coord_tx.send(coord_msg).await.is_err() {
                             break;
@@ -442,6 +447,16 @@ async fn event_loop(
                         .push(ChatLine::User(format!("{label}: {text}"), app::now_ts()));
                     app.streaming = true;
                     app.chat_scroll = 0;
+                }
+                CoordResponse::HeartbeatUpdate { entries } => {
+                    // Prepend new entries (newest first) and cap at 50.
+                    let mut new_entries = entries;
+                    new_entries.extend(app.heartbeat_entries.drain(..));
+                    new_entries.truncate(50);
+                    app.heartbeat_entries = new_entries;
+                    // Reset expanded state since indices shifted.
+                    app.heartbeat_expanded.clear();
+                    app.heartbeat_cursor = 0;
                 }
             }
         }
@@ -661,7 +676,28 @@ async fn event_loop(
             if !handled {
                 match app.focus {
                     Panel::Chat => {
-                        if app.is_dispatch_selected() {
+                        if app.is_heartbeat_selected() {
+                            // ── Content: Heartbeat panel ──
+                            match key.code {
+                                KeyCode::Char('j') | KeyCode::Down => app.heartbeat_next(),
+                                KeyCode::Char('k') | KeyCode::Up => app.heartbeat_prev(),
+                                KeyCode::Enter => app.heartbeat_toggle(),
+                                KeyCode::Char('z') => {
+                                    app.zoomed = !app.zoomed;
+                                }
+                                KeyCode::Esc => {
+                                    if app.zoomed {
+                                        app.zoomed = false;
+                                    } else {
+                                        app.focus = Panel::Workers;
+                                    }
+                                }
+                                KeyCode::Tab | KeyCode::BackTab | KeyCode::Char('h') => {
+                                    app.focus = Panel::Workers;
+                                }
+                                _ => {}
+                            }
+                        } else if app.is_dispatch_selected() {
                             // ── Content: Dispatch review ──
                             match key.code {
                                 KeyCode::Char('y') => {

--- a/crates/hive/src/ui/mod.rs
+++ b/crates/hive/src/ui/mod.rs
@@ -451,7 +451,7 @@ async fn event_loop(
                 CoordResponse::HeartbeatUpdate { entries } => {
                     // Prepend new entries (newest first) and cap at 50.
                     let mut new_entries = entries;
-                    new_entries.extend(app.heartbeat_entries.drain(..));
+                    new_entries.append(&mut app.heartbeat_entries);
                     new_entries.truncate(50);
                     app.heartbeat_entries = new_entries;
                     // Reset expanded state since indices shifted.

--- a/crates/hive/src/ui/render.rs
+++ b/crates/hive/src/ui/render.rs
@@ -144,11 +144,15 @@ fn draw_sidebar_divider(frame: &mut Frame, area: Rect) {
 
 fn draw_sidebar_list(frame: &mut Frame, area: Rect, app: &App) {
     let workers = app.flat_workers();
+    let has_heartbeat = !app.heartbeat_entries.is_empty();
     let has_dispatch = app.active_dispatch.is_some();
     let viewport = area.height as usize;
 
-    // Build item heights: Chat=2, Dispatch=2 (optional), each Worker=3
+    // Build item heights: Chat=2, Heartbeat=2 (optional), Dispatch=2 (optional), each Worker=3
     let mut heights: Vec<usize> = vec![2]; // Chat item
+    if has_heartbeat {
+        heights.push(2); // Heartbeat item
+    }
     if has_dispatch {
         heights.push(2); // Dispatch item
     }
@@ -168,15 +172,17 @@ fn draw_sidebar_list(frame: &mut Frame, area: Rect, app: &App) {
     let total_height = cumulative;
 
     // Find selected item index in the heights array
+    let heartbeat_offset = usize::from(has_heartbeat);
     let dispatch_offset = usize::from(has_dispatch);
     let selected_item = match app.sidebar_selection {
         SidebarItem::Chat => 0,
-        SidebarItem::Dispatch => 1, // only valid when has_dispatch
+        SidebarItem::Heartbeat => 1, // only valid when has_heartbeat
+        SidebarItem::Dispatch => 1 + heartbeat_offset, // only valid when has_dispatch
         SidebarItem::Worker(i) => {
             if workers.is_empty() {
                 0
             } else {
-                1 + dispatch_offset + i
+                1 + heartbeat_offset + dispatch_offset + i
             }
         }
     };
@@ -223,17 +229,29 @@ fn draw_sidebar_list(frame: &mut Frame, area: Rect, app: &App) {
         };
 
     // Item 0: Chat
-    render_item(0, &mut render_y, &|f, r| draw_chat_sidebar_item(f, r, app));
+    let mut item_idx = 0;
+    render_item(item_idx, &mut render_y, &|f, r| {
+        draw_chat_sidebar_item(f, r, app)
+    });
 
-    // Item 1 (optional): Dispatch
+    // Heartbeat (optional)
+    if has_heartbeat {
+        item_idx += 1;
+        render_item(item_idx, &mut render_y, &|f, r| {
+            draw_heartbeat_sidebar_item(f, r, app)
+        });
+    }
+
+    // Dispatch (optional)
     if has_dispatch {
-        render_item(1, &mut render_y, &|f, r| {
+        item_idx += 1;
+        render_item(item_idx, &mut render_y, &|f, r| {
             draw_dispatch_sidebar_item(f, r, app)
         });
     }
 
     // Workers
-    let worker_start = 1 + dispatch_offset;
+    let worker_start = item_idx + 1;
     if workers.is_empty() {
         // "No workers" placeholder
         if render_y < viewport_bottom {
@@ -243,9 +261,9 @@ fn draw_sidebar_list(frame: &mut Frame, area: Rect, app: &App) {
         }
     } else {
         for (i, (_, wt)) in workers.iter().enumerate() {
-            let item_idx = worker_start + i;
-            let item_top = tops[item_idx];
-            let item_bottom = item_top + heights[item_idx];
+            let idx = worker_start + i;
+            let item_top = tops[idx];
+            let item_bottom = item_top + heights[idx];
 
             if item_bottom <= scroll {
                 continue;
@@ -256,7 +274,7 @@ fn draw_sidebar_list(frame: &mut Frame, area: Rect, app: &App) {
 
             let skip_top = scroll.saturating_sub(item_top);
             let available = (viewport_bottom - render_y) as usize;
-            let render_h = (heights[item_idx] - skip_top).min(available);
+            let render_h = (heights[idx] - skip_top).min(available);
 
             if render_h == 0 {
                 continue;
@@ -322,6 +340,65 @@ fn draw_chat_sidebar_item(frame: &mut Frame, area: Rect, app: &App) {
             Span::styled("    ", Style::default()),
             Span::styled(
                 status_text,
+                Style::default().fg(ratatui::style::Color::Rgb(100, 97, 90)),
+            ),
+        ]);
+        frame.render_widget(
+            Paragraph::new(line2).style(row_style),
+            Rect::new(area.x, area.y + 1, area.width, 1),
+        );
+    }
+}
+
+/// 2-line heartbeat entry in the sidebar.
+fn draw_heartbeat_sidebar_item(frame: &mut Frame, area: Rect, app: &App) {
+    let is_selected = app.sidebar_selection == SidebarItem::Heartbeat;
+
+    let row_style = if is_selected {
+        Style::default().bg(ratatui::style::Color::Rgb(58, 50, 42))
+    } else {
+        Style::default().bg(theme::COMB)
+    };
+    frame.render_widget(Paragraph::new("").style(row_style), area);
+
+    let selector = if is_selected { "\u{25b8}" } else { " " };
+    let text_style = if is_selected {
+        theme::selected()
+    } else {
+        theme::text()
+    };
+
+    // Line 1: " ▸ ♡ Heartbeat"
+    if area.height >= 1 {
+        let has_bee = app
+            .heartbeat_entries
+            .iter()
+            .any(|e| e.bee_response.is_some());
+        let icon = if has_bee {
+            Span::styled("\u{1f41d} ", Style::default())
+        } else {
+            Span::styled("\u{2665} ", theme::accent())
+        };
+        let line1 = Line::from(vec![
+            Span::styled(format!(" {selector}"), text_style),
+            Span::styled(" ", Style::default()),
+            icon,
+            Span::styled("Heartbeat", text_style),
+        ]);
+        frame.render_widget(
+            Paragraph::new(line1).style(row_style),
+            Rect::new(area.x, area.y, area.width, 1),
+        );
+    }
+
+    // Line 2: "     N events"
+    if area.height >= 2 {
+        let count = app.heartbeat_entries.len();
+        let status = format!("{count} entr{}", if count == 1 { "y" } else { "ies" });
+        let line2 = Line::from(vec![
+            Span::styled("    ", Style::default()),
+            Span::styled(
+                status,
                 Style::default().fg(ratatui::style::Color::Rgb(100, 97, 90)),
             ),
         ]);
@@ -618,6 +695,17 @@ fn draw_sidebar_status_bar(frame: &mut Frame, area: Rect, app: &App) {
                 Span::styled(" back", theme::key_desc()),
             ]),
         }
+    } else if app.is_heartbeat_selected() {
+        Line::from(vec![
+            Span::styled(" j", theme::key_hint()),
+            Span::styled("/", theme::key_desc()),
+            Span::styled("k", theme::key_hint()),
+            Span::styled(" nav  ", theme::key_desc()),
+            Span::styled("\u{21b5}", theme::key_hint()),
+            Span::styled(" expand  ", theme::key_desc()),
+            Span::styled("?", theme::key_hint()),
+            Span::styled(" help", theme::key_desc()),
+        ])
     } else if app.is_dispatch_selected() {
         Line::from(vec![
             Span::styled(" j", theme::key_hint()),
@@ -692,6 +780,9 @@ fn draw_content_panel(frame: &mut Frame, area: Rect, app: &App) {
 
             draw_chat_panel(frame, right[0], app);
             draw_input_bar(frame, right[1], app);
+        }
+        SidebarItem::Heartbeat => {
+            draw_heartbeat_panel(frame, area, app);
         }
         SidebarItem::Dispatch => {
             draw_dispatch_review(frame, area, app);
@@ -1637,6 +1728,138 @@ fn cursor_position(text: &str, cursor_byte: usize, width: usize) -> (usize, usiz
         col = 0;
     }
     (row, col)
+}
+
+// ── Heartbeat Panel ──────────────────────────────────────
+
+fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
+    let border_style = if app.focus == Panel::Chat {
+        theme::border_active()
+    } else {
+        theme::border()
+    };
+
+    let hint = " j/k nav  \u{21b5} expand  h sidebar ";
+    let block = Block::default()
+        .title(Span::styled(" Heartbeat ", theme::title()))
+        .title_bottom(Line::from(Span::styled(hint, theme::subtitle())).centered())
+        .borders(Borders::ALL)
+        .border_style(border_style);
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if app.heartbeat_entries.is_empty() {
+        let line = Line::from(Span::styled("  No heartbeat events yet.", theme::muted()));
+        frame.render_widget(Paragraph::new(line), inner);
+        return;
+    }
+
+    // Build lines for all entries (collapsed + expanded).
+    let mut lines: Vec<Line> = Vec::new();
+    let dim_style = Style::default().fg(ratatui::style::Color::Rgb(100, 97, 90));
+
+    for (i, entry) in app.heartbeat_entries.iter().enumerate() {
+        let is_selected = i == app.heartbeat_cursor;
+        let is_expanded = app.heartbeat_expanded.contains(&i);
+        let has_bee = entry.bee_response.is_some();
+
+        // Build the main row.
+        let arrow = if is_expanded {
+            "\u{25bc}" // ▼
+        } else {
+            "\u{25b6}" // ▶
+        };
+
+        let row_style = if is_selected {
+            Style::default()
+                .fg(theme::HONEY)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            theme::text()
+        };
+
+        let bee_indicator = if has_bee { " \u{1f41d}" } else { "" };
+
+        let event_label = format!(
+            " \u{00b7} {} event{}",
+            entry.event_count,
+            if entry.event_count == 1 { "" } else { "s" }
+        );
+
+        // Pad source to 9 chars for alignment.
+        let source_padded = format!("{:<9}", entry.source);
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("{arrow} "), row_style),
+            Span::styled(&entry.timestamp, dim_style),
+            Span::styled("  ", Style::default()),
+            Span::styled(source_padded, row_style),
+            Span::styled(
+                &entry.summary,
+                if is_selected {
+                    row_style
+                } else {
+                    theme::text()
+                },
+            ),
+            Span::styled(event_label, dim_style),
+            Span::styled(bee_indicator.to_string(), Style::default()),
+        ]));
+
+        // Expanded detail lines.
+        if is_expanded {
+            for sig in &entry.signals {
+                lines.push(Line::from(vec![
+                    Span::styled("  \u{2022} ", dim_style), // bullet
+                    Span::styled(format!("{}: {}", sig.source, sig.title), dim_style),
+                ]));
+            }
+
+            if let Some(ref bee) = entry.bee_response {
+                lines.push(Line::from(vec![
+                    Span::styled("  \u{1f41d} Bee: ", Style::default().fg(theme::HONEY)),
+                    Span::styled(bee.clone(), theme::text()),
+                ]));
+            }
+
+            // Blank line after expanded section.
+            lines.push(Line::from(""));
+        }
+    }
+
+    // Scroll to keep cursor visible.
+    let visible_height = inner.height as usize;
+    let mut cursor_line = 0usize;
+    let mut line_count = 0usize;
+    for (i, entry) in app.heartbeat_entries.iter().enumerate() {
+        if i == app.heartbeat_cursor {
+            cursor_line = line_count;
+        }
+        line_count += 1; // header line
+        if app.heartbeat_expanded.contains(&i) {
+            line_count += entry.signals.len();
+            if entry.bee_response.is_some() {
+                line_count += 1;
+            }
+            line_count += 1; // blank line
+        }
+    }
+
+    let scroll = if cursor_line >= visible_height {
+        cursor_line.saturating_sub(visible_height / 3)
+    } else {
+        0
+    };
+
+    let visible_lines: Vec<Line> = lines
+        .into_iter()
+        .skip(scroll)
+        .take(visible_height)
+        .collect();
+
+    let paragraph = Paragraph::new(visible_lines).wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, inner);
 }
 
 // ── Worker Output ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Redesigns the heartbeat/signals panel in the TUI to group raw signal events by poll cycle and source
- Each heartbeat row shows: timestamp, watcher source, summary string, event count, and a 🐝 indicator when Bee triaged it
- Pressing Enter expands a row to show full signal list + Bee's coordinator response
- Adds `HeartbeatEntry` data model with `poll_cycle_id`, `bee_response`, `summary`, and signal details
- Daemon builds heartbeat entries during `poll_buzz()` and pushes them to the TUI via `HeartbeatUpdate` socket message
- Stores Bee's triage assessment back into the heartbeat entry after signal follow-through

## Test plan
- [ ] Verify `cargo check` passes cleanly
- [ ] Verify heartbeat panel appears in sidebar when signals are received
- [ ] Verify collapsed rows show timestamp + source + summary + event count
- [ ] Verify 🐝 indicator appears on rows where Bee triaged a signal
- [ ] Verify Enter expands/collapses rows to show signal details + Bee response
- [ ] Verify j/k navigation works within the heartbeat panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)