### PR TITLE
feat: add script/command watcher for user-defined integrations

### DIFF
--- a/crates/apiari/src/buzz/config.rs
+++ b/crates/apiari/src/buzz/config.rs
@@ -62,6 +62,9 @@ pub struct WatchersConfig {
     /// Linear watchers.
     #[serde(default)]
     pub linear: Vec<LinearWatcherConfig>,
+    /// Script watchers.
+    #[serde(default)]
+    pub script: Vec<ScriptWatcherConfig>,
 }
 
 /// GitHub watcher configuration.
@@ -195,6 +198,33 @@ pub struct LinearReviewQueueEntry {
     pub name: String,
     /// Query predicate string (e.g. "assignee:me state:active").
     pub query: String,
+}
+
+/// Script/command watcher configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptWatcherConfig {
+    pub name: String,
+    pub command: String,
+    #[serde(default = "default_script_interval")]
+    pub interval_secs: u64,
+    #[serde(default)]
+    pub emit_on_change: bool,
+    #[serde(default = "default_severity_on_fail")]
+    pub severity_on_fail: String,
+    #[serde(default = "default_script_timeout")]
+    pub timeout_secs: u64,
+}
+
+fn default_script_interval() -> u64 {
+    60
+}
+
+fn default_severity_on_fail() -> String {
+    "warning".to_string()
+}
+
+fn default_script_timeout() -> u64 {
+    30
 }
 
 fn default_linear_interval() -> u64 {

--- a/crates/apiari/src/buzz/coordinator/skills/config.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/config.rs
@@ -286,6 +286,8 @@ mod tests {
             email_names: vec!["gmail".to_string()],
             has_notion: true,
             notion_names: vec!["notion".to_string()],
+            has_scripts: false,
+            script_names: vec![],
             has_telegram: true,
             prompt_preamble: None,
             default_agent: "claude".to_string(),
@@ -309,6 +311,8 @@ mod tests {
             has_notion: false,
             has_telegram: false,
             notion_names: vec![],
+            has_scripts: false,
+            script_names: vec![],
             prompt_preamble: None,
             default_agent: "claude".to_string(),
         }

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -48,12 +48,13 @@ pub struct SkillContext {
 /// Each skill checks whether it's applicable (e.g. Sentry skill only
 /// included when `has_sentry` is true) and contributes instructions.
 pub fn build_skills_prompt(ctx: &SkillContext) -> String {
-    let mut sections = Vec::new();
-
     // Always-on skills
-    sections.push(config::build_prompt(ctx));
-    sections.push(signals::build_prompt(ctx));
-    sections.push(memory::build_prompt(ctx));
+    let mut sections = vec![
+        config::build_prompt(ctx),
+        signals::build_prompt(ctx),
+        memory::build_prompt(ctx),
+        scripts::build_prompt(ctx),
+    ];
 
     // Conditional skills
     if let Some(s) = github::build_prompt(ctx) {
@@ -74,10 +75,6 @@ pub fn build_skills_prompt(ctx: &SkillContext) -> String {
     if let Some(s) = notion::build_prompt(ctx) {
         sections.push(s);
     }
-    if let Some(s) = scripts::build_prompt(ctx) {
-        sections.push(s);
-    }
-
     let mut prompt = format!(
         "## Workspace\n\
          Name: {}\n\

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -10,6 +10,7 @@ mod github;
 mod linear;
 mod memory;
 mod notion;
+mod scripts;
 mod sentry;
 mod signals;
 mod swarm;
@@ -32,6 +33,8 @@ pub struct SkillContext {
     pub email_names: Vec<String>,
     pub has_notion: bool,
     pub notion_names: Vec<String>,
+    pub has_scripts: bool,
+    pub script_names: Vec<String>,
     pub has_telegram: bool,
     /// Custom prompt preamble loaded from prompt_file.
     /// If set, replaces the default identity/role sections in the system prompt.
@@ -69,6 +72,9 @@ pub fn build_skills_prompt(ctx: &SkillContext) -> String {
         sections.push(s);
     }
     if let Some(s) = notion::build_prompt(ctx) {
+        sections.push(s);
+    }
+    if let Some(s) = scripts::build_prompt(ctx) {
         sections.push(s);
     }
 
@@ -143,6 +149,8 @@ mod tests {
             email_names: vec![],
             has_notion: false,
             notion_names: vec![],
+            has_scripts: false,
+            script_names: vec![],
             has_telegram: false,
             prompt_preamble: None,
             default_agent: "claude".to_string(),

--- a/crates/apiari/src/buzz/coordinator/skills/scripts.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/scripts.rs
@@ -1,0 +1,36 @@
+//! Scripts skill — teaches the coordinator about user-defined script watchers.
+
+use super::SkillContext;
+
+pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
+    if !ctx.has_scripts {
+        return None;
+    }
+
+    let scripts_dir = dirs::home_dir()
+        .unwrap_or_else(|| ".".into())
+        .join(".config/apiari/scripts");
+
+    let mut prompt = format!(
+        "## Scripts\n\
+         User-defined script watchers are configured. Scripts directory: `{}`\n\
+         Configured scripts: {}\n\n\
+         Signal sources from scripts use the format `script_{{name}}` (e.g. `script_fly-deploys`).\n\n\
+         You CAN write new scripts to the scripts directory when the user asks. Script conventions:\n\
+         - First lines should be comments documenting the script\n\
+         - Use `# Requires:` to list required CLI tools or env vars\n\
+         - Use `# Params:` to list environment variables the script uses\n\
+         - Scripts must be executable (`chmod +x`)\n\
+         - Scripts should exit 0 on success, non-zero on failure\n\
+         - stdout is captured as the signal body (max 10KB)\n\
+         - When `emit_on_change = true`, signals are only emitted when output changes\n",
+        scripts_dir.display(),
+        ctx.script_names.join(", "),
+    );
+
+    prompt.push_str(
+        "\nTo read a script's description, check the first few comment lines of the script file.\n",
+    );
+
+    Some(prompt)
+}

--- a/crates/apiari/src/buzz/coordinator/skills/scripts.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/scripts.rs
@@ -2,14 +2,23 @@
 
 use super::SkillContext;
 
-pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
-    if !ctx.has_scripts {
-        return None;
-    }
-
+pub fn build_prompt(ctx: &SkillContext) -> String {
     let scripts_dir = dirs::home_dir()
         .unwrap_or_else(|| ".".into())
         .join(".config/apiari/scripts");
+
+    if !ctx.has_scripts {
+        return format!(
+            "## Scripts\n\
+             No script watchers are configured yet. You can set up user-defined script watchers \
+             by adding `[[watchers.script]]` entries to the workspace config and creating scripts \
+             in `{}`.\n\
+             Scripts should document `# Requires:` and `# Params:` at the top, \
+             exit 0 on success / non-zero on failure, and be `chmod +x`.\n\
+             Ask the user if they'd like to set one up.\n",
+            scripts_dir.display(),
+        );
+    }
 
     let mut prompt = format!(
         "## Scripts\n\
@@ -32,5 +41,5 @@ pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
         "\nTo read a script's description, check the first few comment lines of the script file.\n",
     );
 
-    Some(prompt)
+    prompt
 }

--- a/crates/apiari/src/buzz/coordinator/skills/scripts.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/scripts.rs
@@ -22,7 +22,7 @@ pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
          - Use `# Params:` to list environment variables the script uses\n\
          - Scripts must be executable (`chmod +x`)\n\
          - Scripts should exit 0 on success, non-zero on failure\n\
-         - stdout is captured as the signal body (max 10KB)\n\
+         - stdout and stderr are each captured up to 10KB independently\n\
          - When `emit_on_change = true`, signals are only emitted when output changes\n",
         scripts_dir.display(),
         ctx.script_names.join(", "),

--- a/crates/apiari/src/buzz/coordinator/skills/scripts.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/scripts.rs
@@ -31,7 +31,7 @@ pub fn build_prompt(ctx: &SkillContext) -> String {
          - Use `# Params:` to list environment variables the script uses\n\
          - Scripts must be executable (`chmod +x`)\n\
          - Scripts should exit 0 on success, non-zero on failure\n\
-         - stdout and stderr are each captured up to 10KB independently\n\
+         - stdout and stderr are each capped at 10KB independently (up to 20KB combined)\n\
          - When `emit_on_change = true`, signals are only emitted when output changes\n",
         scripts_dir.display(),
         ctx.script_names.join(", "),

--- a/crates/apiari/src/buzz/watcher/mod.rs
+++ b/crates/apiari/src/buzz/watcher/mod.rs
@@ -13,6 +13,7 @@ pub mod github;
 pub mod linear;
 pub mod notion;
 pub mod review_queue;
+pub mod script;
 pub mod sentry;
 pub mod swarm;
 

--- a/crates/apiari/src/buzz/watcher/script.rs
+++ b/crates/apiari/src/buzz/watcher/script.rs
@@ -1,0 +1,311 @@
+//! Script watcher — runs arbitrary shell commands on a configurable interval
+//! and emits signals based on the result.
+
+use async_trait::async_trait;
+use color_eyre::Result;
+use tokio::process::Command;
+use tracing::{info, warn};
+
+use super::Watcher;
+use crate::buzz::config::ScriptWatcherConfig;
+use crate::buzz::signal::store::SignalStore;
+use crate::buzz::signal::{Severity, SignalUpdate};
+
+/// Maximum bytes of stdout/stderr to capture per script execution.
+const MAX_OUTPUT_BYTES: usize = 10 * 1024;
+
+/// Watches by running a shell command and emitting signals based on output/exit code.
+pub struct ScriptWatcher {
+    config: ScriptWatcherConfig,
+    /// Last stdout output, used for change detection when `emit_on_change` is true.
+    last_output: Option<String>,
+    /// Signal source string: `script_{name}`.
+    source: String,
+}
+
+impl ScriptWatcher {
+    pub fn new(config: ScriptWatcherConfig) -> Self {
+        let source = format!("script_{}", config.name);
+        Self {
+            config,
+            last_output: None,
+            source,
+        }
+    }
+
+    /// Expand `~` at the start of a path to the user's home directory.
+    fn expand_tilde(path: &str) -> String {
+        if let Some(rest) = path.strip_prefix("~/") {
+            if let Some(home) = dirs::home_dir() {
+                return format!("{}/{}", home.display(), rest);
+            }
+        }
+        path.to_string()
+    }
+
+    /// Truncate output to MAX_OUTPUT_BYTES, preserving valid UTF-8.
+    fn truncate_output(s: &str) -> &str {
+        if s.len() <= MAX_OUTPUT_BYTES {
+            return s;
+        }
+        // Find a valid char boundary at or before MAX_OUTPUT_BYTES
+        let mut end = MAX_OUTPUT_BYTES;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        &s[..end]
+    }
+}
+
+#[async_trait]
+impl Watcher for ScriptWatcher {
+    fn name(&self) -> &str {
+        &self.config.name
+    }
+
+    fn signal_source(&self) -> &str {
+        &self.source
+    }
+
+    async fn poll(&mut self, _store: &SignalStore) -> Result<Vec<SignalUpdate>> {
+        let command = Self::expand_tilde(&self.config.command);
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(self.config.timeout_secs),
+            Command::new("sh").arg("-c").arg(&command).output(),
+        )
+        .await;
+
+        let output = match result {
+            Ok(Ok(output)) => output,
+            Ok(Err(e)) => {
+                warn!("script '{}': failed to execute: {e}", self.config.name);
+                let signal = SignalUpdate::new(
+                    &self.source,
+                    format!("{}_error", self.source),
+                    format!("Script '{}' failed to execute", self.config.name),
+                    Severity::from_str_loose(&self.config.severity_on_fail),
+                )
+                .with_body(format!("Error: {e}"));
+                return Ok(vec![signal]);
+            }
+            Err(_) => {
+                warn!(
+                    "script '{}': timed out after {}s",
+                    self.config.name, self.config.timeout_secs
+                );
+                let signal = SignalUpdate::new(
+                    &self.source,
+                    format!("{}_timeout", self.source),
+                    format!(
+                        "Script '{}' timed out ({}s)",
+                        self.config.name, self.config.timeout_secs
+                    ),
+                    Severity::from_str_loose(&self.config.severity_on_fail),
+                )
+                .with_body("Script exceeded timeout limit");
+                return Ok(vec![signal]);
+            }
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout_trimmed = Self::truncate_output(stdout.trim());
+        let stderr_trimmed = Self::truncate_output(stderr.trim());
+        let exit_code = output.status.code().unwrap_or(-1);
+
+        // Exit code != 0 → always emit with severity_on_fail
+        if exit_code != 0 {
+            let mut body = String::new();
+            if !stdout_trimmed.is_empty() {
+                body.push_str(stdout_trimmed);
+            }
+            if !stderr_trimmed.is_empty() {
+                if !body.is_empty() {
+                    body.push_str("\n---\n");
+                }
+                body.push_str(stderr_trimmed);
+            }
+            if body.is_empty() {
+                body = format!("Exit code: {exit_code}");
+            }
+
+            let signal = SignalUpdate::new(
+                &self.source,
+                format!("{}_fail", self.source),
+                format!("Script '{}' failed (exit {})", self.config.name, exit_code),
+                Severity::from_str_loose(&self.config.severity_on_fail),
+            )
+            .with_body(body);
+
+            // Update last_output even on failure
+            self.last_output = Some(stdout_trimmed.to_string());
+
+            info!(
+                "script '{}': exit code {exit_code}, emitting failure signal",
+                self.config.name
+            );
+            return Ok(vec![signal]);
+        }
+
+        // Exit code 0 — check emit_on_change
+        let current_output = stdout_trimmed.to_string();
+
+        if self.config.emit_on_change {
+            let changed = match &self.last_output {
+                None => {
+                    // First poll — store output, don't emit
+                    self.last_output = Some(current_output);
+                    return Ok(Vec::new());
+                }
+                Some(prev) => prev != &current_output,
+            };
+
+            self.last_output = Some(current_output.clone());
+
+            if !changed {
+                // Silent heartbeat — no signal
+                return Ok(Vec::new());
+            }
+
+            // Output changed → emit info signal
+            info!(
+                "script '{}': output changed, emitting signal",
+                self.config.name
+            );
+            let signal = SignalUpdate::new(
+                &self.source,
+                format!("{}_changed", self.source),
+                format!("Script '{}' output changed", self.config.name),
+                Severity::Info,
+            )
+            .with_body(current_output);
+
+            Ok(vec![signal])
+        } else {
+            // emit_on_change = false → always emit
+            self.last_output = Some(current_output.clone());
+
+            if current_output.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            let signal = SignalUpdate::new(
+                &self.source,
+                format!("{}_output", self.source),
+                format!("Script '{}'", self.config.name),
+                Severity::Info,
+            )
+            .with_body(current_output);
+
+            Ok(vec![signal])
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> ScriptWatcherConfig {
+        ScriptWatcherConfig {
+            name: "test-script".to_string(),
+            command: "echo hello".to_string(),
+            interval_secs: 60,
+            emit_on_change: false,
+            severity_on_fail: "warning".to_string(),
+            timeout_secs: 30,
+        }
+    }
+
+    #[test]
+    fn test_expand_tilde() {
+        let expanded = ScriptWatcher::expand_tilde("~/scripts/test.sh");
+        assert!(!expanded.starts_with('~'));
+        assert!(expanded.ends_with("/scripts/test.sh"));
+    }
+
+    #[test]
+    fn test_expand_tilde_no_tilde() {
+        let path = "/usr/bin/test";
+        assert_eq!(ScriptWatcher::expand_tilde(path), path);
+    }
+
+    #[test]
+    fn test_truncate_output_short() {
+        let s = "hello world";
+        assert_eq!(ScriptWatcher::truncate_output(s), s);
+    }
+
+    #[test]
+    fn test_truncate_output_long() {
+        let s = "a".repeat(20_000);
+        let truncated = ScriptWatcher::truncate_output(&s);
+        assert_eq!(truncated.len(), MAX_OUTPUT_BYTES);
+    }
+
+    #[test]
+    fn test_new_sets_source() {
+        let watcher = ScriptWatcher::new(test_config());
+        assert_eq!(watcher.signal_source(), "script_test-script");
+    }
+
+    #[test]
+    fn test_name() {
+        let watcher = ScriptWatcher::new(test_config());
+        assert_eq!(watcher.name(), "test-script");
+    }
+
+    #[tokio::test]
+    async fn test_poll_echo_emit_always() {
+        let config = test_config();
+        let mut watcher = ScriptWatcher::new(config);
+        let store = SignalStore::open_memory("test").unwrap();
+        let signals = watcher.poll(&store).await.unwrap();
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].source, "script_test-script");
+        assert!(signals[0].body.as_ref().unwrap().contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn test_poll_emit_on_change_first_silent() {
+        let mut config = test_config();
+        config.emit_on_change = true;
+        let mut watcher = ScriptWatcher::new(config);
+        let store = SignalStore::open_memory("test").unwrap();
+
+        // First poll stores output, doesn't emit
+        let signals = watcher.poll(&store).await.unwrap();
+        assert!(signals.is_empty());
+
+        // Second poll with same output — no signal
+        let signals = watcher.poll(&store).await.unwrap();
+        assert!(signals.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_poll_failure_exit_code() {
+        let mut config = test_config();
+        config.command = "exit 1".to_string();
+        let mut watcher = ScriptWatcher::new(config);
+        let store = SignalStore::open_memory("test").unwrap();
+
+        let signals = watcher.poll(&store).await.unwrap();
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].severity, Severity::Warning);
+        assert!(signals[0].title.contains("failed"));
+    }
+
+    #[tokio::test]
+    async fn test_poll_timeout() {
+        let mut config = test_config();
+        config.command = "sleep 10".to_string();
+        config.timeout_secs = 1;
+        let mut watcher = ScriptWatcher::new(config);
+        let store = SignalStore::open_memory("test").unwrap();
+
+        let signals = watcher.poll(&store).await.unwrap();
+        assert_eq!(signals.len(), 1);
+        assert!(signals[0].title.contains("timed out"));
+    }
+}

--- a/crates/apiari/src/buzz/watcher/script.rs
+++ b/crates/apiari/src/buzz/watcher/script.rs
@@ -1,10 +1,13 @@
 //! Script watcher — runs arbitrary shell commands on a configurable interval
 //! and emits signals based on the result.
 
+use std::process::Stdio;
+
 use async_trait::async_trait;
 use color_eyre::Result;
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use super::Watcher;
 use crate::buzz::config::ScriptWatcherConfig;
@@ -43,17 +46,29 @@ impl ScriptWatcher {
         path.to_string()
     }
 
-    /// Truncate output to MAX_OUTPUT_BYTES, preserving valid UTF-8.
-    fn truncate_output(s: &str) -> &str {
-        if s.len() <= MAX_OUTPUT_BYTES {
-            return s;
+    /// Read up to `MAX_OUTPUT_BYTES` from an async reader into a String.
+    async fn read_capped(
+        reader: &mut (impl tokio::io::AsyncRead + Unpin),
+    ) -> std::io::Result<String> {
+        let mut buf = vec![0u8; MAX_OUTPUT_BYTES + 1];
+        let mut total = 0;
+        loop {
+            let remaining = buf.len() - total;
+            if remaining == 0 {
+                break;
+            }
+            let n = reader.read(&mut buf[total..total + remaining]).await?;
+            if n == 0 {
+                break;
+            }
+            total += n;
+            if total > MAX_OUTPUT_BYTES {
+                total = MAX_OUTPUT_BYTES;
+                break;
+            }
         }
-        // Find a valid char boundary at or before MAX_OUTPUT_BYTES
-        let mut end = MAX_OUTPUT_BYTES;
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        &s[..end]
+        buf.truncate(total);
+        Ok(String::from_utf8_lossy(&buf).into_owned())
     }
 }
 
@@ -67,23 +82,70 @@ impl Watcher for ScriptWatcher {
         &self.source
     }
 
+    /// Disable auto-reconciliation — script watchers intentionally skip emitting
+    /// signals on unchanged polls, so the framework should not resolve prior signals.
+    fn reconcile(
+        &self,
+        _source: &str,
+        _poll_ids: &[String],
+        _store: &SignalStore,
+    ) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn poll(&mut self, _store: &SignalStore) -> Result<Vec<SignalUpdate>> {
         let command = Self::expand_tilde(&self.config.command);
+        debug!("script '{}': running command", self.config.name);
 
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(self.config.timeout_secs),
-            Command::new("sh").arg("-c").arg(&command).output(),
-        )
-        .await;
+        let child_result = Command::new("sh")
+            .arg("-c")
+            .arg(&command)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn();
 
-        let output = match result {
-            Ok(Ok(output)) => output,
-            Ok(Err(e)) => {
-                warn!("script '{}': failed to execute: {e}", self.config.name);
+        let mut child = match child_result {
+            Ok(child) => child,
+            Err(e) => {
+                warn!("script '{}': failed to spawn: {e}", self.config.name);
                 let signal = SignalUpdate::new(
                     &self.source,
                     format!("{}_error", self.source),
                     format!("Script '{}' failed to execute", self.config.name),
+                    Severity::from_str_loose(&self.config.severity_on_fail),
+                )
+                .with_body(format!("Error: {e}"));
+                return Ok(vec![signal]);
+            }
+        };
+
+        // Take ownership of stdout/stderr pipes before waiting
+        let mut stdout_pipe = child.stdout.take().expect("stdout piped");
+        let mut stderr_pipe = child.stderr.take().expect("stderr piped");
+
+        let timeout = std::time::Duration::from_secs(self.config.timeout_secs);
+
+        // Read stdout and stderr concurrently, capped at MAX_OUTPUT_BYTES each
+        let io_future = async {
+            let (stdout_res, stderr_res) = tokio::join!(
+                Self::read_capped(&mut stdout_pipe),
+                Self::read_capped(&mut stderr_pipe),
+            );
+            let status = child.wait().await?;
+            Ok::<_, std::io::Error>((stdout_res?, stderr_res?, status))
+        };
+
+        let (stdout_raw, stderr_raw, status) = match tokio::time::timeout(timeout, io_future).await
+        {
+            Ok(Ok(result)) => result,
+            Ok(Err(e)) => {
+                warn!("script '{}': I/O error: {e}", self.config.name);
+                // kill_on_drop handles cleanup
+                let signal = SignalUpdate::new(
+                    &self.source,
+                    format!("{}_error", self.source),
+                    format!("Script '{}' failed", self.config.name),
                     Severity::from_str_loose(&self.config.severity_on_fail),
                 )
                 .with_body(format!("Error: {e}"));
@@ -94,6 +156,10 @@ impl Watcher for ScriptWatcher {
                     "script '{}': timed out after {}s",
                     self.config.name, self.config.timeout_secs
                 );
+                // Explicitly kill and reap the child to avoid zombies.
+                // kill_on_drop is a safety net, but explicit is better.
+                let _ = child.kill().await;
+                let _ = child.wait().await;
                 let signal = SignalUpdate::new(
                     &self.source,
                     format!("{}_timeout", self.source),
@@ -108,23 +174,21 @@ impl Watcher for ScriptWatcher {
             }
         };
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout_trimmed = Self::truncate_output(stdout.trim());
-        let stderr_trimmed = Self::truncate_output(stderr.trim());
-        let exit_code = output.status.code().unwrap_or(-1);
+        let stdout_trimmed = stdout_raw.trim().to_string();
+        let stderr_trimmed = stderr_raw.trim().to_string();
+        let exit_code = status.code().unwrap_or(-1);
 
         // Exit code != 0 → always emit with severity_on_fail
         if exit_code != 0 {
             let mut body = String::new();
             if !stdout_trimmed.is_empty() {
-                body.push_str(stdout_trimmed);
+                body.push_str(&stdout_trimmed);
             }
             if !stderr_trimmed.is_empty() {
                 if !body.is_empty() {
                     body.push_str("\n---\n");
                 }
-                body.push_str(stderr_trimmed);
+                body.push_str(&stderr_trimmed);
             }
             if body.is_empty() {
                 body = format!("Exit code: {exit_code}");
@@ -138,8 +202,7 @@ impl Watcher for ScriptWatcher {
             )
             .with_body(body);
 
-            // Update last_output even on failure
-            self.last_output = Some(stdout_trimmed.to_string());
+            self.last_output = Some(stdout_trimmed);
 
             info!(
                 "script '{}': exit code {exit_code}, emitting failure signal",
@@ -149,26 +212,22 @@ impl Watcher for ScriptWatcher {
         }
 
         // Exit code 0 — check emit_on_change
-        let current_output = stdout_trimmed.to_string();
-
         if self.config.emit_on_change {
             let changed = match &self.last_output {
                 None => {
                     // First poll — store output, don't emit
-                    self.last_output = Some(current_output);
+                    self.last_output = Some(stdout_trimmed);
                     return Ok(Vec::new());
                 }
-                Some(prev) => prev != &current_output,
+                Some(prev) => *prev != stdout_trimmed,
             };
 
-            self.last_output = Some(current_output.clone());
+            self.last_output = Some(stdout_trimmed.clone());
 
             if !changed {
-                // Silent heartbeat — no signal
                 return Ok(Vec::new());
             }
 
-            // Output changed → emit info signal
             info!(
                 "script '{}': output changed, emitting signal",
                 self.config.name
@@ -179,14 +238,14 @@ impl Watcher for ScriptWatcher {
                 format!("Script '{}' output changed", self.config.name),
                 Severity::Info,
             )
-            .with_body(current_output);
+            .with_body(stdout_trimmed);
 
             Ok(vec![signal])
         } else {
             // emit_on_change = false → always emit
-            self.last_output = Some(current_output.clone());
+            self.last_output = Some(stdout_trimmed.clone());
 
-            if current_output.is_empty() {
+            if stdout_trimmed.is_empty() {
                 return Ok(Vec::new());
             }
 
@@ -196,7 +255,7 @@ impl Watcher for ScriptWatcher {
                 format!("Script '{}'", self.config.name),
                 Severity::Info,
             )
-            .with_body(current_output);
+            .with_body(stdout_trimmed);
 
             Ok(vec![signal])
         }
@@ -221,27 +280,19 @@ mod tests {
     #[test]
     fn test_expand_tilde() {
         let expanded = ScriptWatcher::expand_tilde("~/scripts/test.sh");
-        assert!(!expanded.starts_with('~'));
-        assert!(expanded.ends_with("/scripts/test.sh"));
+        if dirs::home_dir().is_some() {
+            assert!(!expanded.starts_with('~'));
+            assert!(expanded.ends_with("/scripts/test.sh"));
+        } else {
+            // No home dir available (e.g. CI container) — returns unchanged
+            assert_eq!(expanded, "~/scripts/test.sh");
+        }
     }
 
     #[test]
     fn test_expand_tilde_no_tilde() {
         let path = "/usr/bin/test";
         assert_eq!(ScriptWatcher::expand_tilde(path), path);
-    }
-
-    #[test]
-    fn test_truncate_output_short() {
-        let s = "hello world";
-        assert_eq!(ScriptWatcher::truncate_output(s), s);
-    }
-
-    #[test]
-    fn test_truncate_output_long() {
-        let s = "a".repeat(20_000);
-        let truncated = ScriptWatcher::truncate_output(&s);
-        assert_eq!(truncated.len(), MAX_OUTPUT_BYTES);
     }
 
     #[test]
@@ -307,5 +358,30 @@ mod tests {
         let signals = watcher.poll(&store).await.unwrap();
         assert_eq!(signals.len(), 1);
         assert!(signals[0].title.contains("timed out"));
+    }
+
+    #[tokio::test]
+    async fn test_read_capped_limits_output() {
+        // Generate output larger than MAX_OUTPUT_BYTES
+        let big_cmd = format!("python3 -c \"print('x' * {})\"", MAX_OUTPUT_BYTES + 5000);
+        let mut config = test_config();
+        config.command = big_cmd;
+        let mut watcher = ScriptWatcher::new(config);
+        let store = SignalStore::open_memory("test").unwrap();
+
+        let signals = watcher.poll(&store).await.unwrap();
+        assert_eq!(signals.len(), 1);
+        let body = signals[0].body.as_ref().unwrap();
+        assert!(body.len() <= MAX_OUTPUT_BYTES);
+    }
+
+    #[test]
+    fn test_reconcile_returns_zero() {
+        let watcher = ScriptWatcher::new(test_config());
+        let store = SignalStore::open_memory("test").unwrap();
+        let result = watcher
+            .reconcile("script_test-script", &[], &store)
+            .unwrap();
+        assert_eq!(result, 0);
     }
 }

--- a/crates/apiari/src/buzz/watcher/script.rs
+++ b/crates/apiari/src/buzz/watcher/script.rs
@@ -35,10 +35,10 @@ impl ScriptWatcher {
 
     /// Expand `~` at the start of a path to the user's home directory.
     fn expand_tilde(path: &str) -> String {
-        if let Some(rest) = path.strip_prefix("~/") {
-            if let Some(home) = dirs::home_dir() {
-                return format!("{}/{}", home.display(), rest);
-            }
+        if let Some(rest) = path.strip_prefix("~/")
+            && let Some(home) = dirs::home_dir()
+        {
+            return format!("{}/{}", home.display(), rest);
         }
         path.to_string()
     }

--- a/crates/apiari/src/buzz/watcher/script.rs
+++ b/crates/apiari/src/buzz/watcher/script.rs
@@ -14,7 +14,7 @@ use crate::buzz::config::ScriptWatcherConfig;
 use crate::buzz::signal::store::SignalStore;
 use crate::buzz::signal::{Severity, SignalUpdate};
 
-/// Maximum bytes of stdout/stderr to capture per script execution.
+/// Maximum bytes of stdout/stderr to retain per stream per script execution.
 const MAX_OUTPUT_BYTES: usize = 10 * 1024;
 
 /// Watches by running a shell command and emitting signals based on output/exit code.
@@ -46,29 +46,26 @@ impl ScriptWatcher {
         path.to_string()
     }
 
-    /// Read up to `MAX_OUTPUT_BYTES` from an async reader into a String.
+    /// Read from an async reader, retaining up to `MAX_OUTPUT_BYTES` but draining
+    /// to EOF so the child process never blocks on a full pipe.
     async fn read_capped(
         reader: &mut (impl tokio::io::AsyncRead + Unpin),
     ) -> std::io::Result<String> {
-        let mut buf = vec![0u8; MAX_OUTPUT_BYTES + 1];
-        let mut total = 0;
+        let mut retained = Vec::with_capacity(MAX_OUTPUT_BYTES);
+        let mut buf = [0u8; 8192];
         loop {
-            let remaining = buf.len() - total;
-            if remaining == 0 {
-                break;
-            }
-            let n = reader.read(&mut buf[total..total + remaining]).await?;
+            let n = reader.read(&mut buf).await?;
             if n == 0 {
                 break;
             }
-            total += n;
-            if total > MAX_OUTPUT_BYTES {
-                total = MAX_OUTPUT_BYTES;
-                break;
+            let remaining = MAX_OUTPUT_BYTES.saturating_sub(retained.len());
+            if remaining > 0 {
+                let take = n.min(remaining);
+                retained.extend_from_slice(&buf[..take]);
             }
+            // Keep reading (and discarding) until EOF to prevent pipe blocking
         }
-        buf.truncate(total);
-        Ok(String::from_utf8_lossy(&buf).into_owned())
+        Ok(String::from_utf8_lossy(&retained).into_owned())
     }
 }
 
@@ -82,15 +79,16 @@ impl Watcher for ScriptWatcher {
         &self.source
     }
 
-    /// Disable auto-reconciliation — script watchers intentionally skip emitting
-    /// signals on unchanged polls, so the framework should not resolve prior signals.
+    /// Suppress auto-reconciliation — script watchers intentionally skip emitting
+    /// signals on unchanged polls, so the framework must not resolve prior signals.
+    /// Returns Ok(1) to indicate custom reconcile handled it (skips auto-reconcile).
     fn reconcile(
         &self,
         _source: &str,
         _poll_ids: &[String],
         _store: &SignalStore,
     ) -> Result<usize> {
-        Ok(0)
+        Ok(1)
     }
 
     async fn poll(&mut self, _store: &SignalStore) -> Result<Vec<SignalUpdate>> {
@@ -362,26 +360,36 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_capped_limits_output() {
-        // Generate output larger than MAX_OUTPUT_BYTES
-        let big_cmd = format!("python3 -c \"print('x' * {})\"", MAX_OUTPUT_BYTES + 5000);
-        let mut config = test_config();
-        config.command = big_cmd;
-        let mut watcher = ScriptWatcher::new(config);
-        let store = SignalStore::open_memory("test").unwrap();
+        let data = vec![b'x'; MAX_OUTPUT_BYTES + 5000];
+        let mut cursor = std::io::Cursor::new(data);
+        let result = ScriptWatcher::read_capped(&mut cursor).await.unwrap();
+        assert_eq!(result.len(), MAX_OUTPUT_BYTES);
+        assert!(result.chars().all(|c| c == 'x'));
+    }
 
-        let signals = watcher.poll(&store).await.unwrap();
-        assert_eq!(signals.len(), 1);
-        let body = signals[0].body.as_ref().unwrap();
-        assert!(body.len() <= MAX_OUTPUT_BYTES);
+    #[tokio::test]
+    async fn test_read_capped_small_input() {
+        let data = b"hello world";
+        let mut cursor = std::io::Cursor::new(data.to_vec());
+        let result = ScriptWatcher::read_capped(&mut cursor).await.unwrap();
+        assert_eq!(result, "hello world");
+    }
+
+    #[tokio::test]
+    async fn test_read_capped_empty() {
+        let mut cursor = std::io::Cursor::new(Vec::<u8>::new());
+        let result = ScriptWatcher::read_capped(&mut cursor).await.unwrap();
+        assert!(result.is_empty());
     }
 
     #[test]
-    fn test_reconcile_returns_zero() {
+    fn test_reconcile_suppresses_auto_reconcile() {
         let watcher = ScriptWatcher::new(test_config());
         let store = SignalStore::open_memory("test").unwrap();
         let result = watcher
             .reconcile("script_test-script", &[], &store)
             .unwrap();
-        assert_eq!(result, 0);
+        // Must return > 0 to suppress auto-reconcile in ThrottledWatcher
+        assert!(result > 0);
     }
 }

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -252,6 +252,9 @@ pub struct WatchersConfig {
     /// Linear watchers via `[[watchers.linear]]`.
     #[serde(default)]
     pub linear: Vec<LinearWatcherConfig>,
+    /// Script watchers via `[[watchers.script]]`.
+    #[serde(default)]
+    pub script: Vec<ScriptWatcherConfig>,
 }
 
 /// Email mailbox configuration.
@@ -314,6 +317,33 @@ pub struct LinearWatcherConfig {
 pub struct LinearReviewQueueEntry {
     pub name: String,
     pub query: String,
+}
+
+/// Script/command watcher configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptWatcherConfig {
+    pub name: String,
+    pub command: String,
+    #[serde(default = "default_script_interval")]
+    pub interval_secs: u64,
+    #[serde(default)]
+    pub emit_on_change: bool,
+    #[serde(default = "default_severity_on_fail")]
+    pub severity_on_fail: String,
+    #[serde(default = "default_script_timeout")]
+    pub timeout_secs: u64,
+}
+
+fn default_script_interval() -> u64 {
+    60
+}
+
+fn default_severity_on_fail() -> String {
+    "warning".to_string()
+}
+
+fn default_script_timeout() -> u64 {
+    30
 }
 
 fn default_linear_interval() -> u64 {
@@ -593,6 +623,12 @@ pub fn build_skill_context(
         .iter()
         .map(|n| n.name.clone())
         .collect();
+    let script_names: Vec<String> = config
+        .watchers
+        .script
+        .iter()
+        .map(|s| s.name.clone())
+        .collect();
     crate::buzz::coordinator::skills::SkillContext {
         workspace_name: workspace_name.to_string(),
         workspace_root: config.root.clone(),
@@ -608,6 +644,8 @@ pub fn build_skill_context(
         email_names,
         has_notion: !notion_names.is_empty(),
         notion_names,
+        has_scripts: !script_names.is_empty(),
+        script_names,
         has_telegram: config.telegram.is_some(),
         prompt_preamble: config.coordinator.prompt.clone(),
         default_agent: config.swarm.default_agent.clone(),
@@ -721,6 +759,19 @@ pub fn to_buzz_config(ws: &WorkspaceConfig) -> crate::buzz::config::BuzzConfig {
                             query: e.query.clone(),
                         })
                         .collect(),
+                })
+                .collect(),
+            script: ws
+                .watchers
+                .script
+                .iter()
+                .map(|s| crate::buzz::config::ScriptWatcherConfig {
+                    name: s.name.clone(),
+                    command: s.command.clone(),
+                    interval_secs: s.interval_secs,
+                    emit_on_change: s.emit_on_change,
+                    severity_on_fail: s.severity_on_fail.clone(),
+                    timeout_secs: s.timeout_secs,
                 })
                 .collect(),
         },

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -928,8 +928,8 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
 
         for script_config in &buzz_config.watchers.script {
             info!(
-                "[{}] enabling script watcher '{}' ({})",
-                ws.name, script_config.name, script_config.command
+                "[{}] enabling script watcher '{}'",
+                ws.name, script_config.name
             );
             registry.add_with_interval(
                 Box::new(ScriptWatcher::new(script_config.clone())),

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -34,6 +34,7 @@ use crate::buzz::watcher::github::GithubWatcher;
 use crate::buzz::watcher::linear::LinearWatcher;
 use crate::buzz::watcher::notion::NotionWatcher;
 use crate::buzz::watcher::review_queue::ReviewQueueWatcher;
+use crate::buzz::watcher::script::ScriptWatcher;
 use crate::buzz::watcher::sentry::SentryWatcher;
 use crate::buzz::watcher::swarm::SwarmWatcher;
 
@@ -923,6 +924,17 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 query_names.join(", ")
             );
             registry.add_with_interval(Box::new(watcher), linear_config.poll_interval_secs);
+        }
+
+        for script_config in &buzz_config.watchers.script {
+            info!(
+                "[{}] enabling script watcher '{}' ({})",
+                ws.name, script_config.name, script_config.command
+            );
+            registry.add_with_interval(
+                Box::new(ScriptWatcher::new(script_config.clone())),
+                script_config.interval_secs,
+            );
         }
 
         let mut coordinator = build_coordinator(&ws.name, &ws.config);


### PR DESCRIPTION
## Summary
- Adds a new `[[watchers.script]]` watcher type that runs arbitrary shell commands on a configurable interval and emits signals based on output/exit code
- Supports `emit_on_change` mode (only signal when output differs), configurable timeout (default 30s), failure severity, and 10KB output cap
- Adds a `scripts` coordinator skill that teaches the AI about configured script watchers and the scripts directory convention

## Config format
```toml
[[watchers.script]]
name = "fly-deploys"
command = "~/.config/apiari/scripts/fly-deploys.sh"
interval_secs = 60
emit_on_change = true
severity_on_fail = "warning"
```

## Files changed
- `crates/apiari/src/buzz/watcher/script.rs` — new script watcher implementation
- `crates/apiari/src/buzz/coordinator/skills/scripts.rs` — new coordinator skill
- `crates/apiari/src/config.rs` — `ScriptWatcherConfig` struct and wiring
- `crates/apiari/src/buzz/config.rs` — buzz-level config struct
- `crates/apiari/src/daemon/mod.rs` — watcher registration
- `crates/apiari/src/buzz/watcher/mod.rs` — module registration
- `crates/apiari/src/buzz/coordinator/skills/mod.rs` — skill registration + `SkillContext` fields
- `crates/apiari/src/buzz/coordinator/skills/config.rs` — test fixture updates

## Test plan
- [x] `cargo check -p apiari` passes
- [x] `cargo test -p apiari` passes (442 tests, including new script watcher tests)
- [x] `cargo fmt -p apiari` applied
- [ ] Manual test: configure a `[[watchers.script]]` with a simple `echo` command and verify signals appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)