### PR TITLE
feat: send fallback text reply after tool-only coordinator runs

### DIFF
--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -270,9 +270,17 @@ async fn run_coordinator_task(
                             }
                         }
 
+                        // If the coordinator only used tools and produced no text,
+                        // send a brief fallback so the user knows the run completed.
+                        let final_text = if response.trim().is_empty() {
+                            "✅ Done.".to_string()
+                        } else {
+                            response
+                        };
+
                         let msg = OutboundMessage {
                             chat_id,
-                            text: response,
+                            text: final_text,
                             buttons: vec![],
                             topic_id,
                         };


### PR DESCRIPTION
## Summary
- When the coordinator processes a Telegram message using only tool calls (e.g. `cp`, `apiari config set` via Bash) without generating any text response, the user previously received only a reaction emoji (👀) with no confirmation of success or failure.
- After a coordinator run completes, if zero text tokens were produced (i.e. `response.trim().is_empty()`), a brief fallback message "✅ Done." is now sent to the user via the same Telegram send path (same `chat_id`, same `topic_id`).

## Test plan
- [ ] Trigger a coordinator run that only uses tool calls (no text generation) — verify "✅ Done." is sent
- [ ] Trigger a coordinator run that produces a normal text reply — verify the reply is sent as usual (no duplicate "Done")
- [ ] Verify the reaction emoji (👀) is still sent on message receipt regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)