### PR TITLE
fix: auto-wrap long lines in TUI chat input boxes

### DIFF
--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -301,6 +301,9 @@ async fn event_loop(
                         }
                     }
                     Some(Ok(Event::Paste(text))) => {
+                        if settings_state.is_some() {
+                            continue;
+                        }
                         handle_paste(&mut app, &text);
                     }
                     Some(Ok(Event::Resize(_, _))) => {

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -113,6 +113,7 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
     // Terminal setup FIRST — don't block on daemon before the user sees anything.
     stdout().execute(EnterAlternateScreen)?;
     stdout().execute(crossterm::event::EnableMouseCapture)?;
+    stdout().execute(crossterm::event::EnableBracketedPaste)?;
     enable_raw_mode()?;
 
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
@@ -122,6 +123,7 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = disable_raw_mode();
+        let _ = stdout().execute(crossterm::event::DisableBracketedPaste);
         let _ = stdout().execute(crossterm::event::DisableMouseCapture);
         let _ = stdout().execute(LeaveAlternateScreen);
         original_hook(info);
@@ -208,6 +210,7 @@ pub async fn run(focus_workspace: Option<&str>) -> Result<()> {
 
     // Terminal teardown
     disable_raw_mode()?;
+    stdout().execute(crossterm::event::DisableBracketedPaste)?;
     stdout().execute(crossterm::event::DisableMouseCapture)?;
     stdout().execute(LeaveAlternateScreen)?;
 
@@ -296,6 +299,9 @@ async fn event_loop(
                             }
                             _ => {}
                         }
+                    }
+                    Some(Ok(Event::Paste(text))) => {
+                        handle_paste(&mut app, &text);
                     }
                     Some(Ok(Event::Resize(_, _))) => {
                         app.needs_redraw = true;
@@ -534,6 +540,22 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
         View::ReviewList => handle_review_list_key(app, key),
         View::PrList => handle_pr_list_key(app, key),
     }
+}
+
+// ── Paste handling ───────────────────────────────────────
+
+/// Handle a bracketed paste event by inserting the text into the active input.
+fn handle_paste(app: &mut App, text: &str) {
+    if app.chat_focused {
+        if let Some(ws) = app.current_ws_mut() {
+            ws.input.push_str(text);
+        }
+    } else if app.worker_input_active {
+        app.worker_input.push_str(text);
+    } else if app.review_comment_active {
+        app.review_comment_input.push_str(text);
+    }
+    app.needs_redraw = true;
 }
 
 // ── Dashboard keys ───────────────────────────────────────
