### PR TITLE
feat: auto-start swarm daemon when apiari dispatches workers

### DIFF
--- a/crates/apiari/src/buzz/coordinator/skills/swarm.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/swarm.rs
@@ -47,6 +47,14 @@ pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
          - Send message: `swarm --dir {root} send {{worktree_id}} \"message\"`\n\
          - Close worker: `swarm --dir {root} close {{worktree_id}}`\n\n\
          {agent_line}\n\n\
+         ## Daemon Auto-Start\n\
+         If any swarm command fails with \"daemon not running\" or a connection error, \
+         start the daemon first:\n\
+         ```\n\
+         swarm --dir {root} daemon start\n\
+         ```\n\
+         Wait ~2 seconds, then retry the original command. Do not ask the user about this — \
+         just handle it silently.\n\n\
          When dispatching, always include in the task prompt:\n\
          'Plan and implement this completely in one session — do not pause mid-task \
          for confirmation. Commit and open a PR when done.'\n\n\

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -842,6 +842,9 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 Box::new(SwarmWatcher::new(swarm_config.clone())),
                 swarm_config.interval_secs,
             );
+
+            // Auto-start the swarm daemon if it isn't running
+            ensure_swarm_daemon(&ws.config.root);
         }
 
         for email_config in &buzz_config.watchers.email {
@@ -1925,6 +1928,58 @@ pub fn ensure_daemon() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Ensure the swarm daemon is running for a workspace, starting it if needed.
+///
+/// Checks via `swarm --dir <root> status`. If the daemon is not running,
+/// starts it with `swarm --dir <root> daemon start` and waits up to ~2 seconds
+/// for it to come up. This mirrors `ensure_daemon()` for the apiari daemon.
+fn ensure_swarm_daemon(workspace_root: &std::path::Path) {
+    let dir = workspace_root.display().to_string();
+
+    // Check if swarm daemon is already running
+    let status = std::process::Command::new("swarm")
+        .args(["--dir", &dir, "status"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output();
+
+    if status.is_ok_and(|o| o.status.success()) {
+        info!("swarm daemon already running for {}", dir);
+        return;
+    }
+
+    // Daemon not running — start it
+    info!("swarm daemon not running for {}, starting...", dir);
+    let result = std::process::Command::new("swarm")
+        .args(["--dir", &dir, "daemon", "start"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .stdin(std::process::Stdio::null())
+        .spawn();
+
+    match result {
+        Ok(_child) => {
+            // Wait up to ~2 seconds for daemon to come up
+            for _ in 0..20 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let recheck = std::process::Command::new("swarm")
+                    .args(["--dir", &dir, "status"])
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .output();
+                if recheck.is_ok_and(|o| o.status.success()) {
+                    info!("swarm daemon started for {}", dir);
+                    return;
+                }
+            }
+            warn!("swarm daemon may not have started in time for {}", dir);
+        }
+        Err(e) => {
+            warn!("failed to start swarm daemon for {}: {}", dir, e);
+        }
+    }
 }
 
 fn read_pid() -> Option<u32> {

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -844,7 +844,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             );
 
             // Auto-start the swarm daemon if it isn't running
-            ensure_swarm_daemon(&ws.config.root);
+            ensure_swarm_daemon(&ws.config.root).await;
         }
 
         for email_config in &buzz_config.watchers.email {
@@ -1935,51 +1935,87 @@ pub fn ensure_daemon() -> Result<()> {
 /// Checks via `swarm --dir <root> status`. If the daemon is not running,
 /// starts it with `swarm --dir <root> daemon start` and waits up to ~2 seconds
 /// for it to come up. This mirrors `ensure_daemon()` for the apiari daemon.
-fn ensure_swarm_daemon(workspace_root: &std::path::Path) {
-    let dir = workspace_root.display().to_string();
+async fn ensure_swarm_daemon(workspace_root: &std::path::Path) {
+    let root_display = workspace_root.display();
 
     // Check if swarm daemon is already running
-    let status = std::process::Command::new("swarm")
-        .args(["--dir", &dir, "status"])
+    let status = tokio::process::Command::new("swarm")
+        .arg("--dir")
+        .arg(workspace_root)
+        .arg("status")
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output();
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await;
 
-    if status.is_ok_and(|o| o.status.success()) {
-        info!("swarm daemon already running for {}", dir);
-        return;
+    match &status {
+        Ok(o) if o.status.success() => {
+            info!("swarm daemon already running for {}", root_display);
+            return;
+        }
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            tracing::debug!(
+                "swarm status failed for {}: {}",
+                root_display,
+                stderr.trim()
+            );
+        }
+        Err(e) => {
+            warn!("failed to run `swarm status` for {}: {}", root_display, e);
+            return;
+        }
     }
 
     // Daemon not running — start it
-    info!("swarm daemon not running for {}, starting...", dir);
-    let result = std::process::Command::new("swarm")
-        .args(["--dir", &dir, "daemon", "start"])
+    info!("swarm daemon not running for {}, starting...", root_display);
+    let result = tokio::process::Command::new("swarm")
+        .arg("--dir")
+        .arg(workspace_root)
+        .args(["daemon", "start"])
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
         .stdin(std::process::Stdio::null())
-        .spawn();
+        .output()
+        .await;
 
-    match result {
-        Ok(_child) => {
-            // Wait up to ~2 seconds for daemon to come up
-            for _ in 0..20 {
-                std::thread::sleep(std::time::Duration::from_millis(100));
-                let recheck = std::process::Command::new("swarm")
-                    .args(["--dir", &dir, "status"])
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .output();
-                if recheck.is_ok_and(|o| o.status.success()) {
-                    info!("swarm daemon started for {}", dir);
-                    return;
-                }
-            }
-            warn!("swarm daemon may not have started in time for {}", dir);
+    match &result {
+        Ok(o) if !o.status.success() => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            warn!(
+                "swarm daemon start returned {}: {}",
+                o.status,
+                stderr.trim()
+            );
+            return;
         }
         Err(e) => {
-            warn!("failed to start swarm daemon for {}: {}", dir, e);
+            warn!("failed to start swarm daemon for {}: {}", root_display, e);
+            return;
+        }
+        _ => {}
+    }
+
+    // Wait up to ~2 seconds for daemon to come up
+    for _ in 0..20 {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let recheck = tokio::process::Command::new("swarm")
+            .arg("--dir")
+            .arg(workspace_root)
+            .arg("status")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .await;
+        if recheck.is_ok_and(|o| o.status.success()) {
+            info!("swarm daemon started for {}", root_display);
+            return;
         }
     }
+    warn!(
+        "swarm daemon may not have started in time for {}",
+        root_display
+    );
 }
 
 fn read_pid() -> Option<u32> {


### PR DESCRIPTION
## Summary
- Adds `ensure_swarm_daemon()` that checks if the swarm daemon is running via `swarm --dir <root> status` and starts it with `swarm daemon start` if needed, waiting up to ~2s for it to come up
- Called automatically during workspace initialization when a swarm watcher is configured (in `run_event_loop`)
- Adds fallback instructions in the coordinator's swarm skill prompt so it can silently recover if the daemon dies mid-session

This mirrors how `apiari ui` auto-starts the apiari daemon — the user shouldn't need to know about or manually start the swarm daemon.

## Test plan
- [x] `cargo fmt -p apiari` — clean
- [x] `cargo check -p apiari` — passes
- [x] `cargo test -p apiari` — all 432 tests pass
- [ ] Manual: start apiari daemon with swarm configured but swarm daemon stopped — verify swarm daemon auto-starts
- [ ] Manual: kill swarm daemon mid-session, dispatch a worker — verify coordinator auto-recovers via prompt instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)