### PR TITLE
feat: auto-respawn coordinator task on panic or exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apiari"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "apiari-claude-sdk",
  "apiari-tui",

--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/ApiariTools/apiari"

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -65,6 +65,9 @@ struct WorkspaceSlot {
     /// DB path for reopening SignalStore on coordinator respawn.
     db_path: std::path::PathBuf,
     max_session_turns: u32,
+    /// Respawn backoff: number of consecutive respawns and when the last one happened.
+    coord_respawn_count: u32,
+    coord_last_respawn: Option<std::time::Instant>,
 }
 
 /// Key for routing Telegram messages to workspaces.
@@ -988,6 +991,8 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             morning_brief: morning_brief_scheduler,
             db_path: db.clone(),
             max_session_turns,
+            coord_respawn_count: 0,
+            coord_last_respawn: None,
         });
     }
 
@@ -1119,6 +1124,81 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             }
 
             _ = poll_timer.tick() => {
+                // ── Coordinator health check (before watchers so hook dispatches don't get dropped) ──
+                for slot in &mut slots {
+                    if !slot.coord_handle.is_finished() {
+                        continue;
+                    }
+
+                    // Await the finished handle to extract panic info
+                    let old_handle = std::mem::replace(
+                        &mut slot.coord_handle,
+                        tokio::spawn(futures::future::pending()),
+                    );
+                    match old_handle.await {
+                        Ok(()) => {
+                            warn!("[{}] coordinator task exited unexpectedly", slot.name);
+                        }
+                        Err(e) if e.is_panic() => {
+                            let payload = e.into_panic();
+                            let msg = payload
+                                .downcast_ref::<&str>()
+                                .map(|s| s.to_string())
+                                .or_else(|| payload.downcast_ref::<String>().cloned())
+                                .unwrap_or_else(|| "(non-string panic)".to_string());
+                            error!("[{}] coordinator task panicked: {msg}", slot.name);
+                        }
+                        Err(e) => {
+                            error!("[{}] coordinator task cancelled: {e}", slot.name);
+                        }
+                    }
+
+                    // Backoff: if respawned recently, require exponential cooldown (15s, 30s, 60s, 120s, …)
+                    // Reset counter after 5 minutes of stability.
+                    if let Some(last) = slot.coord_last_respawn
+                        && last.elapsed() > std::time::Duration::from_secs(300)
+                    {
+                        slot.coord_respawn_count = 0;
+                    }
+                    let backoff_secs = 15u64.saturating_mul(1u64 << slot.coord_respawn_count.min(4));
+                    if let Some(last) = slot.coord_last_respawn
+                        && last.elapsed() < std::time::Duration::from_secs(backoff_secs)
+                    {
+                        warn!(
+                            "[{}] coordinator respawn backoff ({backoff_secs}s) — skipping this tick",
+                            slot.name
+                        );
+                        continue;
+                    }
+
+                    let mut coordinator = build_coordinator(&slot.name, &slot.config);
+
+                    let coord_store = match SignalStore::open(&slot.db_path, &slot.name) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!("[{}] failed to reopen SignalStore for respawn: {e}", slot.name);
+                            continue;
+                        }
+                    };
+
+                    restore_coordinator_session(&mut coordinator, &coord_store, &slot.name);
+
+                    let (new_tx, new_rx) = mpsc::unbounded_channel::<CoordinatorJob>();
+                    slot.coord_tx = new_tx;
+                    slot.coord_handle = tokio::spawn(run_coordinator_task(
+                        coordinator,
+                        coord_store,
+                        new_rx,
+                        slot.max_session_turns,
+                    ));
+                    slot.coord_respawn_count += 1;
+                    slot.coord_last_respawn = Some(std::time::Instant::now());
+                    info!(
+                        "[{}] coordinator task respawned (attempt {})",
+                        slot.name, slot.coord_respawn_count
+                    );
+                }
+
                 for slot in &mut slots {
                     // Morning brief check (independent of watchers — runs even
                     // for workspaces with no watcher registry entries).
@@ -1355,37 +1435,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
 
                 }
 
