### PR TITLE
feat: action-oriented signal hooks

### DIFF
--- a/crates/apiari/src/buzz/coordinator/skills/config.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/config.rs
@@ -171,27 +171,25 @@ pub fn build_prompt(ctx: &SkillContext) -> String {
          ```\n\n\
          **Signal hooks setup:**\n\
          Signal hooks trigger coordinator follow-through when signals arrive.\n\
-         The `action` field controls what you should DO (not just narrate):\n\
-         - `notify` — just send a message (default if omitted)\n\
-         - `auto_fix` — find the failing worker/PR and dispatch a fix or send the error to an existing worker\n\
-         - `forward_to_worker` — find the swarm worker for this PR and forward the review to it\n\
-         - `triage` — assess the situation and decide whether to act or just notify\n\
+         The optional `action` field is a natural-language instruction telling you what to DO \
+         when this hook fires. If omitted, you just notify (current default behavior).\n\
          ```toml\n\
          [[coordinator.signal_hooks]]\n\
          source = \"github_ci_failure\"\n\
          prompt = \"CI failed: {events}\"\n\
-         action = \"auto_fix\"\n\
+         action = \"Find the relevant swarm worker for this PR and send it the CI error details.\"\n\
          ttl_secs = 300\n\
          \n\
          [[coordinator.signal_hooks]]\n\
          source = \"github_bot_review\"\n\
-         prompt = \"Bot review: {events}\"\n\
-         action = \"forward_to_worker\"\n\
+         prompt = \"Bot review received: {events}\"\n\
+         action = \"Find the swarm worker whose branch matches this PR and forward the review.\"\n\
          ttl_secs = 300\n\
          \n\
          [[coordinator.signal_hooks]]\n\
-         source = \"swarm\"\n\
-         action = \"triage\"\n\
+         source = \"github_release\"\n\
+         prompt = \"Release completed: {events}\"\n\
+         ttl_secs = 300\n\
          ```\n",
     );
 

