### PR TITLE
feat: enhance signals coordinator skill with DB query knowledge

### DIFF
--- a/crates/apiari/src/buzz/coordinator/skills/signals.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/signals.rs
@@ -37,7 +37,7 @@ sqlite3 ~/.config/apiari/apiari.db \"SELECT source, severity, title, created_at 
 
 Unresolved signals:
 ```
-sqlite3 ~/.config/apiari/apiari.db \"SELECT source, severity, title, created_at FROM signals WHERE workspace='{ws}' AND resolved_at IS NULL AND status IN ('open','updated') ORDER BY created_at DESC\"
+sqlite3 ~/.config/apiari/apiari.db \"SELECT source, severity, title, created_at FROM signals WHERE workspace='{ws}' AND status IN ('open','updated') ORDER BY created_at DESC\"
 ```
 
 Recent conversation history:

--- a/crates/apiari/src/buzz/coordinator/skills/signals.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/signals.rs
@@ -4,13 +4,64 @@ use super::SkillContext;
 
 /// Always included — the coordinator should always know about the signal store.
 pub fn build_prompt(ctx: &SkillContext) -> String {
+    let ws = &ctx.workspace_name;
     format!(
-        "## Signal Store\n\
-         The signal database is at ~/.config/apiari/apiari.db \
-         (SQLite, workspace=\"{}\").\n\
-         Open signals are already listed above. For detailed queries:\n\
-         - `apiari status {}`\n\
-         Or query SQLite directly with `sqlite3` if needed.\n",
-        ctx.workspace_name, ctx.workspace_name,
+        "\
+## Signal Store
+
+The signal database is at `~/.config/apiari/apiari.db` (SQLite, workspace-scoped).
+Open signals are already listed above. For detailed queries use `apiari status {ws}` \
+or query SQLite directly.
+
+### Database Tables
+
+**signals** — all watcher events
+Columns: `id, workspace, source, external_id, title, body, severity, status, url, \
+created_at, updated_at, resolved_at, metadata, snoozed_until`
+
+**watcher_cursors** — polling state per watcher/workspace
+Columns: `workspace, watcher, cursor_value, updated_at`
+
+**memory** — coordinator long-term memory
+Columns: `id, workspace, category, content, created_at`
+
+**conversations** — chat history between user and coordinator
+Columns: `id, workspace, role, content, source, provider, session_id, created_at`
+
+### Example Queries
+
+Recent signals:
+```
+sqlite3 ~/.config/apiari/apiari.db \"SELECT source, severity, title, created_at FROM signals WHERE workspace='{ws}' ORDER BY created_at DESC LIMIT 20\"
+```
+
+Unresolved signals:
+```
+sqlite3 ~/.config/apiari/apiari.db \"SELECT source, severity, title, created_at FROM signals WHERE workspace='{ws}' AND resolved_at IS NULL AND status IN ('open','updated') ORDER BY created_at DESC\"
+```
+
+Recent conversation history:
+```
+sqlite3 ~/.config/apiari/apiari.db \"SELECT role, substr(content,1,120), source, created_at FROM conversations WHERE workspace='{ws}' ORDER BY created_at DESC LIMIT 20\"
+```
+
+Watcher cursor state:
+```
+sqlite3 ~/.config/apiari/apiari.db \"SELECT watcher, cursor_value, updated_at FROM watcher_cursors WHERE workspace='{ws}'\"
+```
+
+Coordinator memories:
+```
+sqlite3 ~/.config/apiari/apiari.db \"SELECT category, content, created_at FROM memory WHERE workspace='{ws}' ORDER BY created_at DESC LIMIT 20\"
+```
+
+### When to Query
+
+Proactively query the database when:
+- The user asks \"what happened recently?\" or \"any issues?\" — check signals
+- Debugging why a watcher fired or didn't fire — check watcher_cursors and recent signals
+- The user asks about past responses or conversations — check conversations table
+- Investigating signal state (snoozed, resolved) — query signals with appropriate filters
+",
     )
 }


### PR DESCRIPTION
## Summary
- Enhanced the signals coordinator skill prompt with full SQLite database schema (signals, watcher_cursors, memory, conversations tables)
- Added concrete `sqlite3` query examples with workspace dynamically injected from `SkillContext`
- Added guidance on when Bee should proactively query the DB (recent events, debugging watchers, past conversations, signal state)

## Test plan
- [x] All 21 existing coordinator skills tests pass
- [x] `cargo fmt -p apiari` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)