@@ -887,21 +909,26 @@ fn handle_worker_input_key(
 ) -> KeyAction {
     match key.code {
         KeyCode::Enter => {
-            let text = std::mem::take(&mut app.worker_input);
-            if !text.trim().is_empty()
-                && let Some(ws) = app.current_ws()
-                && let Some(worker) = ws.workers.get(idx)
-            {
-                let id = worker.id.clone();
+            if key.modifiers.contains(KeyModifiers::ALT) {
+                app.worker_input.push('\n');
+                app.needs_redraw = true;
+            } else {
+                let text = std::mem::take(&mut app.worker_input);
+                if !text.trim().is_empty()
+                    && let Some(ws) = app.current_ws()
+                    && let Some(worker) = ws.workers.get(idx)
+                {
+                    let id = worker.id.clone();
+                    app.worker_input_active = false;
+                    app.needs_redraw = true;
+                    return KeyAction::SendWorkerMessage {
+                        worker_id: id,
+                        text,
+                    };
+                }
                 app.worker_input_active = false;
                 app.needs_redraw = true;
-                return KeyAction::SendWorkerMessage {
-                    worker_id: id,
-                    text,
-                };
             }
-            app.worker_input_active = false;
-            app.needs_redraw = true;
         }
         KeyCode::Esc => {
             app.worker_input.clear();

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -18,21 +18,18 @@ const SPINNER: &[&str] = &["|", "/", "-", "\\"];
 
 /// Calculate the number of visual rows needed for input text with wrapping.
 /// `text` is the raw input (may contain newlines), `width` is the available
-/// display width. Accounts for the leading space and trailing cursor char
-/// that are added when rendering (` {text}_`).
+/// display width. Builds the exact rendered string (` {text}_`) and uses
+/// display width for correct Unicode/emoji handling.
 fn visual_input_rows(text: &str, width: u16) -> u16 {
     let w = width as usize;
     if w == 0 {
         return 1;
     }
-    let lines: Vec<&str> = text.split('\n').collect();
-    let last_idx = lines.len().saturating_sub(1);
+    let rendered = format!(" {text}_");
     let mut total: usize = 0;
-    for (i, line) in lines.iter().enumerate() {
-        // Rendered as " {line}" on non-last lines, " {line}_" on last line
-        let extra = if i == last_idx { 2 } else { 1 }; // leading space + optional cursor
-        let len = line.len() + extra;
-        total += len.div_ceil(w);
+    for segment in rendered.split('\n') {
+        let display_w = Line::from(segment).width();
+        total += display_w.max(1).div_ceil(w);
     }
     total.max(1) as u16
 }
@@ -844,11 +841,10 @@ fn draw_chat_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area:
     // Input height (inside the bordered panel)
     let input_h = if app.chat_focused {
         // Account for visual line wrapping, not just explicit newlines.
-        // The input block has a TOP border (1 row), so subtract that as separator.
         // area.width - 2 accounts for the panel's left+right borders.
         let avail_w = area.width.saturating_sub(2);
         let rows = visual_input_rows(&ws.input, avail_w);
-        rows.clamp(1, 6) + 1 // +1 for separator (top border on input block)
+        rows.clamp(1, 6) + 1 // +1 to include the top-border separator row
     } else {
         1 // just the hint line
     };

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -32,7 +32,7 @@ fn visual_input_rows(text: &str, width: u16) -> u16 {
         // Rendered as " {line}" on non-last lines, " {line}_" on last line
         let extra = if i == last_idx { 2 } else { 1 }; // leading space + optional cursor
         let len = line.len() + extra;
-        total += (len + w - 1) / w; // ceil division
+        total += len.div_ceil(w);
     }
     total.max(1) as u16
 }

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -1608,7 +1608,7 @@ fn draw_worker_detail(frame: &mut Frame, app: &App, area: Rect, idx: usize) {
         0
     };
 
-    // Layout: header (1) + conversation (fill) + input (0 or 3)
+    // Layout: header (1) + conversation (fill) + input (input_h, 0 when inactive)
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -16,6 +16,27 @@ use super::theme;
 
 const SPINNER: &[&str] = &["|", "/", "-", "\\"];
 
+/// Calculate the number of visual rows needed for input text with wrapping.
+/// `text` is the raw input (may contain newlines), `width` is the available
+/// display width. Accounts for the leading space and trailing cursor char
+/// that are added when rendering (` {text}_`).
+fn visual_input_rows(text: &str, width: u16) -> u16 {
+    let w = width as usize;
+    if w == 0 {
+        return 1;
+    }
+    let lines: Vec<&str> = text.split('\n').collect();
+    let last_idx = lines.len().saturating_sub(1);
+    let mut total: usize = 0;
+    for (i, line) in lines.iter().enumerate() {
+        // Rendered as " {line}" on non-last lines, " {line}_" on last line
+        let extra = if i == last_idx { 2 } else { 1 }; // leading space + optional cursor
+        let len = line.len() + extra;
+        total += (len + w - 1) / w; // ceil division
+    }
+    total.max(1) as u16
+}
+
 // ── Main draw ────────────────────────────────────────────
 
 pub fn draw(frame: &mut Frame, app: &App) {
@@ -822,8 +843,12 @@ fn draw_chat_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area:
 
     // Input height (inside the bordered panel)
     let input_h = if app.chat_focused {
-        let line_count = ws.input.matches('\n').count() + 1;
-        (line_count as u16).clamp(1, 4) + 1 // +1 for separator
+        // Account for visual line wrapping, not just explicit newlines.
+        // The input block has a TOP border (1 row), so subtract that as separator.
+        // area.width - 2 accounts for the panel's left+right borders.
+        let avail_w = area.width.saturating_sub(2);
+        let rows = visual_input_rows(&ws.input, avail_w);
+        rows.clamp(1, 6) + 1 // +1 for separator (top border on input block)
     } else {
         1 // just the hint line
     };
@@ -1578,8 +1603,14 @@ fn draw_worker_detail(frame: &mut Frame, app: &App, area: Rect, idx: usize) {
         _ => ("\u{25cb}", theme::status_idle()),
     };
 
-    // Input bar height
-    let input_h: u16 = if app.worker_input_active { 3 } else { 0 };
+    // Input bar height — account for visual line wrapping
+    let input_h: u16 = if app.worker_input_active {
+        let avail_w = area.width;
+        let rows = visual_input_rows(&app.worker_input, avail_w);
+        rows.clamp(1, 6) + 1 // +1 for top border separator
+    } else {
+        0
+    };
 
     // Layout: header (1) + conversation (fill) + input (0 or 3)
     let chunks = Layout::default()


### PR DESCRIPTION
## Summary
- Fixed chat panel and worker detail input boxes to calculate height based on visual line wrapping, not just explicit newline characters
- Added `visual_input_rows()` helper that computes wrapped row count accounting for the leading space and cursor character in rendered input text
- Input areas now grow dynamically up to 6 rows as text wraps, preventing long lines from overflowing off screen

## Test plan
- [ ] Type a long line (no Option+Enter) in the chat input — box should grow as text wraps
- [ ] Type multiple lines with Option+Enter — box should still grow correctly
- [ ] Verify worker detail input box also auto-wraps long lines
- [ ] Resize terminal to narrow width — input should recalculate wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)