--- a/crates/apiari/src/buzz/coordinator/skills/config.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/config.rs
@@ -175,7 +175,7 @@ pub fn build_prompt(ctx: &SkillContext) -> String {
          when this hook fires. If omitted, you just notify (current default behavior).\n\
          ```toml\n\
          [[coordinator.signal_hooks]]\n\
-         source = \"github_ci_failure\"\n\
+         source = \"github\"\n\
          prompt = \"CI failed: {events}\"\n\
          action = \"Find the relevant swarm worker for this PR and send it the CI error details.\"\n\
          ttl_secs = 300\n\

--- a/crates/apiari/src/buzz/coordinator/skills/config.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/config.rs
@@ -170,15 +170,29 @@ pub fn build_prompt(ctx: &SkillContext) -> String {
          poll_database_ids = [\"db-id-1\"]  # optional\n\
          ```\n\n\
          **Signal hooks setup:**\n\
-         Signal hooks trigger coordinator follow-through when signals arrive:\n\
+         Signal hooks trigger coordinator follow-through when signals arrive.\n\
+         The `action` field controls what you should DO (not just narrate):\n\
+         - `notify` — just send a message (default if omitted)\n\
+         - `auto_fix` — find the failing worker/PR and dispatch a fix or send the error to an existing worker\n\
+         - `forward_to_worker` — find the swarm worker for this PR and forward the review to it\n\
+         - `triage` — assess the situation and decide whether to act or just notify\n\
          ```toml\n\
          [[coordinator.signal_hooks]]\n\
          source = \"github_ci_failure\"\n\
          prompt = \"CI failed: {events}\"\n\
+         action = \"auto_fix\"\n\
          ttl_secs = 300\n\
-         ```\n\
-         The default hook watches `swarm` signals. Add more hooks for sources like \
-         `github_ci_failure`, `github_bot_review`, `sentry`, etc.\n",
+         \n\
+         [[coordinator.signal_hooks]]\n\
+         source = \"github_bot_review\"\n\
+         prompt = \"Bot review: {events}\"\n\
+         action = \"forward_to_worker\"\n\
+         ttl_secs = 300\n\
+         \n\
+         [[coordinator.signal_hooks]]\n\
+         source = \"swarm\"\n\
+         action = \"triage\"\n\
+         ```\n",
     );
 
     prompt

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -196,31 +196,15 @@ pub struct SignalHookConfig {
     /// Empty string = use default formatting.
     #[serde(default)]
     pub prompt: String,
-    /// Action the coordinator should take when this hook fires.
-    /// Default: `notify` (just send a message).
+    /// Natural-language action instruction for the coordinator.
+    /// When set, appended to the hook prompt so the coordinator knows what to DO
+    /// (e.g. dispatch a worker, forward a review, triage).
+    /// If omitted, the coordinator just notifies (current default behavior).
     #[serde(default)]
-    pub action: SignalHookAction,
+    pub action: Option<String>,
     /// Max seconds to wait in queue before dropping. Default: 120.
     #[serde(default = "default_hook_ttl")]
     pub ttl_secs: u64,
-}
-
-/// Action type for signal hooks — determines what the coordinator should DO
-/// when signals arrive, beyond just narrating what happened.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SignalHookAction {
-    /// Just notify via Telegram/TUI (current default behavior).
-    #[default]
-    Notify,
-    /// Identify the failing worker/PR and dispatch a fix worker or send
-    /// the error to an existing worker.
-    AutoFix,
-    /// Find the relevant swarm worker for the PR and forward the
-    /// review/comments to it.
-    ForwardToWorker,
-    /// Assess the situation and decide whether to act or just notify.
-    Triage,
 }
 
 fn default_hook_ttl() -> u64 {
@@ -231,20 +215,20 @@ fn default_signal_hooks() -> Vec<SignalHookConfig> {
     vec![
         SignalHookConfig {
             source: "swarm".into(),
-            prompt: String::new(),
-            action: SignalHookAction::Triage,
-            ttl_secs: default_hook_ttl(),
+            prompt: "Swarm activity: {events}".into(),
+            action: Some("Assess the situation. If a worker opened a PR, check if Copilot has reviewed it and if so forward any comments to the worker. If a worker is stuck or failed, investigate and either send a fix or dispatch a new worker.".into()),
+            ttl_secs: 300,
         },
         SignalHookConfig {
             source: "github_bot_review".into(),
-            prompt: "Bot code review: {events}".into(),
-            action: SignalHookAction::ForwardToWorker,
+            prompt: "Bot review received: {events}".into(),
+            action: Some("Find the swarm worker whose branch matches this PR and forward the review comments directly to it so it can address them.".into()),
             ttl_secs: 300,
         },
         SignalHookConfig {
             source: "github_ci_failure".into(),
             prompt: "CI failed: {events}".into(),
-            action: SignalHookAction::AutoFix,
+            action: Some("Find the relevant swarm worker for this PR. If a worker exists, send it the CI error details so it can fix them. If no worker exists, dispatch a new one to fix the failure.".into()),
             ttl_secs: 300,
         },
     ]
@@ -1467,33 +1451,19 @@ max_session_turns = 0
         let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.coordinator.signal_hooks.len(), 3);
         assert_eq!(config.coordinator.signal_hooks[0].source, "swarm");
-        assert!(config.coordinator.signal_hooks[0].prompt.is_empty());
-        assert_eq!(
-            config.coordinator.signal_hooks[0].action,
-            SignalHookAction::Triage
-        );
-        assert_eq!(config.coordinator.signal_hooks[0].ttl_secs, 120);
+        assert!(config.coordinator.signal_hooks[0].action.is_some());
+        assert_eq!(config.coordinator.signal_hooks[0].ttl_secs, 300);
         assert_eq!(
             config.coordinator.signal_hooks[1].source,
             "github_bot_review"
         );
-        assert_eq!(
-            config.coordinator.signal_hooks[1].prompt,
-            "Bot code review: {events}"
-        );
-        assert_eq!(
-            config.coordinator.signal_hooks[1].action,
-            SignalHookAction::ForwardToWorker
-        );
+        assert!(config.coordinator.signal_hooks[1].action.is_some());
         assert_eq!(config.coordinator.signal_hooks[1].ttl_secs, 300);
         assert_eq!(
             config.coordinator.signal_hooks[2].source,
             "github_ci_failure"
         );
-        assert_eq!(
-            config.coordinator.signal_hooks[2].action,
-            SignalHookAction::AutoFix
-        );
+        assert!(config.coordinator.signal_hooks[2].action.is_some());
     }
 
     #[test]
