### PR TITLE
feat: add worker activity log and chat view

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -436,6 +436,8 @@ pub struct App {
     // Worker detail
     pub worker_input: String,
     pub worker_input_active: bool,
+    /// When true, scroll/focus targets the activity pane (left) in WorkerDetail split.
+    pub worker_activity_focused: bool,
     // Review comment input
     pub review_comment_active: bool,
     pub review_comment_input: String,
@@ -547,6 +549,7 @@ impl App {
             chat_focused,
             worker_input: String::new(),
             worker_input_active: false,
+            worker_activity_focused: false,
             review_comment_active: false,
             review_comment_input: String::new(),
             review_comment_repo: String::new(),
@@ -663,6 +666,7 @@ impl App {
             chat_focused: true,
             worker_input: String::new(),
             worker_input_active: false,
+            worker_activity_focused: false,
             review_comment_active: false,
             review_comment_input: String::new(),
             review_comment_repo: String::new(),
@@ -1248,6 +1252,7 @@ impl App {
         self.content_scroll = 0;
         self.worker_input.clear();
         self.worker_input_active = false;
+        self.worker_activity_focused = false;
         self.refresh_worker_conversation(idx);
         self.needs_redraw = true;
     }
@@ -3303,5 +3308,118 @@ mod tests {
         assert_eq!(app.workspaces.len(), 2);
         assert!(!app.workspaces[0].is_setup_placeholder);
         assert!(app.workspaces[1].is_setup_placeholder);
+    }
+
+    fn test_worker(prompt: &str, phase: Option<&str>, pr: Option<PrInfo>) -> WorkerInfo {
+        WorkerInfo {
+            id: "w-123".into(),
+            branch: "swarm/test".into(),
+            prompt: prompt.into(),
+            agent_kind: "claude".into(),
+            phase: phase.map(|s| s.into()),
+            agent_session_status: None,
+            summary: None,
+            created_at: Some(Local::now()),
+            pr,
+            last_activity: None,
+            conversation: Vec::new(),
+            conv_scroll: ScrollState::new(),
+            activity: Vec::new(),
+            activity_scroll: ScrollState::new(),
+        }
+    }
+
+    #[test]
+    fn test_build_worker_activity_basic_ordering() {
+        let worker = test_worker("Fix the login bug", Some("running"), None);
+        let events = build_worker_activity(&worker);
+
+        // Should have at least: dispatched + status change
+        assert!(events.len() >= 2);
+        assert!(matches!(events[0].kind, WorkerEventKind::Dispatched));
+        assert!(events[0].text.contains("Fix the login bug"));
+        assert!(matches!(events[1].kind, WorkerEventKind::StatusChange));
+    }
+
+    #[test]
+    fn test_build_worker_activity_with_pr() {
+        let pr = PrInfo {
+            number: 42,
+            title: "fix: login bug".into(),
+            state: "OPEN".into(),
+            url: "https://github.com/test/repo/pull/42".into(),
+        };
+        let worker = test_worker("Fix the login bug", Some("running"), Some(pr));
+        let events = build_worker_activity(&worker);
+
+        // Should have dispatched + status + PR opened
+        let pr_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e.kind, WorkerEventKind::PrOpened))
+            .collect();
+        assert_eq!(pr_events.len(), 1);
+        assert!(pr_events[0].text.contains("#42"));
+    }
+
+    #[test]
+    fn test_build_worker_activity_merged_state() {
+        let pr = PrInfo {
+            number: 42,
+            title: "fix: login bug".into(),
+            state: "MERGED".into(),
+            url: "https://github.com/test/repo/pull/42".into(),
+        };
+        let worker = test_worker("Fix the login bug", Some("completed"), Some(pr));
+        let events = build_worker_activity(&worker);
+
+        // Should detect merged state
+        let merged: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e.kind, WorkerEventKind::Merged))
+            .collect();
+        assert_eq!(merged.len(), 1);
+        assert!(merged[0].text.contains("#42"));
+    }
+
+    #[test]
+    fn test_build_worker_activity_no_phase() {
+        let worker = test_worker("Fix something", None, None);
+        let events = build_worker_activity(&worker);
+
+        // Only dispatched, no status change
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].kind, WorkerEventKind::Dispatched));
+    }
+
+    #[test]
+    fn test_build_worker_activity_event_order() {
+        let pr = PrInfo {
+            number: 10,
+            title: "feat: something".into(),
+            state: "MERGED".into(),
+            url: "https://github.com/test/repo/pull/10".into(),
+        };
+        let worker = test_worker("Add feature", Some("completed"), Some(pr));
+        let events = build_worker_activity(&worker);
+
+        // Verify ordering: dispatched first, then status, then PR, then merged
+        let kinds: Vec<_> = events
+            .iter()
+            .map(|e| std::mem::discriminant(&e.kind))
+            .collect();
+        let dispatched_pos = kinds
+            .iter()
+            .position(|k| *k == std::mem::discriminant(&WorkerEventKind::Dispatched))
+            .unwrap();
+        let pr_pos = kinds
+            .iter()
+            .position(|k| *k == std::mem::discriminant(&WorkerEventKind::PrOpened))
+            .unwrap();
+        let merged_pos = kinds
+            .iter()
+            .position(|k| *k == std::mem::discriminant(&WorkerEventKind::Merged))
+            .unwrap();
+        assert!(dispatched_pos < pr_pos);
+        assert!(pr_pos < merged_pos);
     }
 }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -24,6 +24,7 @@ const CHAT_HISTORY_LIMIT: usize = 20;
 pub enum View {
     Dashboard,
     WorkerDetail(usize),
+    WorkerChat(usize),
     SignalDetail(usize),
     SignalList,
     ReviewList,
@@ -165,6 +166,10 @@ pub struct WorkerInfo {
     pub conversation: Vec<ConversationEntry>,
     /// Per-worker scroll state for conversation view.
     pub conv_scroll: ScrollState,
+    /// Activity log (derived from prompt, PR, phase, etc.).
+    pub activity: Vec<WorkerEvent>,
+    /// Scroll state for activity log in split view.
+    pub activity_scroll: ScrollState,
 }
 
 #[derive(Debug, Clone)]
@@ -174,6 +179,30 @@ pub struct PrInfo {
     pub title: String,
     pub state: String,
     pub url: String,
+}
+
+// ── Worker activity log ───────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct WorkerEvent {
+    pub ts: Option<DateTime<Local>>,
+    pub kind: WorkerEventKind,
+    pub text: String,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum WorkerEventKind {
+    Dispatched,
+    BeeToWorker,
+    UserToWorker,
+    PrOpened,
+    #[allow(dead_code)]
+    CiFailed,
+    #[allow(dead_code)]
+    CiPassed,
+    Merged,
+    StatusChange,
 }
 
 /// Deserialization types for .swarm/state.json.
@@ -1256,7 +1285,9 @@ impl App {
 
     pub fn back_to_dashboard(&mut self) {
         match self.view {
-            View::WorkerDetail(_) | View::PrList => self.focused_panel = Panel::Workers,
+            View::WorkerDetail(_) | View::WorkerChat(_) | View::PrList => {
+                self.focused_panel = Panel::Workers
+            }
             View::SignalDetail(_) | View::SignalList => {
                 // Return to whichever signal panel was focused before drill-in
                 if self.focused_panel != Panel::Reviews {
@@ -1745,7 +1776,7 @@ impl App {
     }
 
     pub fn scroll_worker_conv_up(&mut self, amount: u16) {
-        if let View::WorkerDetail(idx) = self.view
+        if let View::WorkerDetail(idx) | View::WorkerChat(idx) = self.view
             && let Some(ws) = self.workspaces.get_mut(self.active_tab)
             && let Some(worker) = ws.workers.get_mut(idx)
         {
@@ -1755,11 +1786,31 @@ impl App {
     }
 
     pub fn scroll_worker_conv_down(&mut self, amount: u16) {
-        if let View::WorkerDetail(idx) = self.view
+        if let View::WorkerDetail(idx) | View::WorkerChat(idx) = self.view
             && let Some(ws) = self.workspaces.get_mut(self.active_tab)
             && let Some(worker) = ws.workers.get_mut(idx)
         {
             worker.conv_scroll.scroll_down(amount as u32);
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn scroll_worker_activity_up(&mut self, amount: u16) {
+        if let View::WorkerDetail(idx) | View::WorkerChat(idx) = self.view
+            && let Some(ws) = self.workspaces.get_mut(self.active_tab)
+            && let Some(worker) = ws.workers.get_mut(idx)
+        {
+            worker.activity_scroll.scroll_up(amount as u32);
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn scroll_worker_activity_down(&mut self, amount: u16) {
+        if let View::WorkerDetail(idx) | View::WorkerChat(idx) = self.view
+            && let Some(ws) = self.workspaces.get_mut(self.active_tab)
+            && let Some(worker) = ws.workers.get_mut(idx)
+        {
+            worker.activity_scroll.scroll_down(amount as u32);
             self.needs_redraw = true;
         }
     }
@@ -2170,7 +2221,7 @@ impl App {
                     None
                 }
             }
-            View::WorkerDetail(i) => self.current_ws()?.workers.get(*i),
+            View::WorkerDetail(i) | View::WorkerChat(i) => self.current_ws()?.workers.get(*i),
             View::PrList => {
                 let prs = self.workers_with_prs();
                 prs.get(self.pr_list_selection).map(|(_, w)| *w)
@@ -2383,6 +2434,8 @@ fn load_workers_from_state(state_path: &std::path::Path) -> Vec<WorkerInfo> {
                 last_activity: None, // filled by refresh_workers
                 conversation: Vec::new(),
                 conv_scroll: ScrollState::new(),
+                activity: Vec::new(), // populated after load
+                activity_scroll: ScrollState::new(),
             }
         })
         .collect()
@@ -2460,6 +2513,54 @@ fn truncate_preview(s: &str, max_chars: usize) -> String {
     }
 }
 
+/// Build activity events from the data already available in `WorkerInfo`.
+fn build_worker_activity(worker: &WorkerInfo) -> Vec<WorkerEvent> {
+    let mut events = Vec::new();
+
+    // 1. Task dispatched (from prompt + created_at)
+    events.push(WorkerEvent {
+        ts: worker.created_at,
+        kind: WorkerEventKind::Dispatched,
+        text: truncate_preview(&worker.prompt, 120),
+    });
+
+    // 2. Phase changes → status entries
+    if let Some(ref phase) = worker.phase {
+        let phase_text = match phase.as_str() {
+            "running" => "Agent is running",
+            "waiting" => "Waiting for input",
+            "completed" => "Task completed",
+            "failed" => "Task failed",
+            _ => phase.as_str(),
+        };
+        events.push(WorkerEvent {
+            ts: None,
+            kind: WorkerEventKind::StatusChange,
+            text: phase_text.to_string(),
+        });
+    }
+
+    // 3. PR opened
+    if let Some(ref pr) = worker.pr {
+        events.push(WorkerEvent {
+            ts: None,
+            kind: WorkerEventKind::PrOpened,
+            text: format!("PR #{} opened: {}", pr.number, pr.title),
+        });
+
+        // 4. Check if merged
+        if pr.state == "MERGED" || pr.state == "merged" {
+            events.push(WorkerEvent {
+                ts: None,
+                kind: WorkerEventKind::Merged,
+                text: format!("PR #{} merged", pr.number),
+            });
+        }
+    }
+
+    events
+}
+
 // ── Blocking I/O for background tasks ─────────────────────
 
 /// Load workers for all workspaces (blocking filesystem reads).
@@ -2473,6 +2574,7 @@ pub(super) fn load_all_workers_blocking(
             let mut workers = load_workers_from_state(&state_path);
             for worker in &mut workers {
                 worker.last_activity = load_last_activity(&info.root, &worker.id);
+                worker.activity = build_worker_activity(worker);
             }
             (info.name.clone(), workers)
         })

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -445,7 +445,11 @@ async fn event_loop(
                                 if matches!(app.view, View::WorkerChat(_)) {
                                     app.scroll_worker_activity_up(3);
                                 } else if matches!(app.view, View::WorkerDetail(_)) {
-                                    app.scroll_worker_conv_up(3);
+                                    if app.worker_activity_focused {
+                                        app.scroll_worker_activity_up(3);
+                                    } else {
+                                        app.scroll_worker_conv_up(3);
+                                    }
                                 } else {
                                     app.scroll_chat_up(3);
                                 }
@@ -454,7 +458,11 @@ async fn event_loop(
                                 if matches!(app.view, View::WorkerChat(_)) {
                                     app.scroll_worker_activity_down(3);
                                 } else if matches!(app.view, View::WorkerDetail(_)) {
-                                    app.scroll_worker_conv_down(3);
+                                    if app.worker_activity_focused {
+                                        app.scroll_worker_activity_down(3);
+                                    } else {
+                                        app.scroll_worker_conv_down(3);
+                                    }
                                 } else {
                                     app.scroll_chat_down(3);
                                 }
@@ -500,7 +508,7 @@ async fn event_loop(
                     AppUpdate::Workers(data) => {
                         app.apply_worker_update(data);
                         // Refresh conversation in background when viewing worker detail
-                        if let View::WorkerDetail(idx) | View::WorkerChat(idx) = app.view
+                        if let View::WorkerDetail(idx) = app.view
                             && let Some(ws) = app.current_ws()
                             && let Some(worker) = ws.workers.get(idx)
                         {
@@ -1140,10 +1148,13 @@ fn handle_worker_detail_key(
     match key.code {
         KeyCode::Esc => app.back_to_dashboard(),
         KeyCode::Tab => {
-            cycle_fullscreen_next(app, idx);
+            // Toggle focus between activity (left) and conversation (right) panes
+            app.worker_activity_focused = !app.worker_activity_focused;
+            app.needs_redraw = true;
         }
         KeyCode::BackTab => {
-            cycle_fullscreen_prev(app, idx);
+            app.worker_activity_focused = !app.worker_activity_focused;
+            app.needs_redraw = true;
         }
         KeyCode::Char('c') => {
             app.view = View::WorkerChat(idx);
@@ -1154,13 +1165,33 @@ fn handle_worker_detail_key(
             app.worker_input.clear();
             app.needs_redraw = true;
         }
-        KeyCode::Char('j') | KeyCode::Down => app.scroll_worker_conv_up(3),
-        KeyCode::Char('k') | KeyCode::Up => app.scroll_worker_conv_down(3),
+        KeyCode::Char('j') | KeyCode::Down => {
+            if app.worker_activity_focused {
+                app.scroll_worker_activity_up(3);
+            } else {
+                app.scroll_worker_conv_up(3);
+            }
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            if app.worker_activity_focused {
+                app.scroll_worker_activity_down(3);
+            } else {
+                app.scroll_worker_conv_down(3);
+            }
+        }
         KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            app.scroll_worker_conv_down(10);
+            if app.worker_activity_focused {
+                app.scroll_worker_activity_down(10);
+            } else {
+                app.scroll_worker_conv_down(10);
+            }
         }
         KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            app.scroll_worker_conv_up(10);
+            if app.worker_activity_focused {
+                app.scroll_worker_activity_up(10);
+            } else {
+                app.scroll_worker_conv_up(10);
+            }
         }
         KeyCode::Char('o') => {
             if let Some(url) = app.selected_url() {
@@ -2200,6 +2231,7 @@ mod tests {
             chat_focused: false,
             worker_input: String::new(),
             worker_input_active: false,
+            worker_activity_focused: false,
             review_comment_active: false,
             review_comment_input: String::new(),
             review_comment_repo: String::new(),
@@ -2458,5 +2490,110 @@ mod tests {
         app.insert_char('X');
         assert_eq!(app.workspaces[0].input, "abXcd");
         assert_eq!(app.workspaces[0].cursor_pos, 3); // after 'X'
+    }
+
+    /// Create a test worker for WorkerDetail/WorkerChat tests.
+    fn test_worker() -> app::WorkerInfo {
+        app::WorkerInfo {
+            id: "test-worker".into(),
+            branch: "swarm/test".into(),
+            prompt: "Fix the bug".into(),
+            agent_kind: "claude".into(),
+            phase: Some("running".into()),
+            agent_session_status: None,
+            summary: None,
+            created_at: None,
+            pr: None,
+            last_activity: None,
+            conversation: Vec::new(),
+            conv_scroll: apiari_tui::scroll::ScrollState::new(),
+            activity: Vec::new(),
+            activity_scroll: apiari_tui::scroll::ScrollState::new(),
+        }
+    }
+
+    /// Set up a test app in WorkerDetail view with one worker.
+    fn test_app_worker_detail() -> App {
+        let mut app = test_app();
+        app.workspaces[0].workers.push(test_worker());
+        app.view = View::WorkerDetail(0);
+        app.worker_selection = 0;
+        app
+    }
+
+    #[test]
+    fn test_c_key_enters_worker_chat() {
+        let mut app = test_app_worker_detail();
+
+        handle_worker_detail_key(&mut app, key(KeyCode::Char('c')), 0);
+
+        assert_eq!(app.view, View::WorkerChat(0));
+    }
+
+    #[test]
+    fn test_esc_returns_from_worker_chat_to_detail() {
+        let mut app = test_app_worker_detail();
+        app.view = View::WorkerChat(0);
+
+        handle_worker_chat_key(&mut app, key(KeyCode::Esc), 0);
+
+        assert_eq!(app.view, View::WorkerDetail(0));
+    }
+
+    #[test]
+    fn test_c_returns_from_worker_chat_to_detail() {
+        let mut app = test_app_worker_detail();
+        app.view = View::WorkerChat(0);
+
+        handle_worker_chat_key(&mut app, key(KeyCode::Char('c')), 0);
+
+        assert_eq!(app.view, View::WorkerDetail(0));
+    }
+
+    #[test]
+    fn test_worker_chat_scroll_keys() {
+        let mut app = test_app_worker_detail();
+        app.view = View::WorkerChat(0);
+
+        // j scrolls activity
+        handle_worker_chat_key(&mut app, key(KeyCode::Char('j')), 0);
+        let scroll = &app.workspaces[0].workers[0].activity_scroll;
+        assert!(scroll.offset > 0 || !scroll.auto_scroll);
+
+        // k scrolls back
+        handle_worker_chat_key(&mut app, key(KeyCode::Char('k')), 0);
+        assert!(app.needs_redraw);
+    }
+
+    #[test]
+    fn test_worker_detail_tab_toggles_pane_focus() {
+        let mut app = test_app_worker_detail();
+        assert!(!app.worker_activity_focused);
+
+        handle_worker_detail_key(&mut app, key(KeyCode::Tab), 0);
+        assert!(app.worker_activity_focused);
+
+        handle_worker_detail_key(&mut app, key(KeyCode::Tab), 0);
+        assert!(!app.worker_activity_focused);
+    }
+
+    #[test]
+    fn test_worker_detail_scroll_respects_pane_focus() {
+        let mut app = test_app_worker_detail();
+
+        // Default: scroll goes to conversation
+        app.worker_activity_focused = false;
+        handle_worker_detail_key(&mut app, key(KeyCode::Char('j')), 0);
+        let conv_offset = app.workspaces[0].workers[0].conv_scroll.offset;
+        let act_offset = app.workspaces[0].workers[0].activity_scroll.offset;
+        // conv should have scrolled (offset > 0 means scrolled up from bottom)
+        assert!(conv_offset > 0 || !app.workspaces[0].workers[0].conv_scroll.auto_scroll);
+        assert_eq!(act_offset, 0);
+
+        // With activity focused: scroll goes to activity
+        app.worker_activity_focused = true;
+        handle_worker_detail_key(&mut app, key(KeyCode::Char('j')), 0);
+        let act_offset = app.workspaces[0].workers[0].activity_scroll.offset;
+        assert!(act_offset > 0 || !app.workspaces[0].workers[0].activity_scroll.auto_scroll);
     }
 }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -442,14 +442,18 @@ async fn event_loop(
                         use crossterm::event::MouseEventKind;
                         match mouse.kind {
                             MouseEventKind::ScrollUp => {
-                                if matches!(app.view, View::WorkerDetail(_)) {
+                                if matches!(app.view, View::WorkerChat(_)) {
+                                    app.scroll_worker_activity_up(3);
+                                } else if matches!(app.view, View::WorkerDetail(_)) {
                                     app.scroll_worker_conv_up(3);
                                 } else {
                                     app.scroll_chat_up(3);
                                 }
                             }
                             MouseEventKind::ScrollDown => {
-                                if matches!(app.view, View::WorkerDetail(_)) {
+                                if matches!(app.view, View::WorkerChat(_)) {
+                                    app.scroll_worker_activity_down(3);
+                                } else if matches!(app.view, View::WorkerDetail(_)) {
                                     app.scroll_worker_conv_down(3);
                                 } else {
                                     app.scroll_chat_down(3);
@@ -496,7 +500,7 @@ async fn event_loop(
                     AppUpdate::Workers(data) => {
                         app.apply_worker_update(data);
                         // Refresh conversation in background when viewing worker detail
-                        if let View::WorkerDetail(idx) = app.view
+                        if let View::WorkerDetail(idx) | View::WorkerChat(idx) = app.view
                             && let Some(ws) = app.current_ws()
                             && let Some(worker) = ws.workers.get(idx)
                         {
@@ -719,6 +723,7 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
     match &app.view.clone() {
         View::Dashboard => handle_dashboard_key(app, key),
         View::WorkerDetail(i) => handle_worker_detail_key(app, key, *i),
+        View::WorkerChat(i) => handle_worker_chat_key(app, key, *i),
         View::SignalDetail(i) => handle_signal_detail_key(app, key, *i),
         View::SignalList => handle_signal_list_key(app, key),
         View::ReviewList => handle_review_list_key(app, key),
@@ -1141,6 +1146,10 @@ fn handle_worker_detail_key(
             cycle_fullscreen_prev(app, idx);
         }
         KeyCode::Char('c') => {
+            app.view = View::WorkerChat(idx);
+            app.needs_redraw = true;
+        }
+        KeyCode::Char('m') => {
             app.worker_input_active = true;
             app.worker_input.clear();
             app.needs_redraw = true;
@@ -1214,6 +1223,34 @@ fn handle_worker_input_key(
             app.worker_input.push(c);
             app.needs_redraw = true;
         }
+        _ => {}
+    }
+    KeyAction::Redraw
+}
+
+// ── Worker chat keys ─────────────────────────────────────
+
+fn handle_worker_chat_key(app: &mut App, key: crossterm::event::KeyEvent, idx: usize) -> KeyAction {
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('c') => {
+            // Return to WorkerDetail
+            app.view = View::WorkerDetail(idx);
+            app.needs_redraw = true;
+        }
+        KeyCode::Char('j') | KeyCode::Down => app.scroll_worker_activity_up(3),
+        KeyCode::Char('k') | KeyCode::Up => app.scroll_worker_activity_down(3),
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.scroll_worker_activity_down(10);
+        }
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.scroll_worker_activity_up(10);
+        }
+        KeyCode::Char('o') => {
+            if let Some(url) = app.selected_url() {
+                return KeyAction::OpenUrl(url);
+            }
+        }
+        KeyCode::Char('q') => return KeyAction::Quit,
         _ => {}
     }
     KeyAction::Redraw

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -1744,12 +1744,26 @@ fn draw_worker_detail(frame: &mut Frame, app: &App, area: Rect, idx: usize) {
         .split(chunks[1]);
 
     // ── Left: Activity log ──
-    draw_activity_log(frame, worker, body_cols[0]);
+    let activity_block = if app.worker_activity_focused {
+        Block::default()
+            .borders(Borders::RIGHT)
+            .border_style(theme::border_active())
+    } else {
+        Block::default()
+            .borders(Borders::RIGHT)
+            .border_style(Style::default().fg(theme::STEEL))
+    };
+    draw_activity_log_with_block(frame, worker, body_cols[0], activity_block);
 
     // ── Right: Conversation body ──
+    let conv_border_style = if !app.worker_activity_focused {
+        theme::border_active()
+    } else {
+        Style::default().fg(theme::STEEL)
+    };
     let conv_block = Block::default()
-        .borders(Borders::LEFT)
-        .border_style(Style::default().fg(theme::STEEL));
+        .borders(Borders::NONE)
+        .border_style(conv_border_style);
 
     if worker.conversation.is_empty() {
         let inner = conv_block.inner(body_cols[1]);
@@ -1820,7 +1834,7 @@ fn render_activity_lines<'a>(events: &'a [app::WorkerEvent]) -> Vec<Line<'a>> {
                 ("\u{2192}", Style::default().fg(theme::MINT)) // →
             }
             app::WorkerEventKind::UserToWorker => {
-                ("\u{2190}", Style::default().fg(theme::ICE)) // ←
+                ("\u{2192}", Style::default().fg(theme::ICE)) // →
             }
             app::WorkerEventKind::PrOpened => {
                 ("\u{2705}", Style::default().fg(theme::MINT)) // ✅
@@ -1869,10 +1883,13 @@ fn render_activity_lines<'a>(events: &'a [app::WorkerEvent]) -> Vec<Line<'a>> {
     lines
 }
 
-/// Draw the activity log panel (used in the left split of WorkerDetail).
-fn draw_activity_log(frame: &mut Frame, worker: &app::WorkerInfo, area: Rect) {
-    let block = Block::default();
-
+/// Draw the activity log panel with a custom block (used in the left split of WorkerDetail).
+fn draw_activity_log_with_block(
+    frame: &mut Frame,
+    worker: &app::WorkerInfo,
+    area: Rect,
+    block: Block<'_>,
+) {
     if worker.activity.is_empty() {
         let inner = block.inner(area);
         frame.render_widget(block, area);
@@ -2525,6 +2542,8 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 vec![
                     Span::raw(" "),
+                    Span::styled("tab", theme::key_hint()),
+                    Span::styled(":pane  ", theme::key_desc()),
                     Span::styled("c", theme::key_hint()),
                     Span::styled(":activity  ", theme::key_desc()),
                     Span::styled("m", theme::key_hint()),

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -87,6 +87,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
     match &app.view {
         View::Dashboard => draw_dashboard(frame, app, outer[2]),
         View::WorkerDetail(i) => draw_worker_detail(frame, app, outer[2], *i),
+        View::WorkerChat(i) => draw_worker_chat(frame, app, outer[2], *i),
         View::SignalDetail(i) => draw_signal_detail(frame, app, outer[2], *i),
         View::SignalList => draw_signal_list(frame, app, outer[2]),
         View::ReviewList => draw_review_list(frame, app, outer[2]),
@@ -1708,7 +1709,7 @@ fn draw_worker_detail(frame: &mut Frame, app: &App, area: Rect, idx: usize) {
         0
     };
 
-    // Layout: header (1) + conversation (fill) + input (input_h, 0 when inactive)
+    // Layout: header (1) + body (fill) + input (input_h, 0 when inactive)
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -1736,12 +1737,23 @@ fn draw_worker_detail(frame: &mut Frame, app: &App, area: Rect, idx: usize) {
     let header = Paragraph::new(header_line).style(Style::default().bg(theme::COMB));
     frame.render_widget(header, chunks[0]);
 
-    // ── Conversation body — borderless ──
-    let conv_block = Block::default();
+    // ── Split body: activity log (40%) | conversation (60%) ──
+    let body_cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(chunks[1]);
+
+    // ── Left: Activity log ──
+    draw_activity_log(frame, worker, body_cols[0]);
+
+    // ── Right: Conversation body ──
+    let conv_block = Block::default()
+        .borders(Borders::LEFT)
+        .border_style(Style::default().fg(theme::STEEL));
 
     if worker.conversation.is_empty() {
-        let inner = conv_block.inner(chunks[1]);
-        frame.render_widget(conv_block, chunks[1]);
+        let inner = conv_block.inner(body_cols[1]);
+        frame.render_widget(conv_block, body_cols[1]);
         let lines = vec![
             Line::from(""),
             Line::from(vec![
@@ -1760,7 +1772,7 @@ fn draw_worker_detail(frame: &mut Frame, app: &App, area: Rect, idx: usize) {
 
         apiari_tui::scroll::render_scrollable(
             frame,
-            chunks[1],
+            body_cols[1],
             lines,
             &worker.conv_scroll,
             conv_block,
@@ -1784,6 +1796,208 @@ fn draw_worker_detail(frame: &mut Frame, app: &App, area: Rect, idx: usize) {
             .style(theme::text())
             .wrap(Wrap { trim: false });
         frame.render_widget(input_p, input_inner);
+    }
+}
+
+// ── Activity log rendering ──────────────────────────────
+
+/// Render the activity log lines from worker events.
+fn render_activity_lines<'a>(events: &'a [app::WorkerEvent]) -> Vec<Line<'a>> {
+    let mut lines: Vec<Line<'a>> = Vec::new();
+    lines.push(Line::from(""));
+
+    for event in events {
+        let ts_str = event
+            .ts
+            .map(|t| t.format("%H:%M").to_string())
+            .unwrap_or_default();
+
+        let (icon, icon_style) = match event.kind {
+            app::WorkerEventKind::Dispatched => {
+                ("\u{25cf}", Style::default().fg(theme::HONEY)) // ●
+            }
+            app::WorkerEventKind::BeeToWorker => {
+                ("\u{2192}", Style::default().fg(theme::MINT)) // →
+            }
+            app::WorkerEventKind::UserToWorker => {
+                ("\u{2190}", Style::default().fg(theme::ICE)) // ←
+            }
+            app::WorkerEventKind::PrOpened => {
+                ("\u{2705}", Style::default().fg(theme::MINT)) // ✅
+            }
+            app::WorkerEventKind::CiFailed => ("\u{2717}", theme::error()), // ✗
+            app::WorkerEventKind::CiPassed => {
+                ("\u{2713}", theme::status_done()) // ✓
+            }
+            app::WorkerEventKind::Merged => {
+                ("\u{2713}", theme::status_done()) // ✓
+            }
+            app::WorkerEventKind::StatusChange => {
+                ("\u{25cb}", Style::default().fg(theme::SMOKE)) // ○
+            }
+        };
+
+        let kind_label: &str = match event.kind {
+            app::WorkerEventKind::Dispatched => "Task dispatched",
+            app::WorkerEventKind::BeeToWorker => "Bee \u{2192} worker",
+            app::WorkerEventKind::UserToWorker => "You \u{2192} worker",
+            app::WorkerEventKind::PrOpened => "PR opened",
+            app::WorkerEventKind::CiFailed => "CI failed",
+            app::WorkerEventKind::CiPassed => "CI passed",
+            app::WorkerEventKind::Merged => "Merged",
+            app::WorkerEventKind::StatusChange => "Status",
+        };
+
+        // Icon + timestamp + label line
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {icon} "), icon_style),
+            Span::styled(format!("{ts_str}  "), Style::default().fg(theme::SMOKE)),
+            Span::styled(kind_label, theme::muted()),
+        ]));
+
+        // Event text on next line(s), indented
+        for text_line in event.text.lines() {
+            lines.push(Line::from(vec![
+                Span::raw("   "),
+                Span::styled(text_line.to_string(), theme::text()),
+            ]));
+        }
+
+        lines.push(Line::from(""));
+    }
+
+    lines
+}
+
+/// Draw the activity log panel (used in the left split of WorkerDetail).
+fn draw_activity_log(frame: &mut Frame, worker: &app::WorkerInfo, area: Rect) {
+    let block = Block::default();
+
+    if worker.activity.is_empty() {
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        let lines = vec![
+            Line::from(""),
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled("No activity yet.", theme::muted()),
+            ]),
+        ];
+        frame.render_widget(Paragraph::new(lines), inner);
+    } else {
+        let lines = render_activity_lines(&worker.activity);
+        apiari_tui::scroll::render_scrollable(frame, area, lines, &worker.activity_scroll, block);
+    }
+}
+
+// ── Worker chat (full-screen activity view) ──────────────
+
+fn draw_worker_chat(frame: &mut Frame, app: &App, area: Rect, idx: usize) {
+    let ws = match app.current_ws() {
+        Some(ws) => ws,
+        None => return,
+    };
+    let worker = match ws.workers.get(idx) {
+        Some(w) => w,
+        None => return,
+    };
+
+    let phase = app::phase_display(worker);
+
+    // Status icon
+    let (status_icon, status_style) = match phase {
+        "running" => ("\u{25cf}", theme::status_running()),
+        "waiting" => ("\u{25cb}", Style::default().fg(theme::POLLEN)),
+        "completed" => ("\u{2713}", theme::status_done()),
+        "failed" => ("\u{2717}", theme::error()),
+        _ => ("\u{25cb}", theme::status_idle()),
+    };
+
+    // Layout: header (1) + chat body (fill)
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1)])
+        .split(area);
+
+    // ── Header ──
+    let mut header_spans = vec![
+        Span::styled(format!(" {status_icon} "), status_style),
+        Span::styled(format!("{} ", worker.id), theme::title()),
+        Span::styled("Activity Log  ", theme::muted()),
+    ];
+    if let Some(ref pr) = worker.pr {
+        header_spans.push(Span::styled(
+            format!("PR #{} ", pr.number),
+            Style::default().fg(theme::MINT),
+        ));
+        header_spans.push(Span::styled(
+            pr.url.clone(),
+            Style::default().fg(theme::ICE),
+        ));
+    }
+    let header_line = Line::from(header_spans);
+    let header = Paragraph::new(header_line).style(Style::default().bg(theme::COMB));
+    frame.render_widget(header, chunks[0]);
+
+    // ── Chat body: render activity events as conversation entries ──
+    let entries: Vec<conversation::ConversationEntry> = worker
+        .activity
+        .iter()
+        .map(|ev| match ev.kind {
+            app::WorkerEventKind::Dispatched | app::WorkerEventKind::UserToWorker => {
+                let ts = ev
+                    .ts
+                    .map(|t| t.format("%H:%M").to_string())
+                    .unwrap_or_default();
+                conversation::ConversationEntry::User {
+                    text: ev.text.clone(),
+                    timestamp: ts,
+                }
+            }
+            app::WorkerEventKind::BeeToWorker => {
+                let ts = ev
+                    .ts
+                    .map(|t| t.format("%H:%M").to_string())
+                    .unwrap_or_default();
+                conversation::ConversationEntry::AssistantText {
+                    text: ev.text.clone(),
+                    timestamp: ts,
+                }
+            }
+            app::WorkerEventKind::PrOpened
+            | app::WorkerEventKind::CiFailed
+            | app::WorkerEventKind::CiPassed
+            | app::WorkerEventKind::Merged
+            | app::WorkerEventKind::StatusChange => conversation::ConversationEntry::Status {
+                text: ev.text.clone(),
+            },
+        })
+        .collect();
+
+    let block = Block::default();
+
+    if entries.is_empty() {
+        let inner = block.inner(chunks[1]);
+        frame.render_widget(block, chunks[1]);
+        let lines = vec![
+            Line::from(""),
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled("No activity yet.", theme::muted()),
+            ]),
+        ];
+        frame.render_widget(Paragraph::new(lines), inner);
+    } else {
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        conversation::render_conversation(&mut lines, &entries, None, Some("Bee"));
+
+        apiari_tui::scroll::render_scrollable(
+            frame,
+            chunks[1],
+            lines,
+            &worker.activity_scroll,
+            block,
+        );
     }
 }
 
@@ -2312,7 +2526,9 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                 vec![
                     Span::raw(" "),
                     Span::styled("c", theme::key_hint()),
-                    Span::styled(":chat  ", theme::key_desc()),
+                    Span::styled(":activity  ", theme::key_desc()),
+                    Span::styled("m", theme::key_hint()),
+                    Span::styled(":message  ", theme::key_desc()),
                     Span::styled("j/k", theme::key_hint()),
                     Span::styled(":scroll  ", theme::key_desc()),
                     Span::styled("o", theme::key_hint()),
@@ -2324,6 +2540,15 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                 ]
             }
         }
+        View::WorkerChat(_) => vec![
+            Span::raw(" "),
+            Span::styled("j/k", theme::key_hint()),
+            Span::styled(":scroll  ", theme::key_desc()),
+            Span::styled("o", theme::key_hint()),
+            Span::styled(":open PR  ", theme::key_desc()),
+            Span::styled("esc", theme::key_hint()),
+            Span::styled(":back", theme::key_desc()),
+        ],
         View::SignalDetail(_) => vec![
             Span::raw(" "),
             Span::styled("j/k", theme::key_hint()),


### PR DESCRIPTION
## Summary
- Adds a **split-pane layout** to the WorkerDetail view: activity log (40% left) + agent conversation (60% right)
- Activity log shows timestamped, icon-prefixed events: task dispatched, status changes, PR opened/merged
- New **WorkerChat view** (`c` key from WorkerDetail) renders the activity log as a full-screen chat using existing `ConversationEntry` rendering
- Events derived from existing `WorkerInfo` data (prompt, phase, PR info) — no new file I/O required

## Changes
- `app.rs`: Add `WorkerEvent`/`WorkerEventKind` structs, `activity`/`activity_scroll` fields on `WorkerInfo`, `build_worker_activity()` populator, `View::WorkerChat` variant
- `mod.rs`: Add `handle_worker_chat_key`, wire `WorkerChat` in view dispatch, mouse scroll, and conversation refresh
- `render.rs`: Split `draw_worker_detail` into two columns, add `draw_activity_log`/`render_activity_lines`/`draw_worker_chat`, update status bar hints

## Test plan
- [x] `cargo check -p apiari` passes (no warnings)
- [x] `cargo test -p apiari` passes (414 tests)
- [x] `cargo fmt -p apiari` applied
- [ ] Manual: open WorkerDetail for a worker with a PR — verify split pane shows activity on left, conversation on right
- [ ] Manual: press `c` in WorkerDetail — verify full-screen activity chat view opens
- [ ] Manual: press `esc` or `c` in WorkerChat — verify it returns to WorkerDetail
- [ ] Manual: verify `j/k` scroll works in both activity log and conversation panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)