### PR TITLE
feat: add cursor movement and Ctrl+C clearing to chat input

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1359,24 +1359,24 @@ impl App {
     // ── Cursor movement ──────────────────────────────────
 
     pub fn cursor_left(&mut self) {
-        if let Some(ws) = self.current_ws_mut() {
-            if ws.cursor_pos > 0 {
-                ws.cursor_pos = ws.input[..ws.cursor_pos]
-                    .char_indices()
-                    .next_back()
-                    .map(|(i, _)| i)
-                    .unwrap_or(0);
-                self.needs_redraw = true;
-            }
+        if let Some(ws) = self.current_ws_mut()
+            && ws.cursor_pos > 0
+        {
+            ws.cursor_pos = ws.input[..ws.cursor_pos]
+                .char_indices()
+                .next_back()
+                .map(|(i, _)| i)
+                .unwrap_or(0);
+            self.needs_redraw = true;
         }
     }
 
     pub fn cursor_right(&mut self) {
-        if let Some(ws) = self.current_ws_mut() {
-            if ws.cursor_pos < ws.input.len() {
-                ws.cursor_pos += ws.input[ws.cursor_pos..].chars().next().unwrap().len_utf8();
-                self.needs_redraw = true;
-            }
+        if let Some(ws) = self.current_ws_mut()
+            && ws.cursor_pos < ws.input.len()
+        {
+            ws.cursor_pos += ws.input[ws.cursor_pos..].chars().next().unwrap().len_utf8();
+            self.needs_redraw = true;
         }
     }
 

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -366,6 +366,8 @@ pub struct WorkspaceState {
     pub workers: Vec<WorkerInfo>,
     pub chat_history: Vec<ChatLine>,
     pub input: String,
+    /// Cursor byte offset into `input`. Must always be on a char boundary.
+    pub cursor_pos: usize,
     pub chat_scroll: ScrollState,
     pub streaming: bool,
     pub coordinator_preview: Option<String>,
@@ -461,6 +463,7 @@ impl App {
                 workers: Vec::new(),
                 chat_history: Vec::new(),
                 input: String::new(),
+                cursor_pos: 0,
                 chat_scroll: ScrollState::new(),
                 streaming: false,
                 coordinator_preview: None,
@@ -584,6 +587,7 @@ impl App {
             workers: Vec::new(),
             chat_history: Vec::new(),
             input: String::new(),
+            cursor_pos: 0,
             chat_scroll: ScrollState::new(),
             streaming: false,
             coordinator_preview: None,
@@ -844,6 +848,7 @@ impl App {
             workers: Vec::new(),
             chat_history,
             input: String::new(),
+            cursor_pos: 0,
             chat_scroll: ScrollState::new(),
             streaming: false,
             coordinator_preview: None,
@@ -1294,22 +1299,196 @@ impl App {
 
     pub fn insert_char(&mut self, c: char) {
         if let Some(ws) = self.current_ws_mut() {
-            ws.input.push(c);
+            ws.input.insert(ws.cursor_pos, c);
+            ws.cursor_pos += c.len_utf8();
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn insert_str(&mut self, s: &str) {
+        if let Some(ws) = self.current_ws_mut() {
+            ws.input.insert_str(ws.cursor_pos, s);
+            ws.cursor_pos += s.len();
             self.needs_redraw = true;
         }
     }
 
     pub fn backspace(&mut self) {
         if let Some(ws) = self.current_ws_mut() {
-            ws.input.pop();
+            if ws.cursor_pos > 0 {
+                // Find the previous char boundary
+                let prev = ws.input[..ws.cursor_pos]
+                    .char_indices()
+                    .next_back()
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+                ws.input.remove(prev);
+                ws.cursor_pos = prev;
+            }
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn delete_forward(&mut self) {
+        if let Some(ws) = self.current_ws_mut() {
+            if ws.cursor_pos < ws.input.len() {
+                ws.input.remove(ws.cursor_pos);
+            }
             self.needs_redraw = true;
         }
     }
 
     pub fn take_input(&mut self) -> String {
         match self.current_ws_mut() {
-            Some(ws) => std::mem::take(&mut ws.input),
+            Some(ws) => {
+                ws.cursor_pos = 0;
+                std::mem::take(&mut ws.input)
+            }
             None => String::new(),
+        }
+    }
+
+    pub fn clear_input(&mut self) {
+        if let Some(ws) = self.current_ws_mut() {
+            ws.input.clear();
+            ws.cursor_pos = 0;
+            self.needs_redraw = true;
+        }
+    }
+
+    // ── Cursor movement ──────────────────────────────────
+
+    pub fn cursor_left(&mut self) {
+        if let Some(ws) = self.current_ws_mut() {
+            if ws.cursor_pos > 0 {
+                ws.cursor_pos = ws.input[..ws.cursor_pos]
+                    .char_indices()
+                    .next_back()
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+                self.needs_redraw = true;
+            }
+        }
+    }
+
+    pub fn cursor_right(&mut self) {
+        if let Some(ws) = self.current_ws_mut() {
+            if ws.cursor_pos < ws.input.len() {
+                ws.cursor_pos += ws.input[ws.cursor_pos..].chars().next().unwrap().len_utf8();
+                self.needs_redraw = true;
+            }
+        }
+    }
+
+    pub fn cursor_word_left(&mut self) {
+        if let Some(ws) = self.current_ws_mut() {
+            let s = &ws.input[..ws.cursor_pos];
+            // Skip trailing whitespace, then skip non-whitespace
+            let trimmed = s.trim_end();
+            if trimmed.is_empty() {
+                ws.cursor_pos = 0;
+            } else {
+                // Find last whitespace before end of trimmed
+                let pos = trimmed
+                    .rfind(char::is_whitespace)
+                    .map(|i| {
+                        // advance past the whitespace char
+                        i + trimmed[i..].chars().next().unwrap().len_utf8()
+                    })
+                    .unwrap_or(0);
+                ws.cursor_pos = pos;
+            }
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn cursor_word_right(&mut self) {
+        if let Some(ws) = self.current_ws_mut() {
+            let s = &ws.input[ws.cursor_pos..];
+            // Skip non-whitespace, then skip whitespace
+            let after_word = s.find(char::is_whitespace).unwrap_or(s.len());
+            let rest = &s[after_word..];
+            let after_space = rest
+                .find(|c: char| !c.is_whitespace())
+                .unwrap_or(rest.len());
+            ws.cursor_pos += after_word + after_space;
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn cursor_home(&mut self) {
+        if let Some(ws) = self.current_ws_mut() {
+            // Move to start of current line (find last '\n' before cursor)
+            ws.cursor_pos = ws.input[..ws.cursor_pos]
+                .rfind('\n')
+                .map(|i| i + 1)
+                .unwrap_or(0);
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn cursor_end(&mut self) {
+        if let Some(ws) = self.current_ws_mut() {
+            // Move to end of current line (find next '\n' after cursor)
+            ws.cursor_pos = ws.input[ws.cursor_pos..]
+                .find('\n')
+                .map(|i| ws.cursor_pos + i)
+                .unwrap_or(ws.input.len());
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn cursor_up(&mut self) {
+        if let Some(ws) = self.current_ws_mut() {
+            // Find current line start and column
+            let line_start = ws.input[..ws.cursor_pos]
+                .rfind('\n')
+                .map(|i| i + 1)
+                .unwrap_or(0);
+            if line_start == 0 {
+                // Already on first line — move to beginning
+                ws.cursor_pos = 0;
+                self.needs_redraw = true;
+                return;
+            }
+            let col = ws.cursor_pos - line_start;
+            // Find previous line start
+            let prev_line_start = ws.input[..line_start - 1]
+                .rfind('\n')
+                .map(|i| i + 1)
+                .unwrap_or(0);
+            let prev_line_len = line_start - 1 - prev_line_start;
+            ws.cursor_pos = prev_line_start + col.min(prev_line_len);
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn cursor_down(&mut self) {
+        if let Some(ws) = self.current_ws_mut() {
+            // Find current line start and column
+            let line_start = ws.input[..ws.cursor_pos]
+                .rfind('\n')
+                .map(|i| i + 1)
+                .unwrap_or(0);
+            let col = ws.cursor_pos - line_start;
+            // Find next line
+            let next_newline = ws.input[ws.cursor_pos..].find('\n');
+            match next_newline {
+                Some(offset) => {
+                    let next_line_start = ws.cursor_pos + offset + 1;
+                    let next_line_end = ws.input[next_line_start..]
+                        .find('\n')
+                        .map(|i| next_line_start + i)
+                        .unwrap_or(ws.input.len());
+                    let next_line_len = next_line_end - next_line_start;
+                    ws.cursor_pos = next_line_start + col.min(next_line_len);
+                }
+                None => {
+                    // Already on last line — move to end
+                    ws.cursor_pos = ws.input.len();
+                }
+            }
+            self.needs_redraw = true;
         }
     }
 

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1440,7 +1440,7 @@ impl App {
 
     pub fn cursor_up(&mut self) {
         if let Some(ws) = self.current_ws_mut() {
-            // Find current line start and column
+            // Find current line start and column (as char count, not bytes)
             let line_start = ws.input[..ws.cursor_pos]
                 .rfind('\n')
                 .map(|i| i + 1)
@@ -1451,26 +1451,32 @@ impl App {
                 self.needs_redraw = true;
                 return;
             }
-            let col = ws.cursor_pos - line_start;
+            let char_col = ws.input[line_start..ws.cursor_pos].chars().count();
             // Find previous line start
             let prev_line_start = ws.input[..line_start - 1]
                 .rfind('\n')
                 .map(|i| i + 1)
                 .unwrap_or(0);
-            let prev_line_len = line_start - 1 - prev_line_start;
-            ws.cursor_pos = prev_line_start + col.min(prev_line_len);
+            let prev_line = &ws.input[prev_line_start..line_start - 1];
+            // Map char column back to byte offset on prev line
+            let byte_offset: usize = prev_line
+                .char_indices()
+                .nth(char_col)
+                .map(|(i, _)| i)
+                .unwrap_or(prev_line.len());
+            ws.cursor_pos = prev_line_start + byte_offset;
             self.needs_redraw = true;
         }
     }
 
     pub fn cursor_down(&mut self) {
         if let Some(ws) = self.current_ws_mut() {
-            // Find current line start and column
+            // Find current line start and column (as char count, not bytes)
             let line_start = ws.input[..ws.cursor_pos]
                 .rfind('\n')
                 .map(|i| i + 1)
                 .unwrap_or(0);
-            let col = ws.cursor_pos - line_start;
+            let char_col = ws.input[line_start..ws.cursor_pos].chars().count();
             // Find next line
             let next_newline = ws.input[ws.cursor_pos..].find('\n');
             match next_newline {
@@ -1480,8 +1486,14 @@ impl App {
                         .find('\n')
                         .map(|i| next_line_start + i)
                         .unwrap_or(ws.input.len());
-                    let next_line_len = next_line_end - next_line_start;
-                    ws.cursor_pos = next_line_start + col.min(next_line_len);
+                    let next_line = &ws.input[next_line_start..next_line_end];
+                    // Map char column back to byte offset on next line
+                    let byte_offset: usize = next_line
+                        .char_indices()
+                        .nth(char_col)
+                        .map(|(i, _)| i)
+                        .unwrap_or(next_line.len());
+                    ws.cursor_pos = next_line_start + byte_offset;
                 }
                 None => {
                     // Already on last line — move to end

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -540,13 +540,12 @@ async fn event_loop(
 fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
     // Ctrl+C: clear input if chat is focused with text, otherwise quit
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
-        if app.chat_focused {
-            if let Some(ws) = app.current_ws() {
-                if !ws.input.is_empty() {
-                    app.clear_input();
-                    return KeyAction::Redraw;
-                }
-            }
+        if app.chat_focused
+            && let Some(ws) = app.current_ws()
+            && !ws.input.is_empty()
+        {
+            app.clear_input();
+            return KeyAction::Redraw;
         }
         return KeyAction::Quit;
     }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -2219,4 +2219,129 @@ mod tests {
         let input = &app.workspaces[0].input;
         assert_eq!(input, "1");
     }
+
+    fn ctrl_key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::CONTROL,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn test_ctrl_c_clears_input_when_chat_focused_nonempty() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Chat;
+        app.chat_focused = true;
+        app.workspaces[0].input = "hello".to_string();
+        app.workspaces[0].cursor_pos = 5;
+
+        let action = handle_key(&mut app, ctrl_key(KeyCode::Char('c')));
+
+        // Should clear input, not quit
+        assert!(matches!(action, KeyAction::Redraw));
+        assert!(app.workspaces[0].input.is_empty());
+        assert_eq!(app.workspaces[0].cursor_pos, 0);
+        assert!(app.chat_focused, "should stay in chat mode");
+    }
+
+    #[test]
+    fn test_ctrl_c_quits_when_chat_focused_empty() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Chat;
+        app.chat_focused = true;
+        // Input is empty (default)
+
+        let action = handle_key(&mut app, ctrl_key(KeyCode::Char('c')));
+
+        assert!(matches!(action, KeyAction::Quit));
+    }
+
+    #[test]
+    fn test_ctrl_c_quits_when_not_chat_focused() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Workers;
+        app.chat_focused = false;
+
+        let action = handle_key(&mut app, ctrl_key(KeyCode::Char('c')));
+
+        assert!(matches!(action, KeyAction::Quit));
+    }
+
+    #[test]
+    fn test_cursor_movement_multibyte_utf8() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Chat;
+        app.chat_focused = true;
+
+        // Insert multi-byte chars: "café" = c(1) a(1) f(1) é(2) = 5 bytes
+        app.workspaces[0].input = "café".to_string();
+        app.workspaces[0].cursor_pos = 5; // end of "café"
+
+        // Move left once — should land before 'é' (2-byte char), at byte 3
+        app.cursor_left();
+        assert_eq!(app.workspaces[0].cursor_pos, 3);
+        assert!(app.workspaces[0].input.is_char_boundary(3));
+
+        // Move left again — before 'f', at byte 2
+        app.cursor_left();
+        assert_eq!(app.workspaces[0].cursor_pos, 2);
+
+        // Move right — back to byte 3
+        app.cursor_right();
+        assert_eq!(app.workspaces[0].cursor_pos, 3);
+
+        // Move right — past 'é' to byte 5 (end)
+        app.cursor_right();
+        assert_eq!(app.workspaces[0].cursor_pos, 5);
+    }
+
+    #[test]
+    fn test_cursor_up_down_multibyte_utf8() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Chat;
+        app.chat_focused = true;
+
+        // Two lines: "héllo\nwörld"
+        // Line 1: h(1) é(2) l(1) l(1) o(1) = 6 bytes, 5 chars
+        // Line 2: w(1) ö(2) r(1) l(1) d(1) = 6 bytes, 5 chars
+        app.workspaces[0].input = "héllo\nwörld".to_string();
+        // Put cursor at end of line 2 (byte 13)
+        app.workspaces[0].cursor_pos = 13;
+
+        // Move up — should land on line 1 at same char column (5 = end of line)
+        app.cursor_up();
+        let pos = app.workspaces[0].cursor_pos;
+        assert_eq!(pos, 6); // byte offset of end of "héllo"
+        assert!(app.workspaces[0].input.is_char_boundary(pos));
+
+        // Move cursor to char col 2 on line 1: after "hé" = byte 3
+        app.workspaces[0].cursor_pos = 3;
+
+        // Move down — should land at char col 2 on line 2: after "wö" = byte 10
+        app.cursor_down();
+        let pos = app.workspaces[0].cursor_pos;
+        assert_eq!(pos, 10); // "héllo\n" (7) + "wö" (3) = 10
+        assert!(app.workspaces[0].input.is_char_boundary(pos));
+    }
+
+    #[test]
+    fn test_insert_at_cursor_position() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Chat;
+        app.chat_focused = true;
+
+        // Type "abcd"
+        app.workspaces[0].input = "abcd".to_string();
+        app.workspaces[0].cursor_pos = 4;
+
+        // Move cursor to position 2 (between 'b' and 'c')
+        app.workspaces[0].cursor_pos = 2;
+
+        // Insert 'X' at cursor
+        app.insert_char('X');
+        assert_eq!(app.workspaces[0].input, "abXcd");
+        assert_eq!(app.workspaces[0].cursor_pos, 3); // after 'X'
+    }
 }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -538,8 +538,16 @@ async fn event_loop(
 // ── Key handling (pure state) ────────────────────────────
 
 fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
-    // Ctrl+C always quits
+    // Ctrl+C: clear input if chat is focused with text, otherwise quit
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        if app.chat_focused {
+            if let Some(ws) = app.current_ws() {
+                if !ws.input.is_empty() {
+                    app.clear_input();
+                    return KeyAction::Redraw;
+                }
+            }
+        }
         return KeyAction::Quit;
     }
 
@@ -663,9 +671,7 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
 /// Handle a bracketed paste event by inserting the text into the active input.
 fn handle_paste(app: &mut App, text: &str) {
     if app.chat_focused {
-        if let Some(ws) = app.current_ws_mut() {
-            ws.input.push_str(text);
-        }
+        app.insert_str(text);
     } else if app.worker_input_active {
         app.worker_input.push_str(text);
     } else if app.review_comment_active {
@@ -986,11 +992,50 @@ fn handle_dashboard_chat_key(app: &mut App, key: crossterm::event::KeyEvent) -> 
         KeyCode::Backspace => {
             app.backspace();
         }
+        KeyCode::Delete => {
+            app.delete_forward();
+        }
+        KeyCode::Left => {
+            if key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+            {
+                app.cursor_word_left();
+            } else {
+                app.cursor_left();
+            }
+        }
+        KeyCode::Right => {
+            if key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+            {
+                app.cursor_word_right();
+            } else {
+                app.cursor_right();
+            }
+        }
+        KeyCode::Up => {
+            app.cursor_up();
+        }
+        KeyCode::Down => {
+            app.cursor_down();
+        }
+        KeyCode::Home => {
+            app.cursor_home();
+        }
+        KeyCode::End => {
+            app.cursor_end();
+        }
         KeyCode::Char(c) => {
-            if key.modifiers.contains(KeyModifiers::CONTROL) && c == 'u' {
-                app.scroll_chat_up(5);
-            } else if key.modifiers.contains(KeyModifiers::CONTROL) && c == 'd' {
-                app.scroll_chat_down(5);
+            if key.modifiers.contains(KeyModifiers::CONTROL) {
+                match c {
+                    'u' => app.scroll_chat_up(5),
+                    'd' => app.scroll_chat_down(5),
+                    'a' => app.cursor_home(),
+                    'e' => app.cursor_end(),
+                    _ => {}
+                }
             } else {
                 app.insert_char(c);
             }
@@ -2011,6 +2056,7 @@ mod tests {
             workers: Vec::new(),
             chat_history: Vec::new(),
             input: String::new(),
+            cursor_pos: 0,
             chat_scroll: apiari_tui::scroll::ScrollState::new(),
             streaming: false,
             coordinator_preview: None,

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -18,13 +18,19 @@ const SPINNER: &[&str] = &["|", "/", "-", "\\"];
 
 /// Build the display string for the input box with cursor indicator.
 /// Returns the rendered string with `_` at the cursor position.
-/// `cursor_pos` is a byte offset into `text`.
+/// `cursor_pos` is a byte offset into `text`, clamped and snapped to
+/// the nearest char boundary for safety.
 fn build_input_display(text: &str, cursor_pos: usize) -> String {
+    // Clamp to text length, then snap back to a char boundary.
+    let mut pos = cursor_pos.min(text.len());
+    while pos > 0 && !text.is_char_boundary(pos) {
+        pos -= 1;
+    }
     let mut out = String::with_capacity(text.len() + 2);
     out.push(' ');
-    out.push_str(&text[..cursor_pos]);
+    out.push_str(&text[..pos]);
     out.push('_');
-    out.push_str(&text[cursor_pos..]);
+    out.push_str(&text[pos..]);
     out
 }
 

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -16,16 +16,28 @@ use super::theme;
 
 const SPINNER: &[&str] = &["|", "/", "-", "\\"];
 
+/// Build the display string for the input box with cursor indicator.
+/// Returns the rendered string with `_` at the cursor position.
+/// `cursor_pos` is a byte offset into `text`.
+fn build_input_display(text: &str, cursor_pos: usize) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    out.push(' ');
+    out.push_str(&text[..cursor_pos]);
+    out.push('_');
+    out.push_str(&text[cursor_pos..]);
+    out
+}
+
 /// Calculate the number of visual rows needed for input text with wrapping.
 /// `text` is the raw input (may contain newlines), `width` is the available
-/// display width. Builds the exact rendered string (` {text}_`) and uses
+/// display width. Builds the exact rendered string with cursor and uses
 /// display width for correct Unicode/emoji handling.
-fn visual_input_rows(text: &str, width: u16) -> u16 {
+fn visual_input_rows(text: &str, cursor_pos: usize, width: u16) -> u16 {
     let w = width as usize;
     if w == 0 {
         return 1;
     }
-    let rendered = format!(" {text}_");
+    let rendered = build_input_display(text, cursor_pos);
     let mut total: usize = 0;
     for segment in rendered.split('\n') {
         let display_w = Line::from(segment).width();
@@ -863,7 +875,7 @@ fn draw_chat_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area:
         // Account for visual line wrapping, not just explicit newlines.
         // area.width - 2 accounts for the panel's left+right borders.
         let avail_w = area.width.saturating_sub(2);
-        let rows = visual_input_rows(&ws.input, avail_w);
+        let rows = visual_input_rows(&ws.input, ws.cursor_pos, avail_w);
         rows.clamp(1, 6) + 1 // +1 to include the top-border separator row
     } else {
         1 // just the hint line
@@ -977,7 +989,7 @@ fn draw_chat_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area:
         let input_inner = input_block.inner(layout[1]);
         frame.render_widget(input_block, layout[1]);
 
-        let input_text = format!(" {}_", ws.input);
+        let input_text = build_input_display(&ws.input, ws.cursor_pos);
         let input_p = Paragraph::new(input_text)
             .style(theme::text())
             .wrap(Wrap { trim: false });
@@ -1677,7 +1689,7 @@ fn draw_worker_detail(frame: &mut Frame, app: &App, area: Rect, idx: usize) {
     // Input bar height — account for visual line wrapping
     let input_h: u16 = if app.worker_input_active {
         let avail_w = area.width;
-        let rows = visual_input_rows(&app.worker_input, avail_w);
+        let rows = visual_input_rows(&app.worker_input, app.worker_input.len(), avail_w);
         rows.clamp(1, 6) + 1 // +1 for top border separator
     } else {
         0


### PR DESCRIPTION
## Summary
- Add full cursor navigation to the TUI chat input: arrow keys (char/word/line), Home/End, Ctrl+A/E, Up/Down for multi-line, and Delete key
- Ctrl+C now clears the input when chat is focused with text, instead of immediately quitting
- Visual cursor indicator (`_`) renders at the actual cursor position, not always at the end

## Test plan
- [x] All 391 existing tests pass
- [ ] Manual: type text, use ←/→ to move cursor, verify cursor `_` moves correctly
- [ ] Manual: type multi-word text, use Ctrl+←/→ to jump by word
- [ ] Manual: type multi-line (Alt+Enter), use ↑/↓ to navigate lines
- [ ] Manual: Home/End and Ctrl+A/Ctrl+E move to line start/end
- [ ] Manual: Ctrl+C with text in input clears it; Ctrl+C with empty input quits
- [ ] Manual: paste inserts at cursor position, not always at end

🤖 Generated with [Claude Code](https://claude.com/claude-code)