@@ -1508,18 +1478,15 @@ ttl_secs = 60
 [[coordinator.signal_hooks]]
 source = "github_ci_failure"
 prompt = "CI failed: {title}"
-action = "auto_fix"
+action = "Dispatch a worker to fix the CI failure."
 ttl_secs = 300
 "#;
         let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.coordinator.signal_hooks.len(), 2);
         assert_eq!(config.coordinator.signal_hooks[0].source, "swarm");
         assert_eq!(config.coordinator.signal_hooks[0].ttl_secs, 60);
-        // No action specified → defaults to Notify
-        assert_eq!(
-            config.coordinator.signal_hooks[0].action,
-            SignalHookAction::Notify
-        );
+        // No action specified → defaults to None
+        assert!(config.coordinator.signal_hooks[0].action.is_none());
         assert_eq!(
             config.coordinator.signal_hooks[1].source,
             "github_ci_failure"
@@ -1529,50 +1496,32 @@ ttl_secs = 300
             "CI failed: {title}"
         );
         assert_eq!(
-            config.coordinator.signal_hooks[1].action,
-            SignalHookAction::AutoFix
+            config.coordinator.signal_hooks[1].action.as_deref(),
+            Some("Dispatch a worker to fix the CI failure.")
         );
         assert_eq!(config.coordinator.signal_hooks[1].ttl_secs, 300);
     }
 
     #[test]
