### PR TITLE
fix: filter spammy sub-cursor heartbeats from TUI feed

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -2290,8 +2290,7 @@ pub(super) fn load_all_extras_blocking(
                 // Feed: watcher heartbeats
                 if let Ok(cursors) = store.get_watcher_cursors() {
                     for (watcher, updated_at_str) in &cursors {
-                        // Skip sub-cursors (per-repo, per-signal-type) — they're implementation details
-                        if watcher.contains(':') {
+                        if !is_top_level_watcher(watcher) {
                             continue;
                         }
                         if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(updated_at_str) {
@@ -2450,6 +2449,14 @@ pub fn elapsed_display(created_at: &Option<DateTime<Local>>) -> String {
     }
 }
 
+/// Returns true if the watcher name is a known top-level watcher (not a per-repo sub-cursor).
+fn is_top_level_watcher(name: &str) -> bool {
+    matches!(
+        name,
+        "github" | "swarm" | "sentry" | "review_queue" | "linear" | "notion" | "email"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2519,6 +2526,40 @@ mod tests {
         let signal = make_signal("sentry", "sentry-42", None);
         let result = review_signal_target(&signal);
         assert_eq!(result, None);
+    }
+
+    // ── is_top_level_watcher tests ────────────────────────────
+
+    #[test]
+    fn test_top_level_watchers_are_included() {
+        for name in [
+            "github",
+            "swarm",
+            "sentry",
+            "review_queue",
+            "linear",
+            "notion",
+            "email",
+        ] {
+            assert!(is_top_level_watcher(name), "{name} should be top-level");
+        }
+    }
+
+    #[test]
+    fn test_sub_cursors_are_excluded() {
+        for name in [
+            "github_ci_pass:ApiariTools/web",
+            "github_merged_pr:ApiariTools/apiari",
+            "github_release:ApiariTools/apiari",
+            "github_ci_pass:ApiariTools/swarm",
+        ] {
+            assert!(!is_top_level_watcher(name), "{name} should be excluded");
+        }
+    }
+
+    #[test]
+    fn test_unknown_watcher_is_excluded() {
+        assert!(!is_top_level_watcher("some_future_thing"));
     }
 
     // ── apply_chat_history tests ─────────────────────────────

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -2290,6 +2290,10 @@ pub(super) fn load_all_extras_blocking(
                 // Feed: watcher heartbeats
                 if let Ok(cursors) = store.get_watcher_cursors() {
                     for (watcher, updated_at_str) in &cursors {
+                        // Skip sub-cursors (per-repo, per-signal-type) — they're implementation details
+                        if watcher.contains(':') {
+                            continue;
+                        }
                         if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(updated_at_str) {
                             let dt_utc = dt.with_timezone(&Utc);
                             data.feed_items.push(FeedItem {


### PR DESCRIPTION
## Summary
- Skip watcher_cursors entries containing `:` (per-repo, per-signal-type sub-cursors like `github_ci_pass:ApiariTools/web`) from the heartbeat feed panel
- Only top-level watchers (`github`, `swarm`, `sentry`, `review_queue`) now appear as heartbeat items
- Reduces ~20 noisy heartbeat lines to 3-4 meaningful ones

## Test plan
- [ ] Launch TUI and verify the Heartbeat feed panel shows only top-level watcher names
- [ ] Verify sub-cursors (containing `:`) no longer appear in the feed
- [ ] Confirm heartbeat count in panel title reflects the reduced set

🤖 Generated with [Claude Code](https://claude.com/claude-code)