-                // ── Coordinator health check ──
-                // If a coordinator task panicked or exited, respawn it.
-                for slot in &mut slots {
-                    if slot.coord_handle.is_finished() {
-                        warn!("[{}] coordinator task died — respawning", slot.name);
-
-                        let mut coordinator = build_coordinator(&slot.name, &slot.config);
-
-                        // Reopen SignalStore for the new coordinator task
-                        let coord_store = match SignalStore::open(&slot.db_path, &slot.name) {
-                            Ok(s) => s,
-                            Err(e) => {
-                                error!("[{}] failed to reopen SignalStore for respawn: {e}", slot.name);
-                                continue;
-                            }
-                        };
-
-                        // Try to restore session so context isn't lost
-                        restore_coordinator_session(&mut coordinator, &coord_store, &slot.name);
-
-                        let (new_tx, new_rx) = mpsc::unbounded_channel::<CoordinatorJob>();
-                        slot.coord_tx = new_tx;
-                        slot.coord_handle = tokio::spawn(run_coordinator_task(
-                            coordinator,
-                            coord_store,
-                            new_rx,
-                            slot.max_session_turns,
-                        ));
-                        info!("[{}] coordinator task respawned", slot.name);
-                    }
-                }
             }
 
             // ── TUI socket requests ──

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -58,7 +58,7 @@ struct WorkspaceSlot {
     config: WorkspaceConfig,
     registry: WatcherRegistry,
     coord_tx: mpsc::UnboundedSender<CoordinatorJob>,
-    coord_handle: tokio::task::JoinHandle<()>,
+    coord_handle: Option<tokio::task::JoinHandle<()>>,
     store: SignalStore,
     pipeline: Pipeline,
     morning_brief: Option<morning_brief::MorningBriefScheduler>,
@@ -985,7 +985,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             config: ws.config.clone(),
             registry,
             coord_tx,
-            coord_handle,
+            coord_handle: Some(coord_handle),
             store,
             pipeline,
             morning_brief: morning_brief_scheduler,
@@ -1126,30 +1126,33 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             _ = poll_timer.tick() => {
                 // ── Coordinator health check (before watchers so hook dispatches don't get dropped) ──
                 for slot in &mut slots {
-                    if !slot.coord_handle.is_finished() {
+                    // Handle is None when awaiting backoff after a previous death
+                    let needs_respawn = match &slot.coord_handle {
+                        Some(h) => h.is_finished(),
+                        None => true,
+                    };
+                    if !needs_respawn {
                         continue;
                     }
 
-                    // Await the finished handle to extract panic info
-                    let old_handle = std::mem::replace(
-                        &mut slot.coord_handle,
-                        tokio::spawn(futures::future::pending()),
-                    );
-                    match old_handle.await {
-                        Ok(()) => {
-                            warn!("[{}] coordinator task exited unexpectedly", slot.name);
-                        }
-                        Err(e) if e.is_panic() => {
-                            let payload = e.into_panic();
-                            let msg = payload
-                                .downcast_ref::<&str>()
-                                .map(|s| s.to_string())
-                                .or_else(|| payload.downcast_ref::<String>().cloned())
-                                .unwrap_or_else(|| "(non-string panic)".to_string());
-                            error!("[{}] coordinator task panicked: {msg}", slot.name);
-                        }
-                        Err(e) => {
-                            error!("[{}] coordinator task cancelled: {e}", slot.name);
+                    // Await the finished handle to extract panic info (only if present)
+                    if let Some(old_handle) = slot.coord_handle.take() {
+                        match old_handle.await {
+                            Ok(()) => {
+                                warn!("[{}] coordinator task exited unexpectedly", slot.name);
+                            }
+                            Err(e) if e.is_panic() => {
+                                let payload = e.into_panic();
+                                let msg = payload
+                                    .downcast_ref::<&str>()
+                                    .map(|s| s.to_string())
+                                    .or_else(|| payload.downcast_ref::<String>().cloned())
+                                    .unwrap_or_else(|| "(non-string panic)".to_string());
+                                error!("[{}] coordinator task panicked: {msg}", slot.name);
+                            }
+                            Err(e) => {
+                                error!("[{}] coordinator task cancelled: {e}", slot.name);
+                            }
                         }
                     }
 
@@ -1185,12 +1188,12 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
 
                     let (new_tx, new_rx) = mpsc::unbounded_channel::<CoordinatorJob>();
                     slot.coord_tx = new_tx;
-                    slot.coord_handle = tokio::spawn(run_coordinator_task(
+                    slot.coord_handle = Some(tokio::spawn(run_coordinator_task(
                         coordinator,
                         coord_store,
                         new_rx,
                         slot.max_session_turns,
-                    ));
+                    )));
                     slot.coord_respawn_count += 1;
                     slot.coord_last_respawn = Some(std::time::Instant::now());
                     info!(

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -58,9 +58,13 @@ struct WorkspaceSlot {
     config: WorkspaceConfig,
     registry: WatcherRegistry,
     coord_tx: mpsc::UnboundedSender<CoordinatorJob>,
+    coord_handle: tokio::task::JoinHandle<()>,
     store: SignalStore,
     pipeline: Pipeline,
     morning_brief: Option<morning_brief::MorningBriefScheduler>,
+    /// DB path for reopening SignalStore on coordinator respawn.
+    db_path: std::path::PathBuf,
+    max_session_turns: u32,
 }
 
 /// Key for routing Telegram messages to workspaces.
@@ -918,25 +922,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             registry.add_with_interval(Box::new(watcher), linear_config.poll_interval_secs);
         }
 
-        let mut coordinator = Coordinator::new(
-            &ws.config.coordinator.model,
-            ws.config.coordinator.max_turns,
-        );
-        coordinator.set_name(ws.config.coordinator.name.clone());
-        let skill_ctx = build_skill_context(&ws.name, &ws.config);
-        coordinator.set_extra_context(build_skills_prompt(&skill_ctx));
-        if let Some(ref preamble) = skill_ctx.prompt_preamble {
-            coordinator.set_prompt_preamble(preamble.clone());
-        }
-        coordinator.set_tools(default_coordinator_tools());
-        coordinator.set_disallowed_tools(default_coordinator_disallowed_tools());
-        coordinator.set_working_dir(ws.config.root.clone());
-        if let Some(settings) = config::coordinator_settings_json() {
-            coordinator.set_settings(settings);
-        }
-        coordinator.set_safety_hooks(Box::new(GitSafetyHooks {
-            workspace_root: ws.config.root.clone(),
-        }));
+        let mut coordinator = build_coordinator(&ws.name, &ws.config);
 
         // Build route key
         if let Some(tg) = &ws.config.telegram {
@@ -951,29 +937,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
         let pipeline = Pipeline::new(pipeline_rules, ws.config.pipeline.batch_window_secs);
 
         // Restore session from DB if available
-        {
-            let conv = ConversationStore::new(store.conn(), &ws.name);
-            match conv.last_session() {
-                Ok(Some(token)) if token.provider == coordinator.provider() => {
-                    info!("[{}] restoring {} session from DB", ws.name, token.provider);
-                    coordinator.restore_session(token);
-                }
-                Ok(Some(token)) => {
-                    info!(
-                        "[{}] skipping session restore: provider mismatch (db={}, current={})",
-                        ws.name,
-                        token.provider,
-                        coordinator.provider()
-                    );
-                }
-                Ok(None) => {
-                    info!("[{}] no previous session to restore", ws.name);
-                }
-                Err(e) => {
-                    warn!("[{}] failed to query last session: {e}", ws.name);
-                }
-            }
-        }
+        restore_coordinator_session(&mut coordinator, &store, &ws.name);
 
         // Spawn dedicated coordinator task for this workspace
         let coord_store = match SignalStore::open(&db, &ws.name) {
@@ -982,7 +946,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
         };
         let (coord_tx, coord_rx) = mpsc::unbounded_channel::<CoordinatorJob>();
         let max_session_turns = ws.config.coordinator.max_session_turns;
-        tokio::spawn(run_coordinator_task(
+        let coord_handle = tokio::spawn(run_coordinator_task(
             coordinator,
             coord_store,
             coord_rx,
@@ -1018,9 +982,12 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             config: ws.config.clone(),
             registry,
             coord_tx,
+            coord_handle,
             store,
             pipeline,
             morning_brief: morning_brief_scheduler,
+            db_path: db.clone(),
+            max_session_turns,
         });
     }
 
@@ -1386,6 +1353,38 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                         });
                     }
 
+                }
+
+                // ── Coordinator health check ──
+                // If a coordinator task panicked or exited, respawn it.
+                for slot in &mut slots {
+                    if slot.coord_handle.is_finished() {
+                        warn!("[{}] coordinator task died — respawning", slot.name);
+
+                        let mut coordinator = build_coordinator(&slot.name, &slot.config);
+
+                        // Reopen SignalStore for the new coordinator task
+                        let coord_store = match SignalStore::open(&slot.db_path, &slot.name) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                error!("[{}] failed to reopen SignalStore for respawn: {e}", slot.name);
+                                continue;
+                            }
+                        };
+
+                        // Try to restore session so context isn't lost
+                        restore_coordinator_session(&mut coordinator, &coord_store, &slot.name);
+
+                        let (new_tx, new_rx) = mpsc::unbounded_channel::<CoordinatorJob>();
+                        slot.coord_tx = new_tx;
+                        slot.coord_handle = tokio::spawn(run_coordinator_task(
+                            coordinator,
+                            coord_store,
+                            new_rx,
+                            slot.max_session_turns,
+                        ));
+                        info!("[{}] coordinator task respawned", slot.name);
+                    }
                 }
             }
 
@@ -2040,6 +2039,51 @@ fn build_skill_context(workspace_name: &str, config: &WorkspaceConfig) -> SkillC
         );
     }
     ctx
