### PR TITLE
fix: move TUI blocking I/O to background tasks to prevent freezing

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -99,6 +99,49 @@ pub struct WatcherHealth {
     pub last_check_secs: i64, // seconds since last check
 }
 
+// ── Background refresh types ─────────────────────────────
+
+/// Info needed by the background refresh task for each workspace.
+#[derive(Clone)]
+pub struct WorkspaceRefreshInfo {
+    pub name: String,
+    pub root: std::path::PathBuf,
+    pub has_github_watcher: bool,
+    pub has_sentry_watcher: bool,
+    pub has_swarm_watcher: bool,
+}
+
+/// Data returned from background extras refresh (per workspace).
+pub struct WorkspaceExtrasData {
+    pub sparkline_data: Vec<u64>,
+    pub watcher_health: Vec<WatcherHealth>,
+    pub thoughts: Vec<(String, String)>,
+    /// Feed items from SQLite (signals + watcher heartbeats). Worker items merged by caller.
+    pub feed_items: Vec<FeedItem>,
+}
+
+/// Messages from background refresh tasks to the TUI event loop.
+pub enum AppUpdate {
+    Workers(Vec<(String, Vec<WorkerInfo>)>),
+    Signals(Vec<(String, Vec<SignalRecord>)>),
+    Extras {
+        daemon_alive: bool,
+        daemon_uptime_secs: Option<u64>,
+        per_workspace: Vec<(String, WorkspaceExtrasData)>,
+    },
+    ChatHistory(Vec<(String, Vec<ChatLine>, Option<String>)>),
+    DaemonStatus {
+        connected: bool,
+        alive: bool,
+        remote_host: Option<String>,
+    },
+    WorkerConversation {
+        workspace_idx: usize,
+        worker_idx: usize,
+        entries: Vec<ConversationEntry>,
+    },
+}
+
 // ── Worker info from state.json ───────────────────────────
 
 #[derive(Debug, Clone)]
