### PR TITLE
feat: heartbeat panel signal filtering + debug mode

### DIFF
--- a/crates/hive/src/ui/app.rs
+++ b/crates/hive/src/ui/app.rs
@@ -199,6 +199,8 @@ pub struct App {
     pub heartbeat_cursor: usize,
     /// Which heartbeat entries are expanded (by index).
     pub heartbeat_expanded: std::collections::HashSet<usize>,
+    /// Debug/verbose mode for heartbeat panel (shows all signals including non-actionable).
+    pub heartbeat_debug_mode: bool,
 
     // Periodic refresh
     last_worker_refresh: Instant,
@@ -260,6 +262,7 @@ impl App {
             heartbeat_entries: Vec::new(),
             heartbeat_cursor: 0,
             heartbeat_expanded: std::collections::HashSet::new(),
+            heartbeat_debug_mode: false,
             last_worker_refresh: Instant::now(),
         }
     }
@@ -926,9 +929,26 @@ impl App {
         self.sidebar_selection == SidebarItem::Heartbeat
     }
 
+    /// Count of visible heartbeat entries (filtered in normal mode).
+    pub fn visible_heartbeat_count(&self) -> usize {
+        if self.heartbeat_debug_mode {
+            self.heartbeat_entries.len()
+        } else {
+            self.heartbeat_entries
+                .iter()
+                .filter(|e| {
+                    !e.signals.iter().all(|sig| {
+                        sig.source == "github_merged_pr" || sig.source == "github_ci_pass"
+                    })
+                })
+                .count()
+        }
+    }
+
     /// Move heartbeat cursor down.
     pub fn heartbeat_next(&mut self) {
-        if self.heartbeat_cursor + 1 < self.heartbeat_entries.len() {
+        let count = self.visible_heartbeat_count();
+        if count > 0 && self.heartbeat_cursor + 1 < count {
             self.heartbeat_cursor += 1;
         }
     }
@@ -936,6 +956,14 @@ impl App {
     /// Move heartbeat cursor up.
     pub fn heartbeat_prev(&mut self) {
         self.heartbeat_cursor = self.heartbeat_cursor.saturating_sub(1);
+    }
+
+    /// Toggle debug/verbose mode for the heartbeat panel.
+    pub fn heartbeat_toggle_debug(&mut self) {
+        self.heartbeat_debug_mode = !self.heartbeat_debug_mode;
+        // Reset cursor and expanded state when toggling modes since indices change.
+        self.heartbeat_cursor = 0;
+        self.heartbeat_expanded.clear();
     }
 
     /// Toggle expand/collapse of the currently selected heartbeat entry.

--- a/crates/hive/src/ui/app.rs
+++ b/crates/hive/src/ui/app.rs
@@ -9,6 +9,37 @@ use std::time::Instant;
 
 use super::history;
 
+/// Signal sources that are hidden in normal (non-debug) mode.
+pub const HIDDEN_SIGNAL_SOURCES: &[&str] = &["github_merged_pr", "github_ci_pass"];
+
+/// Whether a heartbeat entry contains only non-actionable signals.
+pub fn is_entry_non_actionable(entry: &HeartbeatEntry) -> bool {
+    entry
+        .signals
+        .iter()
+        .all(|sig| HIDDEN_SIGNAL_SOURCES.contains(&sig.source.as_str()))
+}
+
+/// Whether all signals in an entry are `github_merged_pr`.
+pub fn is_all_merged_pr(entry: &HeartbeatEntry) -> bool {
+    !entry.signals.is_empty() && entry.signals.iter().all(|s| s.source == "github_merged_pr")
+}
+
+/// A single visible row in the heartbeat panel.
+///
+/// Built from the raw `heartbeat_entries` based on debug mode and batching rules.
+/// The `heartbeat_cursor` indexes into a `Vec<HeartbeatRow>`.
+#[derive(Debug, Clone)]
+pub enum HeartbeatRow {
+    /// A normal entry (index into `heartbeat_entries`).
+    Entry(usize),
+    /// A batched group of merged-PR-only entries (indices into `heartbeat_entries`).
+    BatchedMergedPrs {
+        entry_indices: Vec<usize>,
+        total_prs: usize,
+    },
+}
+
 /// Pipeline stage for a single repo in dispatch.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RepoStage {
@@ -195,7 +226,7 @@ pub struct App {
 
     // Heartbeat panel state.
     pub heartbeat_entries: Vec<HeartbeatEntry>,
-    /// Which heartbeat entry is selected (index into heartbeat_entries).
+    /// Which visible row is selected (index into `visible_heartbeat_rows()`).
     pub heartbeat_cursor: usize,
     /// Which heartbeat entries are expanded (by index).
     pub heartbeat_expanded: std::collections::HashSet<usize>,
@@ -929,20 +960,57 @@ impl App {
         self.sidebar_selection == SidebarItem::Heartbeat
     }
 
-    /// Count of visible heartbeat entries (filtered in normal mode).
-    pub fn visible_heartbeat_count(&self) -> usize {
+    /// Build the visible rows model for the heartbeat panel.
+    ///
+    /// In normal mode, non-actionable entries are filtered out.
+    /// In debug mode, consecutive merged-PR-only entries are batched.
+    pub fn visible_heartbeat_rows(&self) -> Vec<HeartbeatRow> {
+        let mut rows = Vec::new();
+
         if self.heartbeat_debug_mode {
-            self.heartbeat_entries.len()
+            let mut i = 0;
+            while i < self.heartbeat_entries.len() {
+                if is_all_merged_pr(&self.heartbeat_entries[i]) {
+                    // Collect consecutive merged-PR-only entries.
+                    let start = i;
+                    let mut total_prs = 0usize;
+                    while i < self.heartbeat_entries.len()
+                        && is_all_merged_pr(&self.heartbeat_entries[i])
+                    {
+                        total_prs += self.heartbeat_entries[i]
+                            .signals
+                            .iter()
+                            .filter(|s| s.source == "github_merged_pr")
+                            .count();
+                        i += 1;
+                    }
+                    if i - start > 1 {
+                        rows.push(HeartbeatRow::BatchedMergedPrs {
+                            entry_indices: (start..i).collect(),
+                            total_prs,
+                        });
+                    } else {
+                        rows.push(HeartbeatRow::Entry(start));
+                    }
+                } else {
+                    rows.push(HeartbeatRow::Entry(i));
+                    i += 1;
+                }
+            }
         } else {
-            self.heartbeat_entries
-                .iter()
-                .filter(|e| {
-                    !e.signals.iter().all(|sig| {
-                        sig.source == "github_merged_pr" || sig.source == "github_ci_pass"
-                    })
-                })
-                .count()
+            for (i, entry) in self.heartbeat_entries.iter().enumerate() {
+                if !is_entry_non_actionable(entry) {
+                    rows.push(HeartbeatRow::Entry(i));
+                }
+            }
         }
+
+        rows
+    }
+
+    /// Count of visible rows in the heartbeat panel.
+    pub fn visible_heartbeat_count(&self) -> usize {
+        self.visible_heartbeat_rows().len()
     }
 
     /// Move heartbeat cursor down.
@@ -961,18 +1029,22 @@ impl App {
     /// Toggle debug/verbose mode for the heartbeat panel.
     pub fn heartbeat_toggle_debug(&mut self) {
         self.heartbeat_debug_mode = !self.heartbeat_debug_mode;
-        // Reset cursor and expanded state when toggling modes since indices change.
+        // Reset cursor and expanded state when toggling modes since row indices change.
         self.heartbeat_cursor = 0;
         self.heartbeat_expanded.clear();
     }
 
-    /// Toggle expand/collapse of the currently selected heartbeat entry.
+    /// Toggle expand/collapse of the currently selected heartbeat row.
     pub fn heartbeat_toggle(&mut self) {
-        if self.heartbeat_cursor < self.heartbeat_entries.len() {
-            if self.heartbeat_expanded.contains(&self.heartbeat_cursor) {
-                self.heartbeat_expanded.remove(&self.heartbeat_cursor);
-            } else {
-                self.heartbeat_expanded.insert(self.heartbeat_cursor);
+        let rows = self.visible_heartbeat_rows();
+        if self.heartbeat_cursor < rows.len() {
+            // Only Entry rows are expandable (batched rows are not).
+            if matches!(rows[self.heartbeat_cursor], HeartbeatRow::Entry(_)) {
+                if self.heartbeat_expanded.contains(&self.heartbeat_cursor) {
+                    self.heartbeat_expanded.remove(&self.heartbeat_cursor);
+                } else {
+                    self.heartbeat_expanded.insert(self.heartbeat_cursor);
+                }
             }
         }
     }

--- a/crates/hive/src/ui/mod.rs
+++ b/crates/hive/src/ui/mod.rs
@@ -682,6 +682,7 @@ async fn event_loop(
                                 KeyCode::Char('j') | KeyCode::Down => app.heartbeat_next(),
                                 KeyCode::Char('k') | KeyCode::Up => app.heartbeat_prev(),
                                 KeyCode::Enter => app.heartbeat_toggle(),
+                                KeyCode::Char('d') => app.heartbeat_toggle_debug(),
                                 KeyCode::Char('z') => {
                                     app.zoomed = !app.zoomed;
                                 }

--- a/crates/hive/src/ui/render.rs
+++ b/crates/hive/src/ui/render.rs
@@ -391,10 +391,15 @@ fn draw_heartbeat_sidebar_item(frame: &mut Frame, area: Rect, app: &App) {
         );
     }
 
-    // Line 2: "     N events"
+    // Line 2: "     N signals"
     if area.height >= 2 {
-        let count = app.heartbeat_entries.len();
-        let status = format!("{count} entr{}", if count == 1 { "y" } else { "ies" });
+        let count = app.visible_heartbeat_count();
+        let total = app.heartbeat_entries.len();
+        let status = if app.heartbeat_debug_mode || count == total {
+            format!("{total} entr{}", if total == 1 { "y" } else { "ies" })
+        } else {
+            format!("{count} signal{}", if count == 1 { "" } else { "s" })
+        };
         let line2 = Line::from(vec![
             Span::styled("    ", Style::default()),
             Span::styled(
@@ -703,6 +708,8 @@ fn draw_sidebar_status_bar(frame: &mut Frame, area: Rect, app: &App) {
             Span::styled(" nav  ", theme::key_desc()),
             Span::styled("\u{21b5}", theme::key_hint()),
             Span::styled(" expand  ", theme::key_desc()),
+            Span::styled("d", theme::key_hint()),
+            Span::styled(" debug  ", theme::key_desc()),
             Span::styled("?", theme::key_hint()),
             Span::styled(" help", theme::key_desc()),
         ])
@@ -1732,6 +1739,17 @@ fn cursor_position(text: &str, cursor_byte: usize, width: usize) -> (usize, usiz
 
 // ── Heartbeat Panel ──────────────────────────────────────
 
+/// Signal sources that are hidden in normal (non-debug) mode.
+const HIDDEN_SIGNAL_SOURCES: &[&str] = &["github_merged_pr", "github_ci_pass"];
+
+/// Check whether a heartbeat entry contains only non-actionable signals.
+fn is_entry_non_actionable(entry: &super::app::App, idx: usize) -> bool {
+    let e = &entry.heartbeat_entries[idx];
+    e.signals
+        .iter()
+        .all(|sig| HIDDEN_SIGNAL_SOURCES.contains(&sig.source.as_str()))
+}
+
 fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
     let border_style = if app.focus == Panel::Chat {
         theme::border_active()
@@ -1739,9 +1757,14 @@ fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
         theme::border()
     };
 
-    let hint = " j/k nav  \u{21b5} expand  h sidebar ";
+    let hint = " j/k nav  \u{21b5} expand  d debug  h sidebar ";
+    let title = if app.heartbeat_debug_mode {
+        " Signals [debug] "
+    } else {
+        " Signals "
+    };
     let block = Block::default()
-        .title(Span::styled(" Heartbeat ", theme::title()))
+        .title(Span::styled(title, theme::title()))
         .title_bottom(Line::from(Span::styled(hint, theme::subtitle())).centered())
         .borders(Borders::ALL)
         .border_style(border_style);
@@ -1755,16 +1778,85 @@ fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
         return;
     }
 
-    // Build lines for all entries (collapsed + expanded).
+    // Build the list of visible entry indices based on debug mode.
+    let visible_indices: Vec<usize> = if app.heartbeat_debug_mode {
+        (0..app.heartbeat_entries.len()).collect()
+    } else {
+        (0..app.heartbeat_entries.len())
+            .filter(|&i| !is_entry_non_actionable(app, i))
+            .collect()
+    };
+
+    if visible_indices.is_empty() {
+        let line = Line::from(Span::styled(
+            "  No actionable signals. Press d for debug view.",
+            theme::muted(),
+        ));
+        frame.render_widget(Paragraph::new(line), inner);
+        return;
+    }
+
+    // Build lines for visible entries.
     let mut lines: Vec<Line> = Vec::new();
     let dim_style = Style::default().fg(ratatui::style::Color::Rgb(100, 97, 90));
 
-    for (i, entry) in app.heartbeat_entries.iter().enumerate() {
-        let is_selected = i == app.heartbeat_cursor;
-        let is_expanded = app.heartbeat_expanded.contains(&i);
+    // In debug mode, batch consecutive github_merged_pr-only entries.
+    let mut vi = 0;
+    while vi < visible_indices.len() {
+        let idx = visible_indices[vi];
+        let entry = &app.heartbeat_entries[idx];
+
+        // In debug mode, batch consecutive entries where ALL signals are github_merged_pr.
+        if app.heartbeat_debug_mode && is_all_merged_pr(entry) {
+            let batch_start = vi;
+            let mut batch_count = 0usize;
+            let mut total_merged = 0usize;
+            while vi < visible_indices.len() {
+                let bidx = visible_indices[vi];
+                let bentry = &app.heartbeat_entries[bidx];
+                if is_all_merged_pr(bentry) {
+                    batch_count += 1;
+                    total_merged += bentry
+                        .signals
+                        .iter()
+                        .filter(|s| s.source == "github_merged_pr")
+                        .count();
+                    vi += 1;
+                } else {
+                    break;
+                }
+            }
+
+            if batch_count > 1 {
+                // Render as a single collapsed row.
+                let is_selected = app.heartbeat_cursor == batch_start;
+                let row_style = if is_selected {
+                    Style::default()
+                        .fg(theme::HONEY)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    theme::text()
+                };
+                let first_entry = &app.heartbeat_entries[visible_indices[batch_start]];
+                lines.push(Line::from(vec![
+                    Span::styled("  ", row_style),
+                    Span::styled(&first_entry.timestamp, dim_style),
+                    Span::styled("  ", Style::default()),
+                    Span::styled(
+                        format!("{total_merged} merged PRs ({batch_count} cycles)"),
+                        if is_selected { row_style } else { dim_style },
+                    ),
+                ]));
+                continue;
+            }
+            // Single merged-PR entry: fall through to normal rendering.
+            vi = batch_start;
+        }
+
+        let is_selected = vi == app.heartbeat_cursor;
+        let is_expanded = app.heartbeat_expanded.contains(&vi);
         let has_bee = entry.bee_response.is_some();
 
-        // Build the main row.
         let arrow = if is_expanded {
             "\u{25bc}" // ▼
         } else {
@@ -1787,7 +1879,6 @@ fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
             if entry.event_count == 1 { "" } else { "s" }
         );
 
-        // Pad source to 9 chars for alignment.
         let source_padded = format!("{:<9}", entry.source);
 
         lines.push(Line::from(vec![
@@ -1811,7 +1902,7 @@ fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
         if is_expanded {
             for sig in &entry.signals {
                 lines.push(Line::from(vec![
-                    Span::styled("  \u{2022} ", dim_style), // bullet
+                    Span::styled("  \u{2022} ", dim_style),
                     Span::styled(format!("{}: {}", sig.source, sig.title), dim_style),
                 ]));
             }
@@ -1823,27 +1914,58 @@ fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
                 ]));
             }
 
-            // Blank line after expanded section.
             lines.push(Line::from(""));
         }
+
+        vi += 1;
     }
 
     // Scroll to keep cursor visible.
     let visible_height = inner.height as usize;
     let mut cursor_line = 0usize;
     let mut line_count = 0usize;
-    for (i, entry) in app.heartbeat_entries.iter().enumerate() {
-        if i == app.heartbeat_cursor {
+
+    // Recompute line offsets for scroll tracking.
+    let mut vi2 = 0;
+    while vi2 < visible_indices.len() {
+        let idx2 = visible_indices[vi2];
+        let entry2 = &app.heartbeat_entries[idx2];
+
+        if app.heartbeat_debug_mode && is_all_merged_pr(entry2) {
+            let batch_start2 = vi2;
+            let mut batch_count2 = 0usize;
+            while vi2 < visible_indices.len() {
+                let bidx2 = visible_indices[vi2];
+                let bentry2 = &app.heartbeat_entries[bidx2];
+                if is_all_merged_pr(bentry2) {
+                    batch_count2 += 1;
+                    vi2 += 1;
+                } else {
+                    break;
+                }
+            }
+            if batch_count2 > 1 {
+                if app.heartbeat_cursor == batch_start2 {
+                    cursor_line = line_count;
+                }
+                line_count += 1;
+                continue;
+            }
+            vi2 = batch_start2;
+        }
+
+        if vi2 == app.heartbeat_cursor {
             cursor_line = line_count;
         }
-        line_count += 1; // header line
-        if app.heartbeat_expanded.contains(&i) {
-            line_count += entry.signals.len();
-            if entry.bee_response.is_some() {
+        line_count += 1;
+        if app.heartbeat_expanded.contains(&vi2) {
+            line_count += entry2.signals.len();
+            if entry2.bee_response.is_some() {
                 line_count += 1;
             }
-            line_count += 1; // blank line
+            line_count += 1;
         }
+        vi2 += 1;
     }
 
     let scroll = if cursor_line >= visible_height {
@@ -1860,6 +1982,11 @@ fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
 
     let paragraph = Paragraph::new(visible_lines).wrap(Wrap { trim: false });
     frame.render_widget(paragraph, inner);
+}
+
+/// Check whether all signals in an entry are `github_merged_pr`.
+fn is_all_merged_pr(entry: &crate::daemon::tui_socket::HeartbeatEntry) -> bool {
+    !entry.signals.is_empty() && entry.signals.iter().all(|s| s.source == "github_merged_pr")
 }
 
 // ── Worker Output ─────────────────────────────────────────
@@ -2089,7 +2216,7 @@ fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
 // ── Help Overlay ─────────────────────────────────────────
 
 fn draw_help_overlay(frame: &mut Frame, area: Rect) {
-    let popup = centered_rect(54, 35, area);
+    let popup = centered_rect(54, 40, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()
@@ -2143,6 +2270,11 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect) {
         key_line("g / G", "Scroll to top/bottom"),
         key_line("h / Tab", "Return to sidebar"),
         key_line("z", "Toggle zoom"),
+        Line::from(""),
+        section("Signals"),
+        key_line("j / k", "Navigate entries"),
+        key_line("↵", "Expand / collapse"),
+        key_line("d", "Toggle debug mode"),
         Line::from(""),
         section("Dispatch Review"),
         key_line("j / k", "Navigate sections"),

--- a/crates/hive/src/ui/render.rs
+++ b/crates/hive/src/ui/render.rs
@@ -391,14 +391,17 @@ fn draw_heartbeat_sidebar_item(frame: &mut Frame, area: Rect, app: &App) {
         );
     }
 
-    // Line 2: "     N signals"
+    // Line 2: "     N entries" (filtered count in normal mode)
     if area.height >= 2 {
         let count = app.visible_heartbeat_count();
         let total = app.heartbeat_entries.len();
         let status = if app.heartbeat_debug_mode || count == total {
             format!("{total} entr{}", if total == 1 { "y" } else { "ies" })
         } else {
-            format!("{count} signal{}", if count == 1 { "" } else { "s" })
+            format!(
+                "{count} of {total} entr{}",
+                if total == 1 { "y" } else { "ies" }
+            )
         };
         let line2 = Line::from(vec![
             Span::styled("    ", Style::default()),
@@ -1739,18 +1742,9 @@ fn cursor_position(text: &str, cursor_byte: usize, width: usize) -> (usize, usiz
 
 // ── Heartbeat Panel ──────────────────────────────────────
 
-/// Signal sources that are hidden in normal (non-debug) mode.
-const HIDDEN_SIGNAL_SOURCES: &[&str] = &["github_merged_pr", "github_ci_pass"];
-
-/// Check whether a heartbeat entry contains only non-actionable signals.
-fn is_entry_non_actionable(entry: &super::app::App, idx: usize) -> bool {
-    let e = &entry.heartbeat_entries[idx];
-    e.signals
-        .iter()
-        .all(|sig| HIDDEN_SIGNAL_SOURCES.contains(&sig.source.as_str()))
-}
-
 fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
+    use super::app::HeartbeatRow;
+
     let border_style = if app.focus == Panel::Chat {
         theme::border_active()
     } else {
@@ -1778,16 +1772,9 @@ fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
         return;
     }
 
-    // Build the list of visible entry indices based on debug mode.
-    let visible_indices: Vec<usize> = if app.heartbeat_debug_mode {
-        (0..app.heartbeat_entries.len()).collect()
-    } else {
-        (0..app.heartbeat_entries.len())
-            .filter(|&i| !is_entry_non_actionable(app, i))
-            .collect()
-    };
+    let rows = app.visible_heartbeat_rows();
 
-    if visible_indices.is_empty() {
+    if rows.is_empty() {
         let line = Line::from(Span::styled(
             "  No actionable signals. Press d for debug view.",
             theme::muted(),
@@ -1796,40 +1783,23 @@ fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
         return;
     }
 
-    // Build lines for visible entries.
+    // Build lines and track cursor position in one pass over the row model.
     let mut lines: Vec<Line> = Vec::new();
+    let mut cursor_line = 0usize;
     let dim_style = Style::default().fg(ratatui::style::Color::Rgb(100, 97, 90));
 
-    // In debug mode, batch consecutive github_merged_pr-only entries.
-    let mut vi = 0;
-    while vi < visible_indices.len() {
-        let idx = visible_indices[vi];
-        let entry = &app.heartbeat_entries[idx];
+    for (row_idx, row) in rows.iter().enumerate() {
+        let is_selected = row_idx == app.heartbeat_cursor;
 
-        // In debug mode, batch consecutive entries where ALL signals are github_merged_pr.
-        if app.heartbeat_debug_mode && is_all_merged_pr(entry) {
-            let batch_start = vi;
-            let mut batch_count = 0usize;
-            let mut total_merged = 0usize;
-            while vi < visible_indices.len() {
-                let bidx = visible_indices[vi];
-                let bentry = &app.heartbeat_entries[bidx];
-                if is_all_merged_pr(bentry) {
-                    batch_count += 1;
-                    total_merged += bentry
-                        .signals
-                        .iter()
-                        .filter(|s| s.source == "github_merged_pr")
-                        .count();
-                    vi += 1;
-                } else {
-                    break;
-                }
-            }
+        if is_selected {
+            cursor_line = lines.len();
+        }
 
-            if batch_count > 1 {
-                // Render as a single collapsed row.
-                let is_selected = app.heartbeat_cursor == batch_start;
+        match row {
+            HeartbeatRow::BatchedMergedPrs {
+                entry_indices,
+                total_prs,
+            } => {
                 let row_style = if is_selected {
                     Style::default()
                         .fg(theme::HONEY)
@@ -1837,137 +1807,87 @@ fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
                 } else {
                     theme::text()
                 };
-                let first_entry = &app.heartbeat_entries[visible_indices[batch_start]];
+                let first_entry = &app.heartbeat_entries[entry_indices[0]];
+                let cycle_count = entry_indices.len();
                 lines.push(Line::from(vec![
                     Span::styled("  ", row_style),
                     Span::styled(&first_entry.timestamp, dim_style),
                     Span::styled("  ", Style::default()),
                     Span::styled(
-                        format!("{total_merged} merged PRs ({batch_count} cycles)"),
+                        format!("{total_prs} merged PRs ({cycle_count} cycles)"),
                         if is_selected { row_style } else { dim_style },
                     ),
                 ]));
-                continue;
             }
-            // Single merged-PR entry: fall through to normal rendering.
-            vi = batch_start;
-        }
+            HeartbeatRow::Entry(entry_idx) => {
+                let entry = &app.heartbeat_entries[*entry_idx];
+                let is_expanded = app.heartbeat_expanded.contains(&row_idx);
+                let has_bee = entry.bee_response.is_some();
 
-        let is_selected = vi == app.heartbeat_cursor;
-        let is_expanded = app.heartbeat_expanded.contains(&vi);
-        let has_bee = entry.bee_response.is_some();
+                let arrow = if is_expanded {
+                    "\u{25bc}" // ▼
+                } else {
+                    "\u{25b6}" // ▶
+                };
 
-        let arrow = if is_expanded {
-            "\u{25bc}" // ▼
-        } else {
-            "\u{25b6}" // ▶
-        };
-
-        let row_style = if is_selected {
-            Style::default()
-                .fg(theme::HONEY)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            theme::text()
-        };
-
-        let bee_indicator = if has_bee { " \u{1f41d}" } else { "" };
-
-        let event_label = format!(
-            " \u{00b7} {} event{}",
-            entry.event_count,
-            if entry.event_count == 1 { "" } else { "s" }
-        );
-
-        let source_padded = format!("{:<9}", entry.source);
-
-        lines.push(Line::from(vec![
-            Span::styled(format!("{arrow} "), row_style),
-            Span::styled(&entry.timestamp, dim_style),
-            Span::styled("  ", Style::default()),
-            Span::styled(source_padded, row_style),
-            Span::styled(
-                &entry.summary,
-                if is_selected {
-                    row_style
+                let row_style = if is_selected {
+                    Style::default()
+                        .fg(theme::HONEY)
+                        .add_modifier(Modifier::BOLD)
                 } else {
                     theme::text()
-                },
-            ),
-            Span::styled(event_label, dim_style),
-            Span::styled(bee_indicator.to_string(), Style::default()),
-        ]));
+                };
 
-        // Expanded detail lines.
-        if is_expanded {
-            for sig in &entry.signals {
+                let bee_indicator = if has_bee { " \u{1f41d}" } else { "" };
+
+                let event_label = format!(
+                    " \u{00b7} {} event{}",
+                    entry.event_count,
+                    if entry.event_count == 1 { "" } else { "s" }
+                );
+
+                let source_padded = format!("{:<9}", entry.source);
+
                 lines.push(Line::from(vec![
-                    Span::styled("  \u{2022} ", dim_style),
-                    Span::styled(format!("{}: {}", sig.source, sig.title), dim_style),
+                    Span::styled(format!("{arrow} "), row_style),
+                    Span::styled(&entry.timestamp, dim_style),
+                    Span::styled("  ", Style::default()),
+                    Span::styled(source_padded, row_style),
+                    Span::styled(
+                        &entry.summary,
+                        if is_selected {
+                            row_style
+                        } else {
+                            theme::text()
+                        },
+                    ),
+                    Span::styled(event_label, dim_style),
+                    Span::styled(bee_indicator.to_string(), Style::default()),
                 ]));
-            }
 
-            if let Some(ref bee) = entry.bee_response {
-                lines.push(Line::from(vec![
-                    Span::styled("  \u{1f41d} Bee: ", Style::default().fg(theme::HONEY)),
-                    Span::styled(bee.clone(), theme::text()),
-                ]));
-            }
+                if is_expanded {
+                    for sig in &entry.signals {
+                        lines.push(Line::from(vec![
+                            Span::styled("  \u{2022} ", dim_style),
+                            Span::styled(format!("{}: {}", sig.source, sig.title), dim_style),
+                        ]));
+                    }
 
-            lines.push(Line::from(""));
+                    if let Some(ref bee) = entry.bee_response {
+                        lines.push(Line::from(vec![
+                            Span::styled("  \u{1f41d} Bee: ", Style::default().fg(theme::HONEY)),
+                            Span::styled(bee.clone(), theme::text()),
+                        ]));
+                    }
+
+                    lines.push(Line::from(""));
+                }
+            }
         }
-
-        vi += 1;
     }
 
     // Scroll to keep cursor visible.
     let visible_height = inner.height as usize;
-    let mut cursor_line = 0usize;
-    let mut line_count = 0usize;
-
-    // Recompute line offsets for scroll tracking.
-    let mut vi2 = 0;
-    while vi2 < visible_indices.len() {
-        let idx2 = visible_indices[vi2];
-        let entry2 = &app.heartbeat_entries[idx2];
-
-        if app.heartbeat_debug_mode && is_all_merged_pr(entry2) {
-            let batch_start2 = vi2;
-            let mut batch_count2 = 0usize;
-            while vi2 < visible_indices.len() {
-                let bidx2 = visible_indices[vi2];
-                let bentry2 = &app.heartbeat_entries[bidx2];
-                if is_all_merged_pr(bentry2) {
-                    batch_count2 += 1;
-                    vi2 += 1;
-                } else {
-                    break;
-                }
-            }
-            if batch_count2 > 1 {
-                if app.heartbeat_cursor == batch_start2 {
-                    cursor_line = line_count;
-                }
-                line_count += 1;
-                continue;
-            }
-            vi2 = batch_start2;
-        }
-
-        if vi2 == app.heartbeat_cursor {
-            cursor_line = line_count;
-        }
-        line_count += 1;
-        if app.heartbeat_expanded.contains(&vi2) {
-            line_count += entry2.signals.len();
-            if entry2.bee_response.is_some() {
-                line_count += 1;
-            }
-            line_count += 1;
-        }
-        vi2 += 1;
-    }
-
     let scroll = if cursor_line >= visible_height {
         cursor_line.saturating_sub(visible_height / 3)
     } else {
@@ -1982,11 +1902,6 @@ fn draw_heartbeat_panel(frame: &mut Frame, area: Rect, app: &App) {
 
     let paragraph = Paragraph::new(visible_lines).wrap(Wrap { trim: false });
     frame.render_widget(paragraph, inner);
-}
-
-/// Check whether all signals in an entry are `github_merged_pr`.
-fn is_all_merged_pr(entry: &crate::daemon::tui_socket::HeartbeatEntry) -> bool {
-    !entry.signals.is_empty() && entry.signals.iter().all(|s| s.source == "github_merged_pr")
 }
 
 // ── Worker Output ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Filter non-actionable signals (`github_merged_pr`, `github_ci_pass`) from the heartbeat panel by default, showing only actionable signals like CI failures, releases, bot reviews, and swarm events
- Add `d` key toggle to switch between normal mode ("Signals") and debug mode ("Signals [debug]") which shows all signals
- In debug mode, batch consecutive `github_merged_pr`-only entries into a single collapsed row showing "N merged PRs (M cycles)"
- Update sidebar entry count to show filtered signal count in normal mode
- Add debug key hint to status bar and help overlay

## Test plan
- [ ] Open hive UI with heartbeat entries containing `github_merged_pr` and `github_ci_pass` — verify they are hidden by default
- [ ] Press `d` in the heartbeat panel — verify all signals appear and header shows "Signals [debug]"
- [ ] Press `d` again — verify non-actionable signals are hidden again and header shows "Signals"
- [ ] In debug mode, verify consecutive merged PR entries are batched into a single row
- [ ] Verify `j`/`k` navigation respects filtered entry count in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)