-    fn test_signal_hook_action_all_variants() {
+    fn test_signal_hook_action_string() {
         let toml_str = r#"
 root = "/tmp/test"
 
 [[coordinator.signal_hooks]]
 source = "a"
-action = "notify"
 
 [[coordinator.signal_hooks]]
 source = "b"
-action = "auto_fix"
-
-[[coordinator.signal_hooks]]
-source = "c"
-action = "forward_to_worker"
-
-[[coordinator.signal_hooks]]
-source = "d"
-action = "triage"
+action = "Find the worker and forward the review."
 "#;
         let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.coordinator.signal_hooks.len(), 4);
+        assert_eq!(config.coordinator.signal_hooks.len(), 2);
+        // No action → None (notify only)
+        assert!(config.coordinator.signal_hooks[0].action.is_none());
+        // With action → Some(string)
         assert_eq!(
-            config.coordinator.signal_hooks[0].action,
-            SignalHookAction::Notify
-        );
-        assert_eq!(
-            config.coordinator.signal_hooks[1].action,
-            SignalHookAction::AutoFix
-        );
-        assert_eq!(
-            config.coordinator.signal_hooks[2].action,
-            SignalHookAction::ForwardToWorker
-        );
-        assert_eq!(
-            config.coordinator.signal_hooks[3].action,
-            SignalHookAction::Triage
+            config.coordinator.signal_hooks[1].action.as_deref(),
+            Some("Find the worker and forward the review.")
         );
     }
 

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -196,9 +196,31 @@ pub struct SignalHookConfig {
     /// Empty string = use default formatting.
     #[serde(default)]
     pub prompt: String,
+    /// Action the coordinator should take when this hook fires.
+    /// Default: `notify` (just send a message).
+    #[serde(default)]
+    pub action: SignalHookAction,
     /// Max seconds to wait in queue before dropping. Default: 120.
     #[serde(default = "default_hook_ttl")]
     pub ttl_secs: u64,
+}
+
+/// Action type for signal hooks — determines what the coordinator should DO
+/// when signals arrive, beyond just narrating what happened.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignalHookAction {
+    /// Just notify via Telegram/TUI (current default behavior).
+    #[default]
+    Notify,
+    /// Identify the failing worker/PR and dispatch a fix worker or send
+    /// the error to an existing worker.
+    AutoFix,
+    /// Find the relevant swarm worker for the PR and forward the
+    /// review/comments to it.
+    ForwardToWorker,
+    /// Assess the situation and decide whether to act or just notify.
+    Triage,
 }
 
 fn default_hook_ttl() -> u64 {
@@ -210,11 +232,19 @@ fn default_signal_hooks() -> Vec<SignalHookConfig> {
         SignalHookConfig {
             source: "swarm".into(),
             prompt: String::new(),
+            action: SignalHookAction::Triage,
             ttl_secs: default_hook_ttl(),
         },
         SignalHookConfig {
             source: "github_bot_review".into(),
             prompt: "Bot code review: {events}".into(),
+            action: SignalHookAction::ForwardToWorker,
+            ttl_secs: 300,
+        },
+        SignalHookConfig {
+            source: "github_ci_failure".into(),
+            prompt: "CI failed: {events}".into(),
+            action: SignalHookAction::AutoFix,
             ttl_secs: 300,
         },
     ]
@@ -920,11 +950,15 @@ root = "/tmp/test"
         assert_eq!(config.coordinator.model, "sonnet");
         assert_eq!(config.coordinator.max_turns, 20);
         assert_eq!(config.coordinator.max_session_turns, 50);
-        assert_eq!(config.coordinator.signal_hooks.len(), 2);
+        assert_eq!(config.coordinator.signal_hooks.len(), 3);
         assert_eq!(config.coordinator.signal_hooks[0].source, "swarm");
         assert_eq!(
             config.coordinator.signal_hooks[1].source,
             "github_bot_review"
+        );
+        assert_eq!(
+            config.coordinator.signal_hooks[2].source,
+            "github_ci_failure"
         );
     }
 
@@ -1431,9 +1465,13 @@ max_session_turns = 0
     fn test_signal_hooks_default() {
         let toml_str = r#"root = "/tmp/test""#;
         let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.coordinator.signal_hooks.len(), 2);
+        assert_eq!(config.coordinator.signal_hooks.len(), 3);
         assert_eq!(config.coordinator.signal_hooks[0].source, "swarm");
         assert!(config.coordinator.signal_hooks[0].prompt.is_empty());
+        assert_eq!(
+            config.coordinator.signal_hooks[0].action,
+            SignalHookAction::Triage
+        );
         assert_eq!(config.coordinator.signal_hooks[0].ttl_secs, 120);
         assert_eq!(
             config.coordinator.signal_hooks[1].source,
@@ -1443,7 +1481,19 @@ max_session_turns = 0
             config.coordinator.signal_hooks[1].prompt,
             "Bot code review: {events}"
         );
+        assert_eq!(
+            config.coordinator.signal_hooks[1].action,
+            SignalHookAction::ForwardToWorker
+        );
         assert_eq!(config.coordinator.signal_hooks[1].ttl_secs, 300);
+        assert_eq!(
+            config.coordinator.signal_hooks[2].source,
+            "github_ci_failure"
+        );
+        assert_eq!(
+            config.coordinator.signal_hooks[2].action,
+            SignalHookAction::AutoFix
+        );
     }
 
     #[test]
@@ -1458,12 +1508,18 @@ ttl_secs = 60
 [[coordinator.signal_hooks]]
 source = "github_ci_failure"
 prompt = "CI failed: {title}"
