### PR TITLE
fix: prevent ghost Workers panel during daemon auto-start

### DIFF
--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -52,7 +52,19 @@ pub fn draw(frame: &mut Frame, app: &App) {
         .split(size);
 
     draw_tab_bar(frame, app, outer[0]);
-    // outer[1] is breathing room
+
+    // Paint an explicit background on every cell that no widget would
+    // otherwise cover: the breathing-room gap (outer[1]), the body area
+    // (outer[2]), and the bottom pad (outer[4]).  Without this, those cells
+    // stay at Color::Reset — identical to the cleared previous buffer — so
+    // the ratatui diff never outputs them.  If the terminal's alternate-
+    // screen buffer was not fully blanked, ghost content from a prior
+    // session persists in those unwritten cells and becomes visible when the
+    // dashboard layout shifts (e.g. during daemon auto-start).
+    let bg = Block::default().style(Style::default().bg(theme::COMB));
+    frame.render_widget(bg.clone(), outer[1]);
+    frame.render_widget(bg.clone(), outer[2]);
+    frame.render_widget(bg, outer[4]);
 
     match &app.view {
         View::Dashboard => draw_dashboard(frame, app, outer[2]),
@@ -130,24 +142,6 @@ fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
         Some(ws) => ws,
         None => return,
     };
-
-    // Paint an explicit background on every cell in the body area. Without
-    // this, cells not covered by a widget stay at Color::Reset — identical to
-    // the cleared previous buffer — so the ratatui diff never outputs them.
-    // If the terminal's alternate-screen buffer was not fully blanked (macOS
-    // Terminal.app, some iTerm2 configs), ghost content from a prior session
-    // persists in those unwritten cells. When the layout later shifts (e.g.
-    // kpi_h grows after watcher_health arrives during daemon auto-start), the
-    // old Workers-panel position falls into one of these unwritten gaps and
-    // the ghost "Workers (0)" header becomes visible as a duplicate.
-    //
-    // Filling with bg:COMB makes every cell differ from the empty previous
-    // buffer on the first frame, forcing a full terminal write. On subsequent
-    // frames the fill matches the previous buffer so the diff cost is zero.
-    frame.render_widget(
-        Block::default().style(Style::default().bg(theme::COMB)),
-        area,
-    );
 
     // Zoomed panel (or auto-zoom on narrow terminals)
     let zoomed = if area.width < 50 {

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -131,6 +131,24 @@ fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
         None => return,
     };
 
+    // Paint an explicit background on every cell in the body area. Without
+    // this, cells not covered by a widget stay at Color::Reset — identical to
+    // the cleared previous buffer — so the ratatui diff never outputs them.
+    // If the terminal's alternate-screen buffer was not fully blanked (macOS
+    // Terminal.app, some iTerm2 configs), ghost content from a prior session
+    // persists in those unwritten cells. When the layout later shifts (e.g.
+    // kpi_h grows after watcher_health arrives during daemon auto-start), the
+    // old Workers-panel position falls into one of these unwritten gaps and
+    // the ghost "Workers (0)" header becomes visible as a duplicate.
+    //
+    // Filling with bg:COMB makes every cell differ from the empty previous
+    // buffer on the first frame, forcing a full terminal write. On subsequent
+    // frames the fill matches the previous buffer so the diff cost is zero.
+    frame.render_widget(
+        Block::default().style(Style::default().bg(theme::COMB)),
+        area,
+    );
+
     // Zoomed panel (or auto-zoom on narrow terminals)
     let zoomed = if area.width < 50 {
         Some(app.zoomed_panel.unwrap_or(app.focused_panel))


### PR DESCRIPTION
## Summary
- Fixes a TUI rendering bug where the Workers panel header appears twice when `apiari` auto-starts the daemon
- The duplicate header appears because ratatui's diff engine skips cells that match between its internal buffers — when the terminal's alternate-screen buffer wasn't fully blanked, ghost content from a prior session persists in unwritten cells
- When the layout shifts (kpi_h grows as watcher_health arrives), the Workers panel moves and the ghost header at the old position becomes visible

## Fix
Added an explicit `bg:COMB` background fill at the start of `draw_dashboard`. This forces every cell to differ from the empty previous buffer on the first frame, ensuring a full terminal write that overwrites any ghost content. On subsequent frames the fill matches the previous buffer so the diff cost is zero.

## Test plan
- [ ] Launch `apiari` with no daemon running — verify only one Workers panel header appears after "Daemon started ✓"
- [ ] Launch `apiari` with daemon already running — verify no regression
- [ ] Resize terminal while dashboard is visible — verify no rendering artifacts
- [ ] Verify panel spacing gaps have consistent background (now COMB instead of terminal default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)