### PR TITLE
feat: add heartbeat signal filtering + debug mode

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -398,6 +398,8 @@ pub struct App {
     pub activity_buf: Vec<u8>, // fixed array, each value = bar height 0-7
     // Snooze
     pub snooze_selection: usize,
+    // Signal filtering
+    pub signals_debug_mode: bool,
     // Onboarding
     pub onboarding: OnboardingState,
     // Common
@@ -496,6 +498,7 @@ impl App {
             terminal_width: 80,
             activity_buf: vec![0; 18],
             snooze_selection: 0,
+            signals_debug_mode: false,
             onboarding,
             pending_action: None,
             flash: None,
@@ -691,6 +694,7 @@ impl App {
             ws.signals
                 .iter()
                 .filter(|s| s.source != "github_review_queue")
+                .filter(|s| self.signals_debug_mode || !is_noise_signal(s))
                 .count()
         })
     }
@@ -713,6 +717,7 @@ impl App {
                     ws.signals
                         .iter()
                         .filter(|s| s.source != "github_review_queue")
+                        .filter(|s| self.signals_debug_mode || !is_noise_signal(s))
                         .count(),
                     ws.signals
                         .iter()
@@ -845,11 +850,13 @@ impl App {
                 }
             }
             Panel::Signals => {
+                let debug = self.signals_debug_mode;
                 let orig_idx = self.current_ws().and_then(|ws| {
                     ws.signals
                         .iter()
                         .enumerate()
                         .filter(|(_, s)| s.source != "github_review_queue")
+                        .filter(|(_, s)| debug || !is_noise_signal(s))
                         .map(|(i, _)| i)
                         .nth(self.signal_selection)
                 });
@@ -1494,6 +1501,7 @@ impl App {
                         .signals
                         .iter()
                         .filter(|s| s.source != "github_review_queue")
+                        .filter(|s| self.signals_debug_mode || !is_noise_signal(s))
                         .nth(self.signal_selection)
                 } else if self.focused_panel == Panel::Reviews {
                     self.current_ws()?
@@ -1913,6 +1921,14 @@ pub fn review_signal_target(signal: &SignalRecord) -> Option<(String, u64)> {
     let repo = &rest[..last_dash];
     let number: u64 = rest[last_dash + 1..].parse().ok()?;
     Some((repo.to_string(), number))
+}
+
+/// Non-actionable signal sources that are hidden by default (shown in debug mode).
+const NOISE_SOURCES: &[&str] = &["github_merged_pr", "github_ci_pass"];
+
+/// Returns true if a signal is non-actionable noise (merged PR or CI pass).
+pub fn is_noise_signal(signal: &SignalRecord) -> bool {
+    NOISE_SOURCES.contains(&signal.source.as_str())
 }
 
 /// Severity icon for display.

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -1921,6 +1921,42 @@ mod tests {
     }
 
     #[test]
+    fn test_d_key_toggles_debug_on_signals_panel() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Signals;
+        assert!(!app.signals_debug_mode);
+
+        handle_dashboard_key(&mut app, key(KeyCode::Char('d')));
+        assert!(app.signals_debug_mode, "d should enable debug mode");
+        assert!(app.needs_redraw, "should trigger redraw");
+
+        app.needs_redraw = false;
+        handle_dashboard_key(&mut app, key(KeyCode::Char('d')));
+        assert!(!app.signals_debug_mode, "d should toggle debug off");
+        assert!(app.needs_redraw, "should trigger redraw on toggle off");
+    }
+
+    #[test]
+    fn test_d_key_no_effect_on_other_panels() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Workers;
+        assert!(!app.signals_debug_mode);
+
+        handle_dashboard_key(&mut app, key(KeyCode::Char('d')));
+        assert!(
+            !app.signals_debug_mode,
+            "d should not toggle debug on Workers panel"
+        );
+
+        app.focused_panel = Panel::Feed;
+        handle_dashboard_key(&mut app, key(KeyCode::Char('d')));
+        assert!(
+            !app.signals_debug_mode,
+            "d should not toggle debug on Feed panel"
+        );
+    }
+
+    #[test]
     fn test_number_keys_no_effect_when_chat_focused() {
         let mut app = test_app();
         app.focused_panel = Panel::Chat;

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -690,6 +690,13 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
                 ws.chat_scroll.scroll_to_bottom();
             }
         }