+action = "auto_fix"
 ttl_secs = 300
 "#;
         let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.coordinator.signal_hooks.len(), 2);
         assert_eq!(config.coordinator.signal_hooks[0].source, "swarm");
         assert_eq!(config.coordinator.signal_hooks[0].ttl_secs, 60);
+        // No action specified → defaults to Notify
+        assert_eq!(
+            config.coordinator.signal_hooks[0].action,
+            SignalHookAction::Notify
+        );
         assert_eq!(
             config.coordinator.signal_hooks[1].source,
             "github_ci_failure"
@@ -1472,7 +1528,52 @@ ttl_secs = 300
             config.coordinator.signal_hooks[1].prompt,
             "CI failed: {title}"
         );
+        assert_eq!(
+            config.coordinator.signal_hooks[1].action,
+            SignalHookAction::AutoFix
+        );
         assert_eq!(config.coordinator.signal_hooks[1].ttl_secs, 300);
+    }
+
+    #[test]
+    fn test_signal_hook_action_all_variants() {
+        let toml_str = r#"
+root = "/tmp/test"
+
+[[coordinator.signal_hooks]]
+source = "a"
+action = "notify"
+
+[[coordinator.signal_hooks]]
+source = "b"
+action = "auto_fix"
+
+[[coordinator.signal_hooks]]
+source = "c"
+action = "forward_to_worker"
+
+[[coordinator.signal_hooks]]
+source = "d"
+action = "triage"
+"#;
+        let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.coordinator.signal_hooks.len(), 4);
+        assert_eq!(
+            config.coordinator.signal_hooks[0].action,
+            SignalHookAction::Notify
+        );
+        assert_eq!(
+            config.coordinator.signal_hooks[1].action,
+            SignalHookAction::AutoFix
+        );
+        assert_eq!(
+            config.coordinator.signal_hooks[2].action,
+            SignalHookAction::ForwardToWorker
+        );
+        assert_eq!(
+            config.coordinator.signal_hooks[3].action,
+            SignalHookAction::Triage
+        );
     }
 
     #[test]

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -187,9 +187,9 @@ impl Default for CoordinatorConfig {
 /// signals from the specified source arrive.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignalHookConfig {
-    /// Signal source to match (e.g. "swarm", "github_bot_review", "github_ci_failure").
+    /// Signal source to match (e.g. "swarm", "github_bot_review", "github").
     /// Matches exactly, or as a prefix with `_` separator (e.g. "github" matches
-    /// "github_ci_failure", "github_bot_review", etc.).
+    /// "github_bot_review", "github_release", etc.).
     /// The first matching hook wins when multiple hooks could match a signal.
     pub source: String,
     /// Prompt template sent to coordinator. Supports {source} and {events} placeholders.
@@ -226,7 +226,7 @@ fn default_signal_hooks() -> Vec<SignalHookConfig> {
             ttl_secs: 300,
         },
         SignalHookConfig {
-            source: "github_ci_failure".into(),
+            source: "github".into(),
             prompt: "CI failed: {events}".into(),
             action: Some("Find the relevant swarm worker for this PR. If a worker exists, send it the CI error details so it can fix them. If no worker exists, dispatch a new one to fix the failure.".into()),
             ttl_secs: 300,
@@ -940,10 +940,7 @@ root = "/tmp/test"
             config.coordinator.signal_hooks[1].source,
             "github_bot_review"
         );
-        assert_eq!(
-            config.coordinator.signal_hooks[2].source,
-            "github_ci_failure"
-        );
+        assert_eq!(config.coordinator.signal_hooks[2].source, "github");
     }
 
     #[test]
@@ -1459,10 +1456,7 @@ max_session_turns = 0
         );
         assert!(config.coordinator.signal_hooks[1].action.is_some());
         assert_eq!(config.coordinator.signal_hooks[1].ttl_secs, 300);
-        assert_eq!(
-            config.coordinator.signal_hooks[2].source,
-            "github_ci_failure"
-        );
+        assert_eq!(config.coordinator.signal_hooks[2].source, "github");
         assert!(config.coordinator.signal_hooks[2].action.is_some());
     }
 
