### PR TITLE
chore: bump apiari version to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apiari"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "apiari-claude-sdk",
  "apiari-tui",

--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/ApiariTools/apiari"

--- a/crates/apiari/src/buzz/coordinator/skills/swarm.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/swarm.rs
@@ -47,6 +47,13 @@ pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
          - Send message: `swarm --dir {root} send {{worktree_id}} \"message\"`\n\
          - Close worker: `swarm --dir {root} close {{worktree_id}}`\n\n\
          {agent_line}\n\n\
+         ### Daemon Auto-Start\n\
+         Before running any `swarm create`, `send`, or `close` command, first ensure the swarm daemon is running.\n\
+         Run this helper (it will auto-start the daemon if needed):\n\
+         ```bash\n\
+         swarm --dir {root} status >/dev/null 2>&1 || (swarm --dir {root} daemon start &>/dev/null & sleep 2)\n\
+         ```\n\
+         Then proceed with your swarm command. This ensures the daemon is always ready before dispatch.\n\n\
          When dispatching, always include in the task prompt:\n\
          'Plan and implement this completely in one session — do not pause mid-task \
          for confirmation. Commit and open a PR when done.'\n\n\


### PR DESCRIPTION
## Summary
- Bump apiari crate version from 0.1.7 to 0.1.8
- Update Cargo.lock with new version

## Test plan
- CI will validate build and tests pass with the new version
