### PR TITLE
chore: bump apiari version to v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apiari"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "apiari-claude-sdk",
  "apiari-tui",

--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/ApiariTools/apiari"


### PR DESCRIPTION
## Summary
- Bumps `apiari` crate version from 0.1.5 to 0.1.6 in `crates/apiari/Cargo.toml`
- Updates `Cargo.lock` accordingly

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt -p apiari` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)