+        KeyCode::Char('d') => {
+            if app.focused_panel == Panel::Signals {
+                app.signals_debug_mode = !app.signals_debug_mode;
+                app.clamp_selections();
+                app.needs_redraw = true;
+            }
+        }
         KeyCode::Char('s') => {
             return KeyAction::OpenSettings;
         }
@@ -1856,6 +1863,7 @@ mod tests {
             last_worker_refresh: std::time::Instant::now(),
             last_signal_refresh: std::time::Instant::now(),
             snooze_selection: 0,
+            signals_debug_mode: false,
         }
     }
 

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -1045,14 +1045,26 @@ fn draw_signals_card(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
     }
 
     if total == 0 {
-        let msg = if debug {
-            "No open signals"
+        // Check if there are hidden noise signals that debug mode would reveal
+        let hidden_noise = if debug {
+            0
         } else {
-            "No open signals (d=debug)"
+            ws.signals
+                .iter()
+                .filter(|s| s.source != "github_review_queue")
+                .filter(|s| app::is_noise_signal(s))
+                .count()
+        };
+        let msg = if hidden_noise > 0 {
+            Cow::Owned(format!(
+                "No actionable signals ({hidden_noise} hidden, d=debug)"
+            ))
+        } else {
+            Cow::Borrowed("No open signals")
         };
         let lines = vec![Line::from(vec![
             Span::raw(" "),
-            Span::styled(msg, theme::muted()),
+            Span::styled(msg.into_owned(), theme::muted()),
         ])];
         frame.render_widget(Paragraph::new(lines), content_area);
         return;
@@ -1079,7 +1091,7 @@ fn draw_signals_card(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
                 let mut lines: Vec<Line> = Vec::new();
                 lines.push(Line::from(vec![
                     Span::raw("  "),
-                    Span::styled(format!("{batch_count} merged PRs"), theme::muted()),
+                    Span::styled(format!("{batch_count} noise signals"), theme::muted()),
                     Span::styled(format!("  ({}/{})", idx + 1, total), theme::muted()),
                 ]));
                 let p = Paragraph::new(lines);
@@ -2495,6 +2507,10 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect) {
         Line::from(vec![
             Span::styled("  R             ", theme::key_hint()),
             Span::styled("Resolve signal (confirm)", theme::key_desc()),
+        ]),
+        Line::from(vec![
+            Span::styled("  d             ", theme::key_hint()),
+            Span::styled("Toggle signal debug mode", theme::key_desc()),
         ]),
         Line::from(vec![
             Span::styled("  q             ", theme::key_hint()),

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -306,7 +306,7 @@ fn draw_home_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area:
 
 // ── KPI strip (single inline bar) ────────────────────────
 
-fn draw_kpi_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, area: Rect) {
+fn draw_kpi_strip(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area: Rect) {
     let kpi_border = Style::default().fg(theme::STEEL);
     let kpi_title = Style::default().fg(theme::POLLEN);
     let kpi_bg = Style::default().bg(theme::COMB);
@@ -460,10 +460,18 @@ fn draw_kpi_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, area:
             Span::styled(format!(" \u{2713}{done}"), theme::status_done()),
         ]));
 
-        // Signals summary
+        // Signals summary (filtered in normal mode, total in debug)
+        let sig_display_count = if app.signals_debug_mode {
+            ws.signals.len()
+        } else {
+            ws.signals
+                .iter()
+                .filter(|s| !app::is_noise_signal(s))
+                .count()
+        };
         lines.push(Line::from(vec![
             Span::styled(
-                format!(" {} signals", ws.signals.len()),
+                format!(" {} signals", sig_display_count),
                 Style::default().fg(theme::FROST),
             ),
             if crit > 0 {
@@ -996,30 +1004,34 @@ fn draw_workers_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, ar
 
 fn draw_signals_card(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area: Rect) {
     let panel_focused = app.focused_panel == Panel::Signals;
+    let debug = app.signals_debug_mode;
 
-    // Filter out review queue signals — those go in the Reviews pane
+    // Filter out review queue signals — those go in the Reviews pane.
+    // In normal mode, also hide noise signals (merged PRs, CI pass).
     let filtered: Vec<&crate::buzz::signal::SignalRecord> = ws
         .signals
         .iter()
         .filter(|s| s.source != "github_review_queue")
+        .filter(|s| debug || !app::is_noise_signal(s))
         .collect();
     let total = filtered.len();
 
-    // Title with navigation indicator
+    // Title with navigation indicator + debug badge
+    let label = if debug { "Signals [debug]" } else { "Signals" };
     let title = if total == 0 {
-        format!("Signals ({total})")
+        format!("{label} ({total})")
     } else {
         let idx = app.signal_selection.min(total.saturating_sub(1));
         let signal = filtered[idx];
         let icon = app::severity_icon(&signal.severity);
         if panel_focused {
             format!(
-                "Signals ({total})  {icon} \u{25c0} {}/{} \u{25b6}",
+                "{label} ({total})  {icon} \u{25c0} {}/{} \u{25b6}",
                 idx + 1,
                 total
             )
         } else {
-            format!("Signals ({total})  {icon} {}/{}", idx + 1, total)
+            format!("{label} ({total})  {icon} {}/{}", idx + 1, total)
         }
     };
 
@@ -1033,12 +1045,51 @@ fn draw_signals_card(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
     }
 
     if total == 0 {
+        let msg = if debug {
+            "No open signals"
+        } else {
+            "No open signals (d=debug)"
+        };
         let lines = vec![Line::from(vec![
             Span::raw(" "),
-            Span::styled("No open signals", theme::muted()),
+            Span::styled(msg, theme::muted()),
         ])];
         frame.render_widget(Paragraph::new(lines), content_area);
         return;
+    }
+
+    // In debug mode, batch consecutive merged-PR-only entries
+    if debug {
+        let idx = app.signal_selection.min(total.saturating_sub(1));
+
+        // Check if the selected signal is part of a batch of consecutive noise signals
+        let mut batch_start = idx;
+        let mut batch_end = idx;
+        if app::is_noise_signal(filtered[idx]) {
+            // Expand backward
+            while batch_start > 0 && app::is_noise_signal(filtered[batch_start - 1]) {
+                batch_start -= 1;
+            }
+            // Expand forward
+            while batch_end + 1 < total && app::is_noise_signal(filtered[batch_end + 1]) {
+                batch_end += 1;
+            }
+            let batch_count = batch_end - batch_start + 1;
+            if batch_count > 1 {
+                let mut lines: Vec<Line> = Vec::new();
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(format!("{batch_count} merged PRs"), theme::muted()),
+                    Span::styled(format!("  ({}/{})", idx + 1, total), theme::muted()),
+                ]));
+                let p = Paragraph::new(lines);
+                frame.render_widget(p, content_area);
+                if !panel_focused {
+                    dim_area(frame, content_area);
+                }
+                return;
+            }
+        }
     }
 
     let idx = app.signal_selection.min(total.saturating_sub(1));


### PR DESCRIPTION
## Summary
- Filter non-actionable signals (`github_merged_pr`, `github_ci_pass`) from the signals panel by default to reduce noise
- Add `d` key toggle in signals panel for debug mode — shows all signals with header "Signals [debug]"
- Batch consecutive merged-PR-only entries into a summary row ("N merged PRs") in debug mode
- KPI sidebar count reflects filtered count in normal mode, total in debug mode

## Test plan
- [x] All 373 existing tests pass
- [ ] Verify signals panel hides `github_merged_pr` and `github_ci_pass` entries by default
- [ ] Press `d` while focused on signals panel — header should show "Signals [debug]" and all signals visible
- [ ] Press `d` again to toggle back to filtered view
- [ ] Verify sidebar count updates when toggling debug mode


🤖 Generated with [Claude Code](https://claude.com/claude-code)