@@ -1476,8 +1470,8 @@ source = "swarm"
 ttl_secs = 60
 
 [[coordinator.signal_hooks]]
-source = "github_ci_failure"
-prompt = "CI failed: {title}"
+source = "github"
+prompt = "CI failed: {events}"
 action = "Dispatch a worker to fix the CI failure."
 ttl_secs = 300
 "#;
@@ -1487,13 +1481,10 @@ ttl_secs = 300
         assert_eq!(config.coordinator.signal_hooks[0].ttl_secs, 60);
         // No action specified → defaults to None
         assert!(config.coordinator.signal_hooks[0].action.is_none());
-        assert_eq!(
-            config.coordinator.signal_hooks[1].source,
-            "github_ci_failure"
-        );
+        assert_eq!(config.coordinator.signal_hooks[1].source, "github");
         assert_eq!(
             config.coordinator.signal_hooks[1].prompt,
-            "CI failed: {title}"
+            "CI failed: {events}"
         );
         assert_eq!(
             config.coordinator.signal_hooks[1].action.as_deref(),

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -104,7 +104,7 @@ enum CoordinatorJob {
         signals: Vec<String>,
         source: String,
         prompt_override: Option<String>,
-        action: config::SignalHookAction,
+        action: Option<String>,
         queued_at: std::time::Instant,
         ttl_secs: u64,
         telegram: Option<(TelegramChannel, i64, Option<i64>)>,
@@ -469,10 +469,10 @@ async fn run_coordinator_task(
                     format_system_notification(&source, &signals)
                 };
 
-                // Append action-oriented guidance so the coordinator knows what to DO
-                if let Some(guidance) = action_guidance(&action) {
-                    notification.push_str("\n\n");
-                    notification.push_str(guidance);
+                // Append action instruction so the coordinator knows what to DO
+                if let Some(ref action_str) = action {
+                    notification.push_str("\n\n[Action] ");
+                    notification.push_str(action_str);
                 }
                 info!(
                     "[{slot_name}] triggering coordinator follow-through ({source}, {} event(s))",
@@ -2049,31 +2049,6 @@ fn format_system_notification(source: &str, events: &[String]) -> String {
          provide a brief contextual update. Otherwise respond with just \"ack\".",
     );
     msg
-}
-
-/// Return action-specific guidance for the coordinator, or None for `notify` (default behavior).
-fn action_guidance(action: &config::SignalHookAction) -> Option<&'static str> {
-    match action {
-        config::SignalHookAction::Notify => None,
-        config::SignalHookAction::AutoFix => Some(
-            "[Action: auto_fix] Look at the failure details. \
-             Run `swarm status` to check if there's an existing worker for this PR/branch. \
-             If a worker exists, send the error to that worker with `swarm send`. \
-             If no worker exists, dispatch a new one with `swarm create` including the error details \
-             and instructions to fix it.",
-        ),
-        config::SignalHookAction::ForwardToWorker => Some(
-            "[Action: forward_to_worker] Find the swarm worker whose branch matches this PR. \
-             Run `swarm status` to list workers, then use `swarm send` to forward the review \
-             comments directly to the matching worker.",
-        ),
-        config::SignalHookAction::Triage => Some(
-            "[Action: triage] Assess the situation. \
-             If it needs immediate action (e.g. a worker failed, CI broke, a blocker was raised), \
-             take appropriate action (dispatch a worker, send a message, etc.). \
-             If it's purely informational, summarize and notify.",
-        ),
-    }
 }
 
 /// Format a hook notification using a custom prompt template.

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -104,6 +104,7 @@ enum CoordinatorJob {
         signals: Vec<String>,
         source: String,
         prompt_override: Option<String>,
+        action: config::SignalHookAction,
         queued_at: std::time::Instant,
         ttl_secs: u64,
         telegram: Option<(TelegramChannel, i64, Option<i64>)>,
@@ -443,6 +444,7 @@ async fn run_coordinator_task(
                 signals,
                 source,
                 prompt_override,
+                action,
                 queued_at,
                 ttl_secs,
                 telegram,
@@ -461,11 +463,17 @@ async fn run_coordinator_task(
                     continue;
                 }
 
-                let notification = if let Some(ref tpl) = prompt_override {
+                let mut notification = if let Some(ref tpl) = prompt_override {
                     format_hook_notification(&source, &signals, tpl)
                 } else {
                     format_system_notification(&source, &signals)
                 };
+
+                // Append action-oriented guidance so the coordinator knows what to DO
+                if let Some(guidance) = action_guidance(&action) {
+                    notification.push_str("\n\n");
+                    notification.push_str(guidance);
+                }
                 info!(
                     "[{slot_name}] triggering coordinator follow-through ({source}, {} event(s))",
                     signals.len()
@@ -1230,6 +1238,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                             signals,
                             source,
                             prompt_override,
+                            action: hook.action.clone(),
                             queued_at: std::time::Instant::now(),
                             ttl_secs: hook.ttl_secs,
                             telegram: telegram_info,
@@ -2040,6 +2049,31 @@ fn format_system_notification(source: &str, events: &[String]) -> String {
          provide a brief contextual update. Otherwise respond with just \"ack\".",
     );
     msg
+}
+
+/// Return action-specific guidance for the coordinator, or None for `notify` (default behavior).
+fn action_guidance(action: &config::SignalHookAction) -> Option<&'static str> {
+    match action {
+        config::SignalHookAction::Notify => None,
+        config::SignalHookAction::AutoFix => Some(
+            "[Action: auto_fix] Look at the failure details. \
+             Run `swarm status` to check if there's an existing worker for this PR/branch. \
+             If a worker exists, send the error to that worker with `swarm send`. \
+             If no worker exists, dispatch a new one with `swarm create` including the error details \
+             and instructions to fix it.",
+        ),
+        config::SignalHookAction::ForwardToWorker => Some(
+            "[Action: forward_to_worker] Find the swarm worker whose branch matches this PR. \
+             Run `swarm status` to list workers, then use `swarm send` to forward the review \
+             comments directly to the matching worker.",
+        ),
+        config::SignalHookAction::Triage => Some(
+            "[Action: triage] Assess the situation. \
+             If it needs immediate action (e.g. a worker failed, CI broke, a blocker was raised), \
+             take appropriate action (dispatch a worker, send a message, etc.). \
+             If it's purely informational, summarize and notify.",
+        ),
+    }
 }
 
 /// Format a hook notification using a custom prompt template.

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1944,7 +1944,7 @@ fn build_setup_toml(setup: &SetupState) -> String {
     signal_hooks.push(hook_swarm);
 
     let mut hook_ci = Table::new();
-    hook_ci["source"] = value("github_ci_failure");
+    hook_ci["source"] = value("github");
     hook_ci["prompt"] = value("CI failed: {events}");
     hook_ci["action"] = value(
         "Find the relevant swarm worker for this PR. If a worker exists, send it the CI error details so it can fix them. If no worker exists, dispatch a new one to fix the failure.",

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1927,10 +1927,33 @@ fn build_setup_toml(setup: &SetupState) -> String {
     doc["root"] = value(setup.workspace_root.display().to_string());
     doc["repos"] = Item::Value(toml_edit::Value::Array(Array::new()));
 
-    // [coordinator]
+    // [coordinator] + [[coordinator.signal_hooks]]
     let mut coordinator = Table::new();
     coordinator["model"] = value("sonnet");
     coordinator["max_turns"] = value(20i64);
+
+    let mut signal_hooks = toml_edit::ArrayOfTables::new();
+
+    let mut hook_swarm = Table::new();
+    hook_swarm["source"] = value("swarm");
+    hook_swarm["action"] = value("triage");
+    signal_hooks.push(hook_swarm);
+
+    let mut hook_review = Table::new();
+    hook_review["source"] = value("github_bot_review");
+    hook_review["prompt"] = value("Bot code review: {events}");
+    hook_review["action"] = value("forward_to_worker");
+    hook_review["ttl_secs"] = value(300i64);
+    signal_hooks.push(hook_review);
+
+    let mut hook_ci = Table::new();
+    hook_ci["source"] = value("github_ci_failure");
+    hook_ci["prompt"] = value("CI failed: {events}");
+    hook_ci["action"] = value("auto_fix");
+    hook_ci["ttl_secs"] = value(300i64);
+    signal_hooks.push(hook_ci);
+
+    coordinator.insert("signal_hooks", Item::ArrayOfTables(signal_hooks));
     doc["coordinator"] = Item::Table(coordinator);
 
     // [swarm]

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1936,22 +1936,30 @@ fn build_setup_toml(setup: &SetupState) -> String {
 
     let mut hook_swarm = Table::new();
     hook_swarm["source"] = value("swarm");
-    hook_swarm["action"] = value("triage");
+    hook_swarm["prompt"] = value("Swarm activity: {events}");
+    hook_swarm["action"] = value(
+        "Assess the situation. If a worker opened a PR, check if Copilot has reviewed it and if so forward any comments to the worker. If a worker is stuck or failed, investigate and either send a fix or dispatch a new worker.",
+    );
+    hook_swarm["ttl_secs"] = value(300i64);
     signal_hooks.push(hook_swarm);
-
-    let mut hook_review = Table::new();
-    hook_review["source"] = value("github_bot_review");
-    hook_review["prompt"] = value("Bot code review: {events}");
-    hook_review["action"] = value("forward_to_worker");
-    hook_review["ttl_secs"] = value(300i64);
-    signal_hooks.push(hook_review);
 
     let mut hook_ci = Table::new();
     hook_ci["source"] = value("github_ci_failure");
     hook_ci["prompt"] = value("CI failed: {events}");
-    hook_ci["action"] = value("auto_fix");
+    hook_ci["action"] = value(
+        "Find the relevant swarm worker for this PR. If a worker exists, send it the CI error details so it can fix them. If no worker exists, dispatch a new one to fix the failure.",
+    );
     hook_ci["ttl_secs"] = value(300i64);
     signal_hooks.push(hook_ci);
+
+    let mut hook_review = Table::new();
+    hook_review["source"] = value("github_bot_review");
+    hook_review["prompt"] = value("Bot review received: {events}");
+    hook_review["action"] = value(
+        "Find the swarm worker whose branch matches this PR and forward the review comments directly to it so it can address them.",
+    );
+    hook_review["ttl_secs"] = value(300i64);
+    signal_hooks.push(hook_review);
 
     coordinator.insert("signal_hooks", Item::ArrayOfTables(signal_hooks));
     doc["coordinator"] = Item::Table(coordinator);


### PR DESCRIPTION
## Summary
- Adds a configurable `action` field to `SignalHookConfig` with four variants: `notify` (default), `auto_fix`, `forward_to_worker`, and `triage`
- When signal hooks fire, action-specific guidance is appended to the coordinator prompt so Bee knows what to DO (dispatch workers, forward reviews, triage) instead of just narrating
- Default hooks updated with sensible actions: `swarm`→`triage`, `github_bot_review`→`forward_to_worker`, new `github_ci_failure`→`auto_fix`
- Onboarding setup TOML and config skill documentation updated to include the `action` field

## Test plan
- [x] All 384 existing tests pass
- [x] New test `test_signal_hook_action_all_variants` verifies all action enum variants deserialize from TOML
- [x] Updated `test_signal_hooks_default` and `test_signal_hooks_explicit` verify action field behavior
- [ ] Manual: verify `action = "auto_fix"` in TOML causes coordinator to attempt dispatching a fix worker on CI failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)