@@ -369,72 +412,35 @@ pub struct App {
 impl App {
     /// Create app from discovered workspaces, focusing the given tab.
     /// If `needs_onboarding` is true, the dashboard starts with progressive reveal.
+    ///
+    /// **No I/O**: initializes with empty state. Background tasks load data
+    /// and send updates via the `AppUpdate` channel.
     pub fn new(
         workspaces: Vec<Workspace>,
         focus_workspace: Option<&str>,
         needs_onboarding: bool,
     ) -> Self {
-        let db = config::db_path();
         let ws_states: Vec<WorkspaceState> = workspaces
             .into_iter()
-            .map(|ws| {
-                // Load chat history from DB (primary), falling back to JSONL (legacy)
-                let chat_history: Vec<ChatLine> =
-                    if let Ok(store) = SignalStore::open(&db, &ws.name) {
-                        let conv = ConversationStore::new(store.conn(), &ws.name);
-                        match conv.load_history(200) {
-                            Ok(rows) if !rows.is_empty() => rows
-                                .into_iter()
-                                .map(|row| {
-                                    let ts = chrono::DateTime::parse_from_rfc3339(&row.created_at)
-                                        .map(|dt| dt.format("%H:%M").to_string())
-                                        .unwrap_or_default();
-                                    let source = row.source.as_deref().map(|s| match s {
-                                        "telegram" => MessageSource::Telegram,
-                                        "system" => MessageSource::System,
-                                        _ => MessageSource::Tui,
-                                    });
-                                    match row.role.as_str() {
-                                        "user" => ChatLine::User(row.content, ts, source),
-                                        _ => ChatLine::Assistant(row.content, ts, source),
-                                    }
-                                })
-                                .collect(),
-                            _ => load_history_from_jsonl(&ws.name),
-                        }
-                    } else {
-                        load_history_from_jsonl(&ws.name)
-                    };
-
-                // Extract coordinator preview from last assistant message
-                let coordinator_preview = chat_history.iter().rev().find_map(|msg| {
-                    if let ChatLine::Assistant(s, _, _) = msg {
-                        Some(truncate_preview(s, 120))
-                    } else {
-                        None
-                    }
-                });
-
-                WorkspaceState {
-                    name: ws.name,
-                    config: ws.config,
-                    signals: Vec::new(),
-                    workers: Vec::new(),
-                    chat_history,
-                    input: String::new(),
-                    chat_scroll: ScrollState::new(),
-                    streaming: false,
-                    coordinator_preview,
-                    has_unread_response: false,
-                    sparkline_data: vec![0; 24],
-                    watcher_health: Vec::new(),
-                    feed: Vec::new(),
-                    prev_worker_phases: std::collections::HashMap::new(),
-                    prev_signal_ids: std::collections::HashSet::new(),
-                    prev_pr_workers: std::collections::HashSet::new(),
-                    feed_scroll: ScrollState::new(),
-                    thoughts: Vec::new(),
-                }
+            .map(|ws| WorkspaceState {
+                name: ws.name,
+                config: ws.config,
+                signals: Vec::new(),
+                workers: Vec::new(),
+                chat_history: Vec::new(),
+                input: String::new(),
+                chat_scroll: ScrollState::new(),
+                streaming: false,
+                coordinator_preview: None,
+                has_unread_response: false,
+                sparkline_data: vec![0; 24],
+                watcher_health: Vec::new(),
+                feed: Vec::new(),
+                prev_worker_phases: std::collections::HashMap::new(),
+                prev_signal_ids: std::collections::HashSet::new(),
+                prev_pr_workers: std::collections::HashSet::new(),
+                feed_scroll: ScrollState::new(),
+                thoughts: Vec::new(),
             })
             .collect();
 
@@ -512,9 +518,7 @@ impl App {
             ws.chat_scroll.scroll_to_bottom();
         }
 
-        app.refresh_workers();
-        app.refresh_signals();
-        app.refresh_extras();
+        // No I/O here — background tasks handle initial data load.
         app
     }
 
@@ -1184,83 +1188,6 @@ impl App {
 
     // ── Data refresh ──────────────────────────────────────
 
-    pub fn refresh_workers(&mut self) {
-        for ws in &mut self.workspaces {
-            let state_path = ws.config.root.join(".swarm/state.json");
-            ws.workers = load_workers_from_state(&state_path);
-            // Enrich with last activity from events
-            for worker in &mut ws.workers {
-                worker.last_activity = load_last_activity(&ws.config.root, &worker.id);
-            }
-
-            // Detect state changes and inject chat notifications
-            let is_first_load = ws.prev_worker_phases.is_empty() && !ws.workers.is_empty();
-            for worker in &ws.workers {
-                let phase = phase_display(worker).to_string();
-                let prev = ws.prev_worker_phases.get(&worker.id);
-
-                // Skip first load — don't spam on startup
-                if !is_first_load {
-                    if let Some(prev_phase) = prev {
-                        if *prev_phase != phase {
-                            // Phase changed — announce it
-                            let msg = match phase.as_str() {
-                                "completed" => format!("\u{2713} {} completed", worker.id),
-                                "waiting" => {
-                                    format!("\u{25cb} {} waiting for input", worker.id)
-                                }
-                                "closed" => format!("\u{2500} {} closed", worker.id),
-                                "running" if prev_phase == "waiting" => {
-                                    format!("\u{25cf} {} resumed", worker.id)
-                                }
-                                _ => String::new(),
-                            };
-                            if !msg.is_empty() {
-                                ws.chat_history.push(ChatLine::System(msg));
-                                ws.has_unread_response = true;
-                                ws.chat_scroll.scroll_to_bottom();
-                            }
-                        }
-                    } else {
-                        // New worker appeared
-                        ws.chat_history
-                            .push(ChatLine::System(format!("\u{25cf} {} spawned", worker.id)));
-                        ws.has_unread_response = true;
-                        ws.chat_scroll.scroll_to_bottom();
-                    }
-
-                    // PR opened
-                    if let Some(ref pr) = worker.pr
-                        && !ws.prev_pr_workers.contains(&worker.id)
-                    {
-                        ws.chat_history.push(ChatLine::System(format!(
-                            "\u{27f3} {} opened PR #{}: {}",
-                            worker.id, pr.number, pr.title
-                        )));
-                        ws.has_unread_response = true;
-                        ws.chat_scroll.scroll_to_bottom();
-                    }
-                }
-            }
-
-            // Update tracking state
-            ws.prev_worker_phases = ws
-                .workers
-                .iter()
-                .map(|w| (w.id.clone(), phase_display(w).to_string()))
-                .collect();
-            ws.prev_pr_workers = ws
-                .workers
-                .iter()
-                .filter(|w| w.pr.is_some())
-                .map(|w| w.id.clone())
-                .collect();
-        }
-        self.last_worker_refresh = Instant::now();
-        self.clamp_selections();
-        self.needs_redraw = true;
-    }
-
     pub fn refresh_signals(&mut self) {
         let db = config::db_path();
         for ws in &mut self.workspaces {
@@ -1312,105 +1239,144 @@ impl App {
         self.needs_redraw = true;
     }
 
-    /// Refresh sparkline, thoughts, daemon health, and activity feed.
-    pub fn refresh_extras(&mut self) {
-        let db = config::db_path();
-        let pid_path = config::pid_path();
+    /// Apply worker data from background refresh.
+    pub fn apply_worker_update(&mut self, data: Vec<(String, Vec<WorkerInfo>)>) {
+        for (name, new_workers) in data {
+            if let Some(ws) = self.workspaces.iter_mut().find(|ws| ws.name == name) {
+                // Detect state changes and inject chat notifications
+                let is_first_load = ws.prev_worker_phases.is_empty() && !new_workers.is_empty();
+                for worker in &new_workers {
+                    let phase = phase_display(worker).to_string();
+                    let prev = ws.prev_worker_phases.get(&worker.id);
 
-        // Daemon health
-        self.daemon_alive = crate::daemon::is_daemon_running();
-        self.daemon_uptime_secs = if self.daemon_alive {
-            std::fs::metadata(&pid_path)
-                .ok()
-                .and_then(|m| m.modified().ok())
-                .and_then(|t| std::time::SystemTime::now().duration_since(t).ok())
-                .map(|d| d.as_secs())
-        } else {
-            None
-        };
+                    // Skip first load — don't spam on startup
+                    if !is_first_load {
+                        if let Some(prev_phase) = prev {
+                            if *prev_phase != phase {
+                                let msg = match phase.as_str() {
+                                    "completed" => format!("\u{2713} {} completed", worker.id),
+                                    "waiting" => {
+                                        format!("\u{25cb} {} waiting for input", worker.id)
+                                    }
+                                    "closed" => format!("\u{2500} {} closed", worker.id),
+                                    "running" if prev_phase == "waiting" => {
+                                        format!("\u{25cf} {} resumed", worker.id)
+                                    }
+                                    _ => String::new(),
+                                };
+                                if !msg.is_empty() {
+                                    ws.chat_history.push(ChatLine::System(msg));
+                                    ws.has_unread_response = true;
+                                    ws.chat_scroll.scroll_to_bottom();
+                                }
+                            }
+                        } else {
+                            // New worker appeared
+                            ws.chat_history
+                                .push(ChatLine::System(format!("\u{25cf} {} spawned", worker.id)));
+                            ws.has_unread_response = true;
+                            ws.chat_scroll.scroll_to_bottom();
+                        }
 
-        for ws in &mut self.workspaces {
-            if let Ok(store) = SignalStore::open(&db, &ws.name) {
-                // Sparkline
-                ws.sparkline_data = store
-                    .count_signals_by_hour()
-                    .unwrap_or_else(|_| vec![0; 24]);
-
-                // Thoughts from MemoryStore
-                let mem = MemoryStore::new(store.conn(), &ws.name);
-                ws.thoughts = mem
-                    .get_recent(20)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|e| (e.category.as_str().to_string(), e.content))
-                    .collect();
-
-                // Watcher health — merge config (what's configured) with cursors (runtime)
-                let now = Utc::now();
-                let cursor_map: std::collections::HashMap<String, String> = store
-                    .get_watcher_cursors()
-                    .unwrap_or_default()
-                    .into_iter()
-                    .collect();
-
-                // Build list from configured watchers
-                let mut watchers: Vec<WatcherHealth> = Vec::new();
-                let wc = &ws.config.watchers;
-                let configured: &[(&str, bool)] = &[
-                    ("github", wc.github.is_some()),
-                    ("sentry", wc.sentry.is_some()),
-                    ("swarm", wc.swarm.is_some()),
-                ];
-                for &(name, enabled) in configured {
-                    if !enabled {
-                        continue;
-                    }
-                    if let Some(updated_at) = cursor_map.get(name) {
-                        let dt = chrono::DateTime::parse_from_rfc3339(updated_at)
-                            .map(|d| d.with_timezone(&Utc))
-                            .unwrap_or(now);
-                        let age = now.signed_duration_since(dt);
-                        watchers.push(WatcherHealth {
-                            name: name.to_string(),
-                            healthy: age.num_minutes() < 5,
-                            last_check_secs: age.num_seconds(),
-                        });
-                    } else {
-                        // Configured but never ran
-                        watchers.push(WatcherHealth {
-                            name: name.to_string(),
-                            healthy: false,
-                            last_check_secs: -1, // sentinel: never checked
-                        });
+                        // PR opened
+                        if let Some(ref pr) = worker.pr
+                            && !ws.prev_pr_workers.contains(&worker.id)
+                        {
+                            ws.chat_history.push(ChatLine::System(format!(
+                                "\u{27f3} {} opened PR #{}: {}",
+                                worker.id, pr.number, pr.title
+                            )));
+                            ws.has_unread_response = true;
+                            ws.chat_scroll.scroll_to_bottom();
+                        }
                     }
                 }
-                ws.watcher_health = watchers;
 
-                // Build feed: proactive AI activity only (signals + workers, not chat)
-                let mut feed: Vec<FeedItem> = Vec::new();
+                // Update tracking state
+                ws.prev_worker_phases = new_workers
+                    .iter()
+                    .map(|w| (w.id.clone(), phase_display(w).to_string()))
+                    .collect();
+                ws.prev_pr_workers = new_workers
+                    .iter()
+                    .filter(|w| w.pr.is_some())
+                    .map(|w| w.id.clone())
+                    .collect();
+
+                ws.workers = new_workers;
+            }
+        }
+        self.last_worker_refresh = Instant::now();
+        self.clamp_selections();
+        self.needs_redraw = true;
+    }
+
+    /// Apply signal data from background refresh.
+    pub fn apply_signal_update(&mut self, data: Vec<(String, Vec<SignalRecord>)>) {
+        for (name, new_signals) in data {
+            if let Some(ws) = self.workspaces.iter_mut().find(|ws| ws.name == name) {
+                let current_ids: std::collections::HashSet<i64> =
+                    new_signals.iter().map(|s| s.id).collect();
+                let is_first_load = ws.prev_signal_ids.is_empty() && !new_signals.is_empty();
+
+                if !is_first_load {
+                    let new_sigs: Vec<&SignalRecord> = new_signals
+                        .iter()
+                        .filter(|s| !ws.prev_signal_ids.contains(&s.id))
+                        .collect();
+
+                    if !new_sigs.is_empty() {
+                        let count = new_sigs.len();
+                        let mut by_source: std::collections::HashMap<&str, usize> =
+                            std::collections::HashMap::new();
+                        for sig in &new_sigs {
+                            *by_source.entry(sig.source.as_str()).or_default() += 1;
+                        }
+                        let summary: Vec<String> = by_source
+                            .iter()
+                            .map(|(src, n)| format!("{n} {src}"))
+                            .collect();
+                        let msg = format!(
+                            "! {} new signal{}: {}",
+                            count,
+                            if count > 1 { "s" } else { "" },
+                            summary.join(", ")
+                        );
+                        ws.chat_history.push(ChatLine::System(msg));
+                        ws.has_unread_response = true;
+                        ws.chat_scroll.scroll_to_bottom();
+                    }
+                }
+
+                ws.prev_signal_ids = current_ids;
+                ws.signals = new_signals;
+            }
+        }
+        self.last_signal_refresh = Instant::now();
+        self.clamp_selections();
+        self.needs_redraw = true;
+    }
+
+    /// Apply extras data from background refresh.
+    pub fn apply_extras_update(
+        &mut self,
+        daemon_alive: bool,
+        daemon_uptime_secs: Option<u64>,
+        per_workspace: Vec<(String, WorkspaceExtrasData)>,
+    ) {
+        self.daemon_alive = daemon_alive;
+        self.daemon_uptime_secs = daemon_uptime_secs;
+
+        for (name, data) in per_workspace {
+            if let Some(ws) = self.workspaces.iter_mut().find(|ws| ws.name == name) {
+                ws.sparkline_data = data.sparkline_data;
+                ws.watcher_health = data.watcher_health;
+                ws.thoughts = data.thoughts;
+
+                // Start with SQLite-sourced feed items, then add in-memory worker items
+                let mut feed = data.feed_items;
+
                 let now_utc = Utc::now();
-
-                // Recent signals — deduplicated by title prefix (collapse similar errors)
-                if let Ok(recent) = store.get_recent_signals(30) {
-                    let mut seen_ids = std::collections::HashSet::new();
-                    let mut seen_titles = std::collections::HashSet::new();
-                    for sig in recent {
-                        if !seen_ids.insert(sig.external_id.clone()) {
-                            continue;
-                        }
-                        let title_key: String = sig.title.chars().take(50).collect();
-                        if !seen_titles.insert(title_key) {
-                            continue;
-                        }
-                        feed.push(FeedItem {
-                            when: sig.updated_at,
-                            kind: FeedKind::Signal,
-                            text: sig.title.clone(),
-                        });
-                    }
-                }
-
-                // Worker lifecycle events
                 for worker in &ws.workers {
                     let phase = phase_display(worker);
                     let when = worker
@@ -1431,22 +1397,7 @@ impl App {
                     });
                 }
 
-                // Watcher heartbeats — show when each watcher last checked in
-                if let Ok(cursors) = store.get_watcher_cursors() {
-                    for (watcher, updated_at_str) in &cursors {
-                        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(updated_at_str) {
-                            let dt_utc = dt.with_timezone(&Utc);
-                            feed.push(FeedItem {
-                                when: dt_utc,
-                                kind: FeedKind::Heartbeat,
-                                text: format!("{watcher} checked"),
-                            });
-                        }
-                    }
-                }
-
-                // If daemon is alive but no signals and no workers doing anything, say so
-                if self.daemon_alive
+                if daemon_alive
                     && ws.signals.is_empty()
                     && ws.workers.iter().all(|w| {
                         let p = phase_display(w);
@@ -1460,7 +1411,6 @@ impl App {
                     });
                 }
 
-                // Sort by time descending (most recent first)
                 feed.sort_by(|a, b| b.when.cmp(&a.when));
                 feed.truncate(20);
                 ws.feed = feed;
@@ -1472,22 +1422,42 @@ impl App {
         self.needs_redraw = true;
     }
 
-    /// Check if periodic refreshes are due.
-    pub fn maybe_refresh(&mut self) {
-        let now = Instant::now();
-        if now.duration_since(self.last_worker_refresh).as_secs() >= 2 {
-            self.refresh_workers();
-            // Also refresh conversation when viewing a worker detail
-            if let View::WorkerDetail(idx) = self.view {
-                self.refresh_worker_conversation(idx);
+    /// Apply initial chat history loaded in background.
+    pub fn apply_chat_history(&mut self, data: Vec<(String, Vec<ChatLine>, Option<String>)>) {
+        for (name, history, preview) in data {
+            if let Some(ws) = self.workspaces.iter_mut().find(|ws| ws.name == name) {
+                // Only apply if chat history is still empty (or just has onboarding msg)
+                let only_onboarding = ws.chat_history.len() <= 1 && self.onboarding.active;
+                if ws.chat_history.is_empty() || only_onboarding {
+                    let onboarding_msg = if self.onboarding.active {
+                        ws.chat_history.pop()
+                    } else {
+                        None
+                    };
+                    ws.chat_history = history;
+                    if let Some(msg) = onboarding_msg {
+                        ws.chat_history.push(msg);
+                    }
+                    ws.coordinator_preview = preview;
+                    ws.chat_scroll.scroll_to_bottom();
+                }
             }
         }
-        if now.duration_since(self.last_signal_refresh).as_secs() >= 5 {
-            self.refresh_signals();
-        }
-        if now.duration_since(self.last_extras_refresh).as_secs() >= 10 {
-            self.refresh_extras();
-        }
+        self.needs_redraw = true;
+    }
+
+    /// Build refresh infos for background task from current workspace state.
+    pub fn build_refresh_infos(&self) -> Vec<WorkspaceRefreshInfo> {
+        self.workspaces
+            .iter()
+            .map(|ws| WorkspaceRefreshInfo {
+                name: ws.name.clone(),
+                root: ws.config.root.clone(),
+                has_github_watcher: ws.config.watchers.github.is_some(),
+                has_sentry_watcher: ws.config.watchers.sentry.is_some(),
+                has_swarm_watcher: ws.config.watchers.swarm.is_some(),
+            })
+            .collect()
     }
 
     // ── Helpers ───────────────────────────────────────────
@@ -1700,6 +1670,217 @@ fn truncate_preview(s: &str, max_chars: usize) -> String {
 /// Extract (repo, pr_number) from a review queue signal.
 /// Prefers metadata fields; falls back to parsing `external_id` (`rq-{repo}-{number}`).
 /// Returns `None` for non-GitHub review signals (e.g. Linear).
+// ── Blocking I/O for background tasks ─────────────────────
+
+/// Load workers for all workspaces (blocking filesystem reads).
+pub fn load_all_workers_blocking(infos: &[WorkspaceRefreshInfo]) -> Vec<(String, Vec<WorkerInfo>)> {
+    infos
+        .iter()
+        .map(|info| {
+            let state_path = info.root.join(".swarm/state.json");
+            let mut workers = load_workers_from_state(&state_path);
+            for worker in &mut workers {
+                worker.last_activity = load_last_activity(&info.root, &worker.id);
+            }
+            (info.name.clone(), workers)
+        })
+        .collect()
+}
+
+/// Load signals for all workspaces (blocking SQLite queries).
+pub fn load_all_signals_blocking(
+    db_path: &Path,
+    names: &[String],
+) -> Vec<(String, Vec<SignalRecord>)> {
+    names
+        .iter()
+        .map(|name| {
+            let signals = if let Ok(store) = SignalStore::open(db_path, name) {
+                store.get_open_signals().unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+            (name.clone(), signals)
+        })
+        .collect()
+}
+
+/// Load extras (sparkline, thoughts, watcher health, feed) for all workspaces.
+/// Returns (daemon_alive, daemon_uptime_secs, per-workspace extras).
+pub fn load_all_extras_blocking(
+    db_path: &Path,
+    pid_path: &Path,
+    infos: &[WorkspaceRefreshInfo],
+) -> (bool, Option<u64>, Vec<(String, WorkspaceExtrasData)>) {
+    let daemon_alive = crate::daemon::is_daemon_running();
+    let daemon_uptime_secs = if daemon_alive {
+        std::fs::metadata(pid_path)
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| std::time::SystemTime::now().duration_since(t).ok())
+            .map(|d| d.as_secs())
+    } else {
+        None
+    };
+
+    let per_workspace = infos
+        .iter()
+        .map(|info| {
+            let mut data = WorkspaceExtrasData {
+                sparkline_data: vec![0; 24],
+                watcher_health: Vec::new(),
+                thoughts: Vec::new(),
+                feed_items: Vec::new(),
+            };
+
+            if let Ok(store) = SignalStore::open(db_path, &info.name) {
+                // Sparkline
+                data.sparkline_data = store
+                    .count_signals_by_hour()
+                    .unwrap_or_else(|_| vec![0; 24]);
+
+                // Thoughts from MemoryStore
+                let mem = MemoryStore::new(store.conn(), &info.name);
+                data.thoughts = mem
+                    .get_recent(20)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|e| (e.category.as_str().to_string(), e.content))
+                    .collect();
+
+                // Watcher health
+                let now = Utc::now();
+                let cursor_map: std::collections::HashMap<String, String> = store
+                    .get_watcher_cursors()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect();
+                let configured: &[(&str, bool)] = &[
+                    ("github", info.has_github_watcher),
+                    ("sentry", info.has_sentry_watcher),
+                    ("swarm", info.has_swarm_watcher),
+                ];
+                for &(name, enabled) in configured {
+                    if !enabled {
+                        continue;
+                    }
+                    if let Some(updated_at) = cursor_map.get(name) {
+                        let dt = chrono::DateTime::parse_from_rfc3339(updated_at)
+                            .map(|d| d.with_timezone(&Utc))
+                            .unwrap_or(now);
+                        let age = now.signed_duration_since(dt);
+                        data.watcher_health.push(WatcherHealth {
+                            name: name.to_string(),
+                            healthy: age.num_minutes() < 5,
+                            last_check_secs: age.num_seconds(),
+                        });
+                    } else {
+                        data.watcher_health.push(WatcherHealth {
+                            name: name.to_string(),
+                            healthy: false,
+                            last_check_secs: -1,
+                        });
+                    }
+                }
+
+                // Feed: signal items
+                if let Ok(recent) = store.get_recent_signals(30) {
+                    let mut seen_ids = std::collections::HashSet::new();
+                    let mut seen_titles = std::collections::HashSet::new();
+                    for sig in recent {
+                        if !seen_ids.insert(sig.external_id.clone()) {
+                            continue;
+                        }
+                        let title_key: String = sig.title.chars().take(50).collect();
+                        if !seen_titles.insert(title_key) {
+                            continue;
+                        }
+                        data.feed_items.push(FeedItem {
+                            when: sig.updated_at,
+                            kind: FeedKind::Signal,
+                            text: sig.title.clone(),
+                        });
+                    }
+                }
+
+                // Feed: watcher heartbeats
+                if let Ok(cursors) = store.get_watcher_cursors() {
+                    for (watcher, updated_at_str) in &cursors {
+                        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(updated_at_str) {
+                            let dt_utc = dt.with_timezone(&Utc);
+                            data.feed_items.push(FeedItem {
+                                when: dt_utc,
+                                kind: FeedKind::Heartbeat,
+                                text: format!("{watcher} checked"),
+                            });
+                        }
+                    }
+                }
+            }
+
+            (info.name.clone(), data)
+        })
+        .collect();
+
+    (daemon_alive, daemon_uptime_secs, per_workspace)
+}
+
+/// Load chat history for all workspaces (blocking SQLite/JSONL reads).
+pub fn load_chat_history_blocking(
+    db_path: &Path,
+    workspace_names: &[String],
+) -> Vec<(String, Vec<ChatLine>, Option<String>)> {
+    workspace_names
+        .iter()
+        .map(|name| {
+            let chat_history: Vec<ChatLine> = if let Ok(store) = SignalStore::open(db_path, name) {
+                let conv = ConversationStore::new(store.conn(), name);
+                match conv.load_history(200) {
+                    Ok(rows) if !rows.is_empty() => rows
+                        .into_iter()
+                        .map(|row| {
+                            let ts = chrono::DateTime::parse_from_rfc3339(&row.created_at)
+                                .map(|dt| dt.format("%H:%M").to_string())
+                                .unwrap_or_default();
+                            let source = row.source.as_deref().map(|s| match s {
+                                "telegram" => MessageSource::Telegram,
+                                "system" => MessageSource::System,
+                                _ => MessageSource::Tui,
+                            });
+                            match row.role.as_str() {
+                                "user" => ChatLine::User(row.content, ts, source),
+                                _ => ChatLine::Assistant(row.content, ts, source),
+                            }
+                        })
+                        .collect(),
+                    _ => load_history_from_jsonl(name),
+                }
+            } else {
+                load_history_from_jsonl(name)
+            };
+
+            let coordinator_preview = chat_history.iter().rev().find_map(|msg| {
+                if let ChatLine::Assistant(s, _, _) = msg {
+                    Some(truncate_preview(s, 120))
+                } else {
+                    None
+                }
+            });
+
+            (name.clone(), chat_history, coordinator_preview)
+        })
+        .collect()
+}
+
+/// Load worker conversation entries from events.jsonl (blocking).
+pub fn load_worker_conversation_blocking(root: &Path, worker_id: &str) -> Vec<ConversationEntry> {
+    let events_path = root
+        .join(".swarm/agents")
+        .join(worker_id)
+        .join("events.jsonl");
+    apiari_tui::events_parser::parse_events(&events_path)
+}
+
 pub fn review_signal_target(signal: &SignalRecord) -> Option<(String, u64)> {
     if signal.source != "github_review_queue" {
         return None;

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -103,25 +103,25 @@ pub struct WatcherHealth {
 
 /// Info needed by the background refresh task for each workspace.
 #[derive(Clone)]
-pub struct WorkspaceRefreshInfo {
-    pub name: String,
-    pub root: std::path::PathBuf,
-    pub has_github_watcher: bool,
-    pub has_sentry_watcher: bool,
-    pub has_swarm_watcher: bool,
+pub(super) struct WorkspaceRefreshInfo {
+    pub(super) name: String,
+    pub(super) root: std::path::PathBuf,
+    pub(super) has_github_watcher: bool,
+    pub(super) has_sentry_watcher: bool,
+    pub(super) has_swarm_watcher: bool,
 }
 
 /// Data returned from background extras refresh (per workspace).
-pub struct WorkspaceExtrasData {
-    pub sparkline_data: Vec<u64>,
-    pub watcher_health: Vec<WatcherHealth>,
-    pub thoughts: Vec<(String, String)>,
+pub(super) struct WorkspaceExtrasData {
+    pub(super) sparkline_data: Vec<u64>,
+    pub(super) watcher_health: Vec<WatcherHealth>,
+    pub(super) thoughts: Vec<(String, String)>,
     /// Feed items from SQLite (signals + watcher heartbeats). Worker items merged by caller.
-    pub feed_items: Vec<FeedItem>,
+    pub(super) feed_items: Vec<FeedItem>,
 }
 
 /// Messages from background refresh tasks to the TUI event loop.
-pub enum AppUpdate {
+pub(super) enum AppUpdate {
     Workers(Vec<(String, Vec<WorkerInfo>)>),
     Signals(Vec<(String, Vec<SignalRecord>)>),
     Extras {
@@ -136,8 +136,8 @@ pub enum AppUpdate {
         remote_host: Option<String>,
     },
     WorkerConversation {
-        workspace_idx: usize,
-        worker_idx: usize,
+        workspace_name: String,
+        worker_id: String,
         entries: Vec<ConversationEntry>,
     },
 }
@@ -819,7 +819,8 @@ impl App {
             let events_path = ws
                 .config
                 .root
-                .join(".swarm/agents")
+                .join(".swarm")
+                .join("agents")
                 .join(&worker.id)
                 .join("events.jsonl");
             let new_entries = apiari_tui::events_parser::parse_events(&events_path);
@@ -1240,7 +1241,7 @@ impl App {
     }
 
     /// Apply worker data from background refresh.
-    pub fn apply_worker_update(&mut self, data: Vec<(String, Vec<WorkerInfo>)>) {
+    pub(super) fn apply_worker_update(&mut self, data: Vec<(String, Vec<WorkerInfo>)>) {
         for (name, new_workers) in data {
             if let Some(ws) = self.workspaces.iter_mut().find(|ws| ws.name == name) {
                 // Detect state changes and inject chat notifications
@@ -1312,7 +1313,7 @@ impl App {
     }
 
     /// Apply signal data from background refresh.
-    pub fn apply_signal_update(&mut self, data: Vec<(String, Vec<SignalRecord>)>) {
+    pub(super) fn apply_signal_update(&mut self, data: Vec<(String, Vec<SignalRecord>)>) {
         for (name, new_signals) in data {
             if let Some(ws) = self.workspaces.iter_mut().find(|ws| ws.name == name) {
                 let current_ids: std::collections::HashSet<i64> =
@@ -1358,7 +1359,7 @@ impl App {
     }
 
     /// Apply extras data from background refresh.
-    pub fn apply_extras_update(
+    pub(super) fn apply_extras_update(
         &mut self,
         daemon_alive: bool,
         daemon_uptime_secs: Option<u64>,
@@ -1423,7 +1424,10 @@ impl App {
     }
 
     /// Apply initial chat history loaded in background.
-    pub fn apply_chat_history(&mut self, data: Vec<(String, Vec<ChatLine>, Option<String>)>) {
+    pub(super) fn apply_chat_history(
+        &mut self,
+        data: Vec<(String, Vec<ChatLine>, Option<String>)>,
+    ) {
         for (name, history, preview) in data {
             if let Some(ws) = self.workspaces.iter_mut().find(|ws| ws.name == name) {
                 // Only apply if chat history is still empty (or just has onboarding msg)
@@ -1447,7 +1451,7 @@ impl App {
     }
 
     /// Build refresh infos for background task from current workspace state.
-    pub fn build_refresh_infos(&self) -> Vec<WorkspaceRefreshInfo> {
+    pub(super) fn build_refresh_infos(&self) -> Vec<WorkspaceRefreshInfo> {
         self.workspaces
             .iter()
             .map(|ws| WorkspaceRefreshInfo {
@@ -1670,7 +1674,9 @@ fn truncate_preview(s: &str, max_chars: usize) -> String {
 // ── Blocking I/O for background tasks ─────────────────────
 
 /// Load workers for all workspaces (blocking filesystem reads).
-pub fn load_all_workers_blocking(infos: &[WorkspaceRefreshInfo]) -> Vec<(String, Vec<WorkerInfo>)> {
+pub(super) fn load_all_workers_blocking(
+    infos: &[WorkspaceRefreshInfo],
+) -> Vec<(String, Vec<WorkerInfo>)> {
     infos
         .iter()
         .map(|info| {
@@ -1685,7 +1691,7 @@ pub fn load_all_workers_blocking(infos: &[WorkspaceRefreshInfo]) -> Vec<(String,
 }
 
 /// Load signals for all workspaces (blocking SQLite queries).
-pub fn load_all_signals_blocking(
+pub(super) fn load_all_signals_blocking(
     db_path: &Path,
     names: &[String],
 ) -> Vec<(String, Vec<SignalRecord>)> {
@@ -1704,7 +1710,7 @@ pub fn load_all_signals_blocking(
 
 /// Load extras (sparkline, thoughts, watcher health, feed) for all workspaces.
 /// Returns (daemon_alive, daemon_uptime_secs, per-workspace extras).
-pub fn load_all_extras_blocking(
+pub(super) fn load_all_extras_blocking(
     db_path: &Path,
     pid_path: &Path,
     infos: &[WorkspaceRefreshInfo],
@@ -1823,7 +1829,7 @@ pub fn load_all_extras_blocking(
 }
 
 /// Load chat history for all workspaces (blocking SQLite/JSONL reads).
-pub fn load_chat_history_blocking(
+pub(super) fn load_chat_history_blocking(
     db_path: &Path,
     workspace_names: &[String],
 ) -> Vec<(String, Vec<ChatLine>, Option<String>)> {
@@ -1870,9 +1876,13 @@ pub fn load_chat_history_blocking(
 }
 
 /// Load worker conversation entries from events.jsonl (blocking).
-pub fn load_worker_conversation_blocking(root: &Path, worker_id: &str) -> Vec<ConversationEntry> {
+pub(super) fn load_worker_conversation_blocking(
+    root: &Path,
+    worker_id: &str,
+) -> Vec<ConversationEntry> {
     let events_path = root
-        .join(".swarm/agents")
+        .join(".swarm")
+        .join("agents")
         .join(worker_id)
         .join("events.jsonl");
     apiari_tui::events_parser::parse_events(&events_path)
@@ -2016,5 +2026,102 @@ mod tests {
         let signal = make_signal("sentry", "sentry-42", None);
         let result = review_signal_target(&signal);
         assert_eq!(result, None);
+    }
+
+    // ── apply_chat_history tests ─────────────────────────────
+
+    fn make_test_workspace(name: &str) -> config::Workspace {
+        let config: config::WorkspaceConfig =
+            toml::from_str(&format!("root = '/tmp/{name}'")).unwrap();
+        config::Workspace {
+            name: name.to_string(),
+            config,
+        }
+    }
+
+    fn make_app(names: &[&str], needs_onboarding: bool) -> App {
+        let workspaces: Vec<config::Workspace> =
+            names.iter().map(|n| make_test_workspace(n)).collect();
+        App::new(workspaces, None, needs_onboarding)
+    }
+
+    #[test]
+    fn test_apply_chat_history_populates_empty_workspace() {
+        let mut app = make_app(&["ws1"], false);
+        assert!(app.workspaces[0].chat_history.is_empty());
+
+        let history = vec![
+            ChatLine::User("hello".into(), "12:00".into(), None),
+            ChatLine::Assistant("hi".into(), "12:01".into(), None),
+        ];
+        app.apply_chat_history(vec![("ws1".into(), history, Some("hi".into()))]);
+
+        assert_eq!(app.workspaces[0].chat_history.len(), 2);
+        assert_eq!(app.workspaces[0].coordinator_preview, Some("hi".into()));
+    }
+
+    #[test]
+    fn test_apply_chat_history_preserves_onboarding_message() {
+        let mut app = make_app(&["ws1"], true);
+        // Onboarding injects one message
+        assert_eq!(app.workspaces[0].chat_history.len(), 1);
+
+        let history = vec![ChatLine::User("old msg".into(), "11:00".into(), None)];
+        app.apply_chat_history(vec![("ws1".into(), history, None)]);
+
+        // Should have loaded history + preserved onboarding msg at end
+        assert_eq!(app.workspaces[0].chat_history.len(), 2);
+        // Last message should be the onboarding assistant message
+        assert!(matches!(
+            &app.workspaces[0].chat_history[1],
+            ChatLine::Assistant(_, _, _)
+        ));
+    }
+
+    #[test]
+    fn test_apply_chat_history_does_not_overwrite_user_chat() {
+        let mut app = make_app(&["ws1"], false);
+        // Simulate user already typing messages before background load completes
+        app.workspaces[0].chat_history.push(ChatLine::User(
+            "user typed this".into(),
+            "12:00".into(),
+            None,
+        ));
+        app.workspaces[0].chat_history.push(ChatLine::Assistant(
+            "bot replied".into(),
+            "12:01".into(),
+            None,
+        ));
+
+        let history = vec![ChatLine::User("old history".into(), "10:00".into(), None)];
+        app.apply_chat_history(vec![("ws1".into(), history, None)]);
+
+        // Should NOT overwrite — still has the 2 user messages
+        assert_eq!(app.workspaces[0].chat_history.len(), 2);
+        if let ChatLine::User(content, _, _) = &app.workspaces[0].chat_history[0] {
+            assert_eq!(content, "user typed this");
+        } else {
+            panic!("expected user message");
+        }
+    }
+
+    #[test]
+    fn test_apply_chat_history_inactive_onboarding_empty_workspace() {
+        let mut app = make_app(&["ws1"], false);
+        assert!(!app.onboarding.active);
+        assert!(app.workspaces[0].chat_history.is_empty());
+
+        let history = vec![ChatLine::Assistant(
+            "welcome back".into(),
+            "09:00".into(),
+            None,
+        )];
+        app.apply_chat_history(vec![("ws1".into(), history, Some("welcome back".into()))]);
+
+        assert_eq!(app.workspaces[0].chat_history.len(), 1);
+        assert_eq!(
+            app.workspaces[0].coordinator_preview,
+            Some("welcome back".into())
+        );
     }
 }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1667,9 +1667,6 @@ fn truncate_preview(s: &str, max_chars: usize) -> String {
     }
 }
 
-/// Extract (repo, pr_number) from a review queue signal.
-/// Prefers metadata fields; falls back to parsing `external_id` (`rq-{repo}-{number}`).
-/// Returns `None` for non-GitHub review signals (e.g. Linear).
 // ── Blocking I/O for background tasks ─────────────────────
 
 /// Load workers for all workspaces (blocking filesystem reads).
@@ -1881,6 +1878,9 @@ pub fn load_worker_conversation_blocking(root: &Path, worker_id: &str) -> Vec<Co
     apiari_tui::events_parser::parse_events(&events_path)
 }
 
+/// Extract (repo, pr_number) from a review queue signal.
+/// Prefers metadata fields; falls back to parsing `external_id` (`rq-{repo}-{number}`).
+/// Returns `None` for non-GitHub review signals (e.g. Linear).
 pub fn review_signal_target(signal: &SignalRecord) -> Option<(String, u64)> {
     if signal.source != "github_review_queue" {
         return None;

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -158,13 +158,13 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
         let coord_tx_clone = coord_tx.clone();
         tokio::spawn(async move {
             // Auto-start daemon if not running
-            if !crate::daemon::is_daemon_running() {
-                if let Ok(()) = crate::daemon::spawn_background() {
-                    for _ in 0..20 {
-                        tokio::time::sleep(Duration::from_millis(250)).await;
-                        if daemon_client::socket_exists() && crate::daemon::is_daemon_running() {
-                            break;
-                        }
+            if !crate::daemon::is_daemon_running()
+                && let Ok(()) = crate::daemon::spawn_background()
+            {
+                for _ in 0..20 {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                    if daemon_client::socket_exists() && crate::daemon::is_daemon_running() {
+                        break;
                     }
                 }
             }
@@ -326,23 +326,22 @@ async fn event_loop(
                     AppUpdate::Workers(data) => {
                         app.apply_worker_update(data);
                         // Refresh conversation in background when viewing worker detail
-                        if let View::WorkerDetail(idx) = app.view {
-                            if let Some(ws) = app.current_ws() {
-                                if let Some(worker) = ws.workers.get(idx) {
-                                    let root = ws.config.root.clone();
-                                    let worker_id = worker.id.clone();
-                                    let ws_idx = app.active_tab;
-                                    let tx = update_tx.clone();
-                                    tokio::task::spawn_blocking(move || {
-                                        let entries = app::load_worker_conversation_blocking(&root, &worker_id);
-                                        let _ = tx.blocking_send(AppUpdate::WorkerConversation {
-                                            workspace_idx: ws_idx,
-                                            worker_idx: idx,
-                                            entries,
-                                        });
-                                    });
-                                }
-                            }
+                        if let View::WorkerDetail(idx) = app.view
+                            && let Some(ws) = app.current_ws()
+                            && let Some(worker) = ws.workers.get(idx)
+                        {
+                            let root = ws.config.root.clone();
+                            let worker_id = worker.id.clone();
+                            let ws_idx = app.active_tab;
+                            let tx = update_tx.clone();
+                            tokio::task::spawn_blocking(move || {
+                                let entries = app::load_worker_conversation_blocking(&root, &worker_id);
+                                let _ = tx.blocking_send(AppUpdate::WorkerConversation {
+                                    workspace_idx: ws_idx,
+                                    worker_idx: idx,
+                                    entries,
+                                });
+                            });
                         }
                     }
                     AppUpdate::Signals(data) => {
@@ -363,13 +362,13 @@ async fn event_loop(
                         app.needs_redraw = true;
                     }
                     AppUpdate::WorkerConversation { workspace_idx, worker_idx, entries } => {
-                        if let Some(ws) = app.workspaces.get_mut(workspace_idx) {
-                            if let Some(worker) = ws.workers.get_mut(worker_idx) {
-                                let had = worker.conversation.len();
-                                worker.conversation = entries;
-                                if worker.conversation.len() > had {
-                                    worker.conv_scroll.scroll_to_bottom();
-                                }
+                        if let Some(ws) = app.workspaces.get_mut(workspace_idx)
+                            && let Some(worker) = ws.workers.get_mut(worker_idx)
+                        {
+                            let had = worker.conversation.len();
+                            worker.conversation = entries;
+                            if worker.conversation.len() > had {
+                                worker.conv_scroll.scroll_to_bottom();
                             }
                         }
                         app.needs_redraw = true;

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -8,7 +8,7 @@ pub mod render;
 pub mod settings;
 pub mod theme;
 
-use app::{App, Mode, Panel, PendingAction, View, review_signal_target};
+use app::{App, AppUpdate, Mode, Panel, PendingAction, View, review_signal_target};
 use color_eyre::Result;
 use crossterm::ExecutableCommand;
 use crossterm::event::{Event, EventStream, KeyCode, KeyModifiers};
@@ -99,83 +99,18 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
     let (user_tx, user_rx) = mpsc::channel::<UserMessage>(32);
     let (coord_tx, coord_rx) = mpsc::channel::<CoordResponse>(64);
 
+    // Background refresh channels
+    let (update_tx, update_rx) = mpsc::channel::<AppUpdate>(64);
+
     // Detect remote workspace before auto-start so we skip local daemon spawn.
     let focused = app.current_ws();
     let remote_endpoints = focused
         .map(|ws| ws.config.resolved_daemon_endpoints())
         .unwrap_or_default();
     let is_remote = !remote_endpoints.is_empty();
-
-    // Auto-start daemon if not running (skip for remote workspaces — they
-    // connect to a daemon running on the remote host).
-    if !is_remote && !crate::daemon::is_daemon_running() {
-        eprintln!("Starting daemon in the background...");
-        if let Err(e) = crate::daemon::spawn_background() {
-            eprintln!("Warning: failed to start daemon: {e}");
-        } else {
-            // Wait for the daemon to create the socket
-            for _ in 0..20 {
-                tokio::time::sleep(Duration::from_millis(250)).await;
-                if daemon_client::socket_exists() && crate::daemon::is_daemon_running() {
-                    break;
-                }
-            }
-        }
-    }
-
-    // Choose daemon client (shared session) or local coordinator (standalone).
-    let use_daemon = if is_remote {
-        true // remote always uses daemon client
-    } else {
-        daemon_client::socket_exists() && crate::daemon::is_daemon_running()
-    };
-    // For remote: daemon_connected starts false until TCP actually succeeds.
-    app.daemon_connected = if is_remote { false } else { use_daemon };
     app.daemon_remote = is_remote;
 
-    if is_remote {
-        // Remote daemon — connect via TCP with endpoint fallback.
-        // The oneshot reports the connected host (or None on failure).
-        // We update daemon_connected + remote_host once the result arrives,
-        // but cap the wait so the TUI isn't blocked indefinitely.
-        let coord_tx_clone = coord_tx.clone();
-        let (host_tx, host_rx) = tokio::sync::oneshot::channel();
-        tokio::spawn(daemon_client_task_tcp(
-            remote_endpoints,
-            user_rx,
-            coord_tx_clone,
-            host_tx,
-        ));
-        // Wait up to 3s for the connection result so the status bar is accurate
-        // on first render, but don't block startup forever.
-        match tokio::time::timeout(Duration::from_secs(3), host_rx).await {
-            Ok(Ok(Some(host))) => {
-                app.daemon_connected = true;
-                app.remote_host = Some(host);
-            }
-            Ok(Ok(None)) => {
-                // All endpoints failed — daemon_connected stays false.
-            }
-            _ => {
-                // Timeout or channel dropped — proceed without host info.
-            }
-        }
-    } else if use_daemon {
-        // Spawn daemon client task (tokio task — the daemon handles coordinator)
-        let coord_tx_clone = coord_tx.clone();
-        tokio::spawn(daemon_client_task(user_rx, coord_tx_clone));
-    } else {
-        // Spawn coordinator on a dedicated thread (SignalStore is !Send).
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("failed to build coordinator runtime");
-            rt.block_on(coordinator_task(user_rx, coord_tx));
-        });
-    }
-
-    // Terminal setup
+    // Terminal setup FIRST — don't block on daemon before the user sees anything.
     stdout().execute(EnterAlternateScreen)?;
     stdout().execute(crossterm::event::EnableMouseCapture)?;
     enable_raw_mode()?;
@@ -192,7 +127,84 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
         original_hook(info);
     }));
 
-    let result = event_loop(&mut terminal, app, &user_tx, coord_rx).await;
+    // Spawn daemon startup + coordinator connection in background.
+    // The TUI renders immediately with empty state; daemon status arrives
+    // via AppUpdate::DaemonStatus once the connection is established.
+    let startup_update_tx = update_tx.clone();
+    if is_remote {
+        let coord_tx_clone = coord_tx.clone();
+        tokio::spawn(async move {
+            let (host_tx, host_rx) = tokio::sync::oneshot::channel();
+            tokio::spawn(daemon_client_task_tcp(
+                remote_endpoints,
+                user_rx,
+                coord_tx_clone,
+                host_tx,
+            ));
+            let (connected, host) =
+                match tokio::time::timeout(Duration::from_secs(3), host_rx).await {
+                    Ok(Ok(Some(host))) => (true, Some(host)),
+                    _ => (false, None),
+                };
+            let _ = startup_update_tx
+                .send(AppUpdate::DaemonStatus {
+                    connected,
+                    alive: connected,
+                    remote_host: host,
+                })
+                .await;
+        });
+    } else {
+        let coord_tx_clone = coord_tx.clone();
+        tokio::spawn(async move {
+            // Auto-start daemon if not running
+            if !crate::daemon::is_daemon_running() {
+                if let Ok(()) = crate::daemon::spawn_background() {
+                    for _ in 0..20 {
+                        tokio::time::sleep(Duration::from_millis(250)).await;
+                        if daemon_client::socket_exists() && crate::daemon::is_daemon_running() {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            let use_daemon = daemon_client::socket_exists() && crate::daemon::is_daemon_running();
+            let _ = startup_update_tx
+                .send(AppUpdate::DaemonStatus {
+                    connected: use_daemon,
+                    alive: use_daemon,
+                    remote_host: None,
+                })
+                .await;
+
+            if use_daemon {
+                daemon_client_task(user_rx, coord_tx_clone).await;
+            } else {
+                // Spawn coordinator on a dedicated thread (SignalStore is !Send).
+                std::thread::spawn(move || {
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .expect("failed to build coordinator runtime");
+                    rt.block_on(coordinator_task(user_rx, coord_tx_clone));
+                });
+            }
+        });
+    }
+
+    // Spawn background refresh task (workers, signals, extras, chat history).
+    let refresh_infos = app.build_refresh_infos();
+    let db_path = config::db_path();
+    let pid_path = config::pid_path();
+    tokio::spawn(background_refresh_task(
+        update_tx.clone(),
+        refresh_infos,
+        db_path,
+        pid_path,
+    ));
+
+    let result = event_loop(&mut terminal, app, &user_tx, coord_rx, update_rx, update_tx).await;
 
     // Terminal teardown
     disable_raw_mode()?;
@@ -209,6 +221,8 @@ async fn event_loop(
     mut app: App,
     user_tx: &mpsc::Sender<UserMessage>,
     mut coord_rx: mpsc::Receiver<CoordResponse>,
+    mut update_rx: mpsc::Receiver<AppUpdate>,
+    update_tx: mpsc::Sender<AppUpdate>,
 ) -> Result<()> {
     let mut events = EventStream::new();
     let mut tick = tokio::time::interval(Duration::from_millis(250));
@@ -307,6 +321,62 @@ async fn event_loop(
                 }
             }
 
+            Some(update) = update_rx.recv() => {
+                match update {
+                    AppUpdate::Workers(data) => {
+                        app.apply_worker_update(data);
+                        // Refresh conversation in background when viewing worker detail
+                        if let View::WorkerDetail(idx) = app.view {
+                            if let Some(ws) = app.current_ws() {
+                                if let Some(worker) = ws.workers.get(idx) {
+                                    let root = ws.config.root.clone();
+                                    let worker_id = worker.id.clone();
+                                    let ws_idx = app.active_tab;
+                                    let tx = update_tx.clone();
+                                    tokio::task::spawn_blocking(move || {
+                                        let entries = app::load_worker_conversation_blocking(&root, &worker_id);
+                                        let _ = tx.blocking_send(AppUpdate::WorkerConversation {
+                                            workspace_idx: ws_idx,
+                                            worker_idx: idx,
+                                            entries,
+                                        });
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    AppUpdate::Signals(data) => {
+                        app.apply_signal_update(data);
+                    }
+                    AppUpdate::Extras { daemon_alive, daemon_uptime_secs, per_workspace } => {
+                        app.apply_extras_update(daemon_alive, daemon_uptime_secs, per_workspace);
+                    }
+                    AppUpdate::ChatHistory(data) => {
+                        app.apply_chat_history(data);
+                    }
+                    AppUpdate::DaemonStatus { connected, alive, remote_host } => {
+                        app.daemon_connected = connected;
+                        app.daemon_alive = alive;
+                        if remote_host.is_some() {
+                            app.remote_host = remote_host;
+                        }
+                        app.needs_redraw = true;
+                    }
+                    AppUpdate::WorkerConversation { workspace_idx, worker_idx, entries } => {
+                        if let Some(ws) = app.workspaces.get_mut(workspace_idx) {
+                            if let Some(worker) = ws.workers.get_mut(worker_idx) {
+                                let had = worker.conversation.len();
+                                worker.conversation = entries;
+                                if worker.conversation.len() > had {
+                                    worker.conv_scroll.scroll_to_bottom();
+                                }
+                            }
+                        }
+                        app.needs_redraw = true;
+                    }
+                }
+            }
+
             _ = tick.tick() => {
                 app.spinner_tick = app.spinner_tick.wrapping_add(1);
 
@@ -334,7 +404,8 @@ async fn event_loop(
                 app.push_activity_value(val);
 
                 app.tick_flash();
-                app.maybe_refresh();
+                // Periodic refresh handled by background_refresh_task — no
+                // blocking I/O on the event thread.
                 app.needs_redraw = true;
             }
         }
@@ -1346,6 +1417,102 @@ async fn handle_action(
     }
     app.needs_redraw = true;
     None
+}
+
+// ── Background refresh task ──────────────────────────────
+
+/// Runs periodic data refreshes on background threads, sending results
+/// back to the TUI event loop via `AppUpdate` messages. All blocking I/O
+/// (filesystem reads, SQLite queries) happens inside `spawn_blocking`.
+async fn background_refresh_task(
+    update_tx: mpsc::Sender<AppUpdate>,
+    workspace_infos: Vec<app::WorkspaceRefreshInfo>,
+    db_path: std::path::PathBuf,
+    pid_path: std::path::PathBuf,
+) {
+    // Load initial chat history
+    {
+        let db = db_path.clone();
+        let names: Vec<String> = workspace_infos.iter().map(|i| i.name.clone()).collect();
+        let tx = update_tx.clone();
+        tokio::task::spawn_blocking(move || {
+            let history = app::load_chat_history_blocking(&db, &names);
+            let _ = tx.blocking_send(AppUpdate::ChatHistory(history));
+        });
+    }
+
+    // Do initial data refresh immediately
+    do_worker_refresh(&update_tx, &workspace_infos).await;
+    do_signal_refresh(&update_tx, &workspace_infos, &db_path).await;
+    do_extras_refresh(&update_tx, &workspace_infos, &db_path, &pid_path).await;
+
+    let mut worker_interval = tokio::time::interval(Duration::from_secs(2));
+    let mut signal_interval = tokio::time::interval(Duration::from_secs(5));
+    let mut extras_interval = tokio::time::interval(Duration::from_secs(10));
+
+    // Skip first ticks (already did initial refresh above)
+    worker_interval.tick().await;
+    signal_interval.tick().await;
+    extras_interval.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = worker_interval.tick() => {
+                do_worker_refresh(&update_tx, &workspace_infos).await;
+            }
+            _ = signal_interval.tick() => {
+                do_signal_refresh(&update_tx, &workspace_infos, &db_path).await;
+            }
+            _ = extras_interval.tick() => {
+                do_extras_refresh(&update_tx, &workspace_infos, &db_path, &pid_path).await;
+            }
+        }
+    }
+}
+
+async fn do_worker_refresh(tx: &mpsc::Sender<AppUpdate>, infos: &[app::WorkspaceRefreshInfo]) {
+    let infos = infos.to_vec();
+    if let Ok(result) =
+        tokio::task::spawn_blocking(move || app::load_all_workers_blocking(&infos)).await
+    {
+        let _ = tx.send(AppUpdate::Workers(result)).await;
+    }
+}
+
+async fn do_signal_refresh(
+    tx: &mpsc::Sender<AppUpdate>,
+    infos: &[app::WorkspaceRefreshInfo],
+    db_path: &std::path::Path,
+) {
+    let db = db_path.to_path_buf();
+    let names: Vec<String> = infos.iter().map(|i| i.name.clone()).collect();
+    if let Ok(result) =
+        tokio::task::spawn_blocking(move || app::load_all_signals_blocking(&db, &names)).await
+    {
+        let _ = tx.send(AppUpdate::Signals(result)).await;
+    }
+}
+
+async fn do_extras_refresh(
+    tx: &mpsc::Sender<AppUpdate>,
+    infos: &[app::WorkspaceRefreshInfo],
+    db_path: &std::path::Path,
+    pid_path: &std::path::Path,
+) {
+    let infos = infos.to_vec();
+    let db = db_path.to_path_buf();
+    let pid = pid_path.to_path_buf();
+    if let Ok((daemon_alive, daemon_uptime_secs, per_workspace)) =
+        tokio::task::spawn_blocking(move || app::load_all_extras_blocking(&db, &pid, &infos)).await
+    {
+        let _ = tx
+            .send(AppUpdate::Extras {
+                daemon_alive,
+                daemon_uptime_secs,
+                per_workspace,
+            })
+            .await;
+    }
 }
 
 // ── Daemon client task ───────────────────────────────────

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -332,13 +332,13 @@ async fn event_loop(
                         {
                             let root = ws.config.root.clone();
                             let worker_id = worker.id.clone();
-                            let ws_idx = app.active_tab;
+                            let ws_name = ws.name.clone();
                             let tx = update_tx.clone();
                             tokio::task::spawn_blocking(move || {
                                 let entries = app::load_worker_conversation_blocking(&root, &worker_id);
                                 let _ = tx.blocking_send(AppUpdate::WorkerConversation {
-                                    workspace_idx: ws_idx,
-                                    worker_idx: idx,
+                                    workspace_name: ws_name,
+                                    worker_id,
                                     entries,
                                 });
                             });
@@ -361,9 +361,9 @@ async fn event_loop(
                         }
                         app.needs_redraw = true;
                     }
-                    AppUpdate::WorkerConversation { workspace_idx, worker_idx, entries } => {
-                        if let Some(ws) = app.workspaces.get_mut(workspace_idx)
-                            && let Some(worker) = ws.workers.get_mut(worker_idx)
+                    AppUpdate::WorkerConversation { workspace_name, worker_id, entries } => {
+                        if let Some(ws) = app.workspaces.iter_mut().find(|ws| ws.name == workspace_name)
+                            && let Some(worker) = ws.workers.iter_mut().find(|w| w.id == worker_id)
                         {
                             let had = worker.conversation.len();
                             worker.conversation = entries;
@@ -1446,8 +1446,11 @@ async fn background_refresh_task(
     do_extras_refresh(&update_tx, &workspace_infos, &db_path, &pid_path).await;
 
     let mut worker_interval = tokio::time::interval(Duration::from_secs(2));
+    worker_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut signal_interval = tokio::time::interval(Duration::from_secs(5));
+    signal_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut extras_interval = tokio::time::interval(Duration::from_secs(10));
+    extras_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     // Skip first ticks (already did initial refresh above)
     worker_interval.tick().await;
@@ -1455,6 +1458,9 @@ async fn background_refresh_task(
     extras_interval.tick().await;
 
     loop {
+        if update_tx.is_closed() {
+            break;
+        }
         tokio::select! {
             _ = worker_interval.tick() => {
                 do_worker_refresh(&update_tx, &workspace_infos).await;


### PR DESCRIPTION
## Summary

- **Moves all periodic refresh I/O off the async event loop** — filesystem reads (`state.json`, `events.jsonl`) and SQLite queries (`SignalStore`, `MemoryStore`, `ConversationStore`) now run in `tokio::task::spawn_blocking` inside a dedicated background refresh task
- **Eliminates startup blank screen** — terminal enters alternate screen immediately, daemon startup (up to 5s socket wait) happens in background; TUI renders with empty state while connecting
- **`App::new()` does zero I/O** — chat history, workers, signals, and extras all load asynchronously via `AppUpdate` channel messages

## Root causes fixed

1. `maybe_refresh()` called every 250ms tick inside `tokio::select!` — ran blocking `std::fs::read_to_string()` and SQLite queries directly on the event thread, stalling keyboard input and rendering
2. TUI launch blocked by daemon wait loop (up to 5s) before terminal was even initialized
3. `App::new()` did synchronous SQLite/filesystem I/O before first render

## Architecture

```
background_refresh_task (tokio task)
  ├─ workers refresh (spawn_blocking) ─── every 2s ──→ AppUpdate::Workers
  ├─ signals refresh (spawn_blocking) ─── every 5s ──→ AppUpdate::Signals
  ├─ extras refresh  (spawn_blocking) ─── every 10s ─→ AppUpdate::Extras
  └─ chat history    (spawn_blocking) ─── once ──────→ AppUpdate::ChatHistory

event_loop (main thread)
  ├─ crossterm events (keyboard, mouse, resize)
  ├─ coordinator responses (Token, Done, Error, Activity)
  ├─ AppUpdate messages (non-blocking recv) ← applies to App state
  └─ tick (250ms) — animation only, no I/O
```

State change detection (new workers, phase changes, new signals, PR opens) preserved in `apply_worker_update()` / `apply_signal_update()` methods.

## Test plan

- [x] All 369 existing tests pass
- [x] `cargo check -p apiari` clean (zero warnings)
- [x] `cargo check -p hive` clean
- [ ] Manual test: TUI renders immediately on startup (no blank screen)
- [ ] Manual test: keyboard input remains responsive during refresh cycles
- [ ] Manual test: worker/signal/feed data loads and updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)