### PR TITLE
feat: add persistent memory skill to coordinator prompt

### DIFF
--- a/crates/apiari/src/buzz/coordinator/skills/memory.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/memory.rs
@@ -1,0 +1,57 @@
+//! Persistent memory skill — teaches the coordinator how to update MEMORY.md.
+
+use super::SkillContext;
+
+/// Always included — the coordinator should always know about persistent memory.
+pub fn build_prompt(_ctx: &SkillContext) -> String {
+    "\
+## Persistent Memory
+
+You have a persistent memory file at `~/.claude/projects/*/memory/MEMORY.md` \
+(the exact path depends on the workspace directory). This file is loaded into \
+your system prompt at the start of every session, so anything written there \
+persists across conversations.
+
+### How to Update
+
+You can **append** to MEMORY.md via Bash. The validate-bash hook allows writes \
+to `~/.claude/.../memory/` paths. Examples:
+
+```bash
+# Append a line
+echo '- User prefers PRs squash-merged' >> ~/.claude/projects/-Users-josh-Developer-myproject/memory/MEMORY.md
+
+# Append a block
+cat >> ~/.claude/projects/-Users-josh-Developer-myproject/memory/MEMORY.md << 'EOF'
+
+## Deploy process
+- Always run tests before deploying
+- Use `make deploy-prod` for production
+EOF
+```
+
+To find the exact path, look for a `memory/` directory under `~/.claude/projects/`.
+
+### What to Remember
+
+Update MEMORY.md when you learn something important about the workspace that \
+should be remembered long-term:
+- User preferences for workflow, tools, and communication style
+- Key architectural decisions and project conventions
+- Repo-specific patterns (branch naming, CI quirks, deploy steps)
+- Solutions to recurring problems
+
+### What NOT to Remember
+
+- Session-specific context (current task details, in-progress work)
+- Information already in the workspace config or CLAUDE.md files
+- Speculative or unverified conclusions
+
+### Rules
+
+- **Append only** — do not overwrite the file. Use `>>` or `cat >>`, never `>`.
+- **Keep it concise** — lines after 200 are truncated in the system prompt.
+- **No secrets** — never write tokens, passwords, or API keys to MEMORY.md.
+"
+    .to_string()
+}

--- a/crates/apiari/src/buzz/coordinator/skills/memory.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/memory.rs
@@ -12,25 +12,44 @@ You have a persistent memory file at `~/.claude/projects/*/memory/MEMORY.md` \
 your system prompt at the start of every session, so anything written there \
 persists across conversations.
 
+This is different from the **Signal Store `memory` table** (SQLite). Use each for \
+different purposes:
+- **MEMORY.md** — human-readable notes loaded into your prompt automatically. \
+Best for workspace conventions, user preferences, and lessons learned. \
+Workspace-local and prompt-visible.
+- **SQLite `memory` table** — structured records queryable via `sqlite3`. Best \
+for programmatic storage (observations, decisions) that you query on demand \
+rather than always having in context.
+
+When in doubt: if you want to remember something that should influence every \
+future conversation, put it in MEMORY.md. If it's a structured fact you'll \
+query occasionally, use the SQLite memory table.
+
 ### How to Update
 
-You can **append** to MEMORY.md via Bash. The validate-bash hook allows writes \
-to `~/.claude/.../memory/` paths. Examples:
+First, discover the exact path:
+```bash
+ls ~/.claude/projects/*/memory/MEMORY.md
+```
+
+Then **append** via Bash. The validate-bash hook allows writes to \
+`~/.claude/.../memory/` paths. Examples:
 
 ```bash
+# Find the path
+MEMORY=$(ls ~/.claude/projects/*/memory/MEMORY.md 2>/dev/null | head -1)
+
 # Append a line
-echo '- User prefers PRs squash-merged' >> ~/.claude/projects/-Users-josh-Developer-myproject/memory/MEMORY.md
+echo '- User prefers PRs squash-merged' >> \"$MEMORY\"
 
 # Append a block
-cat >> ~/.claude/projects/-Users-josh-Developer-myproject/memory/MEMORY.md << 'EOF'
+cat >> \"$MEMORY\" << 'EOF'
 
 ## Deploy process
 - Always run tests before deploying
 - Use `make deploy-prod` for production
 EOF
 ```
-
-To find the exact path, look for a `memory/` directory under `~/.claude/projects/`.
 
 ### What to Remember
 
@@ -50,7 +69,7 @@ should be remembered long-term:
 ### Rules
 
 - **Append only** — do not overwrite the file. Use `>>` or `cat >>`, never `>`.
-- **Keep it concise** — lines after 200 are truncated in the system prompt.
+- **Keep it concise** — very long entries may be truncated in the system prompt.
 - **No secrets** — never write tokens, passwords, or API keys to MEMORY.md.
 "
     .to_string()

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -8,6 +8,7 @@ pub mod config;
 mod email;
 mod github;
 mod linear;
+mod memory;
 mod notion;
 mod sentry;
 mod signals;
@@ -49,6 +50,7 @@ pub fn build_skills_prompt(ctx: &SkillContext) -> String {
     // Always-on skills
     sections.push(config::build_prompt(ctx));
     sections.push(signals::build_prompt(ctx));
+    sections.push(memory::build_prompt(ctx));
 
     // Conditional skills
     if let Some(s) = github::build_prompt(ctx) {
@@ -231,6 +233,13 @@ mod tests {
         let ctx = test_ctx();
         let prompt = build_skills_prompt(&ctx);
         assert!(!prompt.contains("## Notion"));
+    }
+
+    #[test]
+    fn test_build_skills_prompt_includes_memory() {
+        let prompt = build_skills_prompt(&test_ctx());
+        assert!(prompt.contains("## Persistent Memory"));
+        assert!(prompt.contains("MEMORY.md"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a new `memory` skill to the coordinator skills system that teaches Bee how to append to `~/.claude/projects/*/memory/MEMORY.md`
- The validate-bash hook already allowed writes to memory paths — this adds the prompt instructions so the coordinator actually knows about the capability
- Includes guidance on what to remember, what not to remember, and append-only rules

## Test plan
- [x] `cargo test -p apiari -- skills::tests::test_build_skills_prompt_includes_memory` passes
- [x] Existing `audit::tests::test_claude_memory_exception_*` tests confirm the bash hook allows these writes
- [x] `cargo fmt -p apiari` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)