+}
+
+/// Build a fresh Coordinator for a workspace (used at startup and on respawn).
+fn build_coordinator(ws_name: &str, config: &WorkspaceConfig) -> Coordinator {
+    let mut coordinator = Coordinator::new(&config.coordinator.model, config.coordinator.max_turns);
+    coordinator.set_name(config.coordinator.name.clone());
+    let skill_ctx = build_skill_context(ws_name, config);
+    coordinator.set_extra_context(build_skills_prompt(&skill_ctx));
+    if let Some(ref preamble) = skill_ctx.prompt_preamble {
+        coordinator.set_prompt_preamble(preamble.clone());
+    }
+    coordinator.set_tools(default_coordinator_tools());
+    coordinator.set_disallowed_tools(default_coordinator_disallowed_tools());
+    coordinator.set_working_dir(config.root.clone());
+    if let Some(settings) = config::coordinator_settings_json() {
+        coordinator.set_settings(settings);
+    }
+    coordinator.set_safety_hooks(Box::new(GitSafetyHooks {
+        workspace_root: config.root.clone(),
+    }));
+    coordinator
+}
+
+/// Try to restore the last coordinator session from the database.
+fn restore_coordinator_session(coordinator: &mut Coordinator, store: &SignalStore, ws_name: &str) {
+    let conv = ConversationStore::new(store.conn(), ws_name);
+    match conv.last_session() {
+        Ok(Some(token)) if token.provider == coordinator.provider() => {
+            info!("[{ws_name}] restoring session from DB");
+            coordinator.restore_session(token);
+        }
+        Ok(Some(token)) => {
+            info!(
+                "[{ws_name}] skipping session restore: provider mismatch (db={}, current={})",
+                token.provider,
+                coordinator.provider()
+            );
+        }
+        Ok(None) => {
+            info!("[{ws_name}] no previous session to restore");
+        }
+        Err(e) => {
+            warn!("[{ws_name}] failed to query last session: {e}");
+        }
+    }
 }
 
 fn write_pid() -> Result<()> {


### PR DESCRIPTION
## Summary
- Monitor coordinator `JoinHandle` in the existing poll timer tick (~15s). If the task has finished (panicked or exited), rebuild the coordinator, restore session from DB, create a new channel, and respawn.
- Extract `build_coordinator()` and `restore_coordinator_session()` helpers for reuse at both startup and respawn.
- Add `coord_handle`, `db_path`, and `max_session_turns` fields to `WorkspaceSlot`.

## Test plan
- [x] `cargo check -p apiari` — compiles clean
- [x] `cargo test -p apiari` — 432 tests pass
- [x] `cargo clippy -p apiari -- -D warnings` — no warnings
- [x] `cargo fmt -p apiari` — formatted
- [x] Install + codesign + daemon restart — all 3 workspaces start, sessions restore, watchers poll normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)