### PR TITLE
feat: add /devmode toggle for elevated coordinator Bash permissions

### DIFF
--- a/crates/apiari/src/buzz/coordinator/audit.rs
+++ b/crates/apiari/src/buzz/coordinator/audit.rs
@@ -295,6 +295,10 @@ fn is_allowed_write_target(path: &str) -> bool {
         || path.starts_with("/home/")
         || path.starts_with("$HOME/");
     let in_apiari_config = path.contains("/.config/apiari/") || path.ends_with("/.config/apiari");
+    // Block writes to the devmode state file (prevent privilege escalation).
+    if path.ends_with("/.devmode") {
+        return false;
+    }
     (is_home_anchored && in_apiari_config) || path == "~/.config/apiari"
 }
 
@@ -822,22 +826,15 @@ if len(data) > 0:
     // -- Dev-mode aware classification tests --
     //
     // These tests use APIARI_DEVMODE_PATH to isolate the devmode file per test,
-    // serialized via a mutex since env vars are process-global.
-
-    use std::sync::Mutex;
-    static DEVMODE_ENV_LOCK: Mutex<()> = Mutex::new(());
+    // serialized via a shared mutex + RAII guard from the devmode module.
 
     /// Helper: run a closure with devmode on or off, using a temp file.
     fn with_devmode<F: FnOnce()>(enabled: bool, f: F) {
-        let _guard = DEVMODE_ENV_LOCK.lock().unwrap();
-        let tmp = tempfile::tempdir().unwrap();
-        let devmode_file = tmp.path().join(".devmode");
-        unsafe { std::env::set_var("APIARI_DEVMODE_PATH", &devmode_file) };
+        let _guard = super::super::devmode::setup_test_env();
         if enabled {
-            super::super::devmode::enable();
+            super::super::devmode::enable().unwrap();
         }
         f();
-        unsafe { std::env::remove_var("APIARI_DEVMODE_PATH") };
     }
 
     #[test]
@@ -960,7 +957,7 @@ if len(data) > 0:
     fn test_devmode_expired_blocks_commands() {
         with_devmode(false, || {
             // Enable with 0 minutes (immediately expired)
-            super::super::devmode::enable_with_duration(0);
+            super::super::devmode::enable_with_duration(0).unwrap();
             let result = classify_bash_command_with_devmode("mkdir -p new-project");
             assert!(
                 result.is_mutating(),

--- a/crates/apiari/src/buzz/coordinator/audit.rs
+++ b/crates/apiari/src/buzz/coordinator/audit.rs
@@ -51,7 +51,44 @@ const GIT_MUTATING: &[&str] = &[
     "git branch -D",
     "git stash",
     "git cherry-pick",
+    "git clone",
+    "git init",
 ];
+
+/// Commands that require dev-mode to run (blocked by default).
+const DEVMODE_ONLY: &[&str] = &["gh repo create"];
+
+/// Classify a Bash command, taking dev-mode into account.
+///
+/// When dev-mode is active, additional commands are allowed:
+/// `gh repo create`, `git clone`, `git init`, `mkdir`, and general file writes.
+pub fn classify_bash_command_with_devmode(command: &str) -> BashClassification {
+    let result = classify_bash_command(command);
+    if result.is_mutating() && super::devmode::is_active() {
+        if let BashClassification::PotentiallyMutating {
+            ref matched_pattern,
+        } = result
+        {
+            // Patterns unlocked in dev-mode: file creation, repo setup, writes
+            let devmode_unlocked = [
+                "mkdir ",
+                "touch ",
+                "cp ",
+                "mv ",
+                "output redirect",
+                "tee",
+                "curl download",
+                "git clone",
+                "git init",
+                "gh repo create",
+            ];
+            if devmode_unlocked.iter().any(|p| matched_pattern == p) {
+                return BashClassification::ReadOnly;
+            }
+        }
+    }
+    result
+}
 
 /// Classify a Bash command as read-only or potentially mutating.
 ///
@@ -112,6 +149,15 @@ pub fn classify_bash_command(command: &str) -> BashClassification {
         return BashClassification::PotentiallyMutating {
             matched_pattern: "curl download".to_string(),
         };
+    }
+
+    // Dev-mode-only commands (blocked by default, allowed in dev-mode)
+    for &pattern in DEVMODE_ONLY {
+        if contains_pattern(check, pattern) {
+            return BashClassification::PotentiallyMutating {
+                matched_pattern: pattern.to_string(),
+            };
+        }
     }
 
     BashClassification::ReadOnly
@@ -771,5 +817,155 @@ if len(data) > 0:
             result.is_mutating(),
             "writing to non-apiari config dir should be mutating"
         );
+    }
+
+    // -- Dev-mode aware classification tests --
+    //
+    // These tests use APIARI_DEVMODE_PATH to isolate the devmode file per test,
+    // serialized via a mutex since env vars are process-global.
+
+    use std::sync::Mutex;
+    static DEVMODE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Helper: run a closure with devmode on or off, using a temp file.
+    fn with_devmode<F: FnOnce()>(enabled: bool, f: F) {
+        let _guard = DEVMODE_ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let devmode_file = tmp.path().join(".devmode");
+        unsafe { std::env::set_var("APIARI_DEVMODE_PATH", &devmode_file) };
+        if enabled {
+            super::super::devmode::enable();
+        }
+        f();
+        unsafe { std::env::remove_var("APIARI_DEVMODE_PATH") };
+    }
+
+    #[test]
+    fn test_devmode_on_allows_gh_repo_create() {
+        with_devmode(true, || {
+            let result = classify_bash_command_with_devmode("gh repo create my-repo --public");
+            assert_eq!(
+                result,
+                BashClassification::ReadOnly,
+                "gh repo create should be allowed in dev-mode"
+            );
+        });
+    }
+
+    #[test]
+    fn test_devmode_on_allows_git_clone() {
+        with_devmode(true, || {
+            let result =
+                classify_bash_command_with_devmode("git clone https://github.com/example/repo.git");
+            assert_eq!(
+                result,
+                BashClassification::ReadOnly,
+                "git clone should be allowed in dev-mode"
+            );
+        });
+    }
+
+    #[test]
+    fn test_devmode_on_allows_git_init() {
+        with_devmode(true, || {
+            let result = classify_bash_command_with_devmode("git init");
+            assert_eq!(
+                result,
+                BashClassification::ReadOnly,
+                "git init should be allowed in dev-mode"
+            );
+        });
+    }
+
+    #[test]
+    fn test_devmode_on_allows_mkdir() {
+        with_devmode(true, || {
+            let result = classify_bash_command_with_devmode("mkdir -p new-project/src");
+            assert_eq!(
+                result,
+                BashClassification::ReadOnly,
+                "mkdir should be allowed in dev-mode"
+            );
+        });
+    }
+
+    #[test]
+    fn test_devmode_on_allows_file_redirect() {
+        with_devmode(true, || {
+            let result = classify_bash_command_with_devmode("echo 'hello' > src/main.rs");
+            assert_eq!(
+                result,
+                BashClassification::ReadOnly,
+                "file redirect should be allowed in dev-mode"
+            );
+        });
+    }
+
+    #[test]
+    fn test_devmode_off_blocks_commands() {
+        with_devmode(false, || {
+            let result = classify_bash_command_with_devmode("gh repo create my-repo");
+            assert!(
+                result.is_mutating(),
+                "gh repo create should be blocked when dev-mode is off"
+            );
+
+            let result = classify_bash_command_with_devmode("git clone https://github.com/a/b");
+            assert!(
+                result.is_mutating(),
+                "git clone should be blocked when dev-mode is off"
+            );
+
+            let result = classify_bash_command_with_devmode("git init");
+            assert!(
+                result.is_mutating(),
+                "git init should be blocked when dev-mode is off"
+            );
+
+            let result = classify_bash_command_with_devmode("mkdir -p new-project");
+            assert!(
+                result.is_mutating(),
+                "mkdir should be blocked when dev-mode is off"
+            );
+        });
+    }
+
+    #[test]
+    fn test_devmode_on_still_blocks_dangerous_commands() {
+        with_devmode(true, || {
+            // cargo install should still be blocked even in dev-mode
+            let result = classify_bash_command_with_devmode("cargo install --path .");
+            assert!(
+                result.is_mutating(),
+                "cargo install should still be blocked in dev-mode"
+            );
+
+            // rm should still be blocked
+            let result = classify_bash_command_with_devmode("rm -rf /important");
+            assert!(
+                result.is_mutating(),
+                "rm should still be blocked in dev-mode"
+            );
+
+            // git push should still be blocked
+            let result = classify_bash_command_with_devmode("git push origin main");
+            assert!(
+                result.is_mutating(),
+                "git push should still be blocked in dev-mode"
+            );
+        });
+    }
+
+    #[test]
+    fn test_devmode_expired_blocks_commands() {
+        with_devmode(false, || {
+            // Enable with 0 minutes (immediately expired)
+            super::super::devmode::enable_with_duration(0);
+            let result = classify_bash_command_with_devmode("mkdir -p new-project");
+            assert!(
+                result.is_mutating(),
+                "mkdir should be blocked when dev-mode is expired"
+            );
+        });
     }
 }

--- a/crates/apiari/src/buzz/coordinator/audit.rs
+++ b/crates/apiari/src/buzz/coordinator/audit.rs
@@ -64,27 +64,27 @@ const DEVMODE_ONLY: &[&str] = &["gh repo create"];
 /// `gh repo create`, `git clone`, `git init`, `mkdir`, and general file writes.
 pub fn classify_bash_command_with_devmode(command: &str) -> BashClassification {
     let result = classify_bash_command(command);
-    if result.is_mutating() && super::devmode::is_active() {
-        if let BashClassification::PotentiallyMutating {
+    if result.is_mutating()
+        && super::devmode::is_active()
+        && let BashClassification::PotentiallyMutating {
             ref matched_pattern,
         } = result
-        {
-            // Patterns unlocked in dev-mode: file creation, repo setup, writes
-            let devmode_unlocked = [
-                "mkdir ",
-                "touch ",
-                "cp ",
-                "mv ",
-                "output redirect",
-                "tee",
-                "curl download",
-                "git clone",
-                "git init",
-                "gh repo create",
-            ];
-            if devmode_unlocked.iter().any(|p| matched_pattern == p) {
-                return BashClassification::ReadOnly;
-            }
+    {
+        // Patterns unlocked in dev-mode: file creation, repo setup, writes
+        let devmode_unlocked = [
+            "mkdir ",
+            "touch ",
+            "cp ",
+            "mv ",
+            "output redirect",
+            "tee",
+            "curl download",
+            "git clone",
+            "git init",
+            "gh repo create",
+        ];
+        if devmode_unlocked.iter().any(|p| matched_pattern == p) {
+            return BashClassification::ReadOnly;
         }
     }
     result

--- a/crates/apiari/src/buzz/coordinator/devmode.rs
+++ b/crates/apiari/src/buzz/coordinator/devmode.rs
@@ -4,16 +4,21 @@
 //! commands that are normally blocked (e.g. `gh repo create`, `git clone`,
 //! `git init`, `mkdir`, file writes under the workspace root).
 //!
-//! State is persisted as a JSON file at `~/.config/apiari/.devmode`.
+//! State is persisted as a JSON file at `~/.local/state/apiari/.devmode`.
+//! This path is intentionally **outside** `~/.config/apiari/` (which is an
+//! allowed Bash write target) so the coordinator cannot self-enable dev-mode.
 
 use chrono::{DateTime, Duration, Utc};
+use color_eyre::eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
-use crate::config::config_dir;
-
 /// Default dev-mode duration: 30 minutes.
 const DEFAULT_DURATION_MINUTES: i64 = 30;
+
+/// Maximum allowed TTL in minutes. Prevents manual edits from keeping
+/// dev-mode on indefinitely.
+const MAX_TTL_MINUTES: i64 = 60;
 
 /// The devmode state file contents.
 #[derive(Debug, Serialize, Deserialize)]
@@ -24,57 +29,82 @@ pub struct DevModeState {
 
 /// Path to the devmode state file.
 ///
+/// Uses `~/.local/state/apiari/.devmode` — intentionally NOT under
+/// `~/.config/apiari/` to prevent the coordinator from self-enabling
+/// dev-mode via allowed Bash writes.
+///
 /// In tests, set `APIARI_DEVMODE_PATH` to override the default location.
 pub fn devmode_path() -> PathBuf {
     if let Ok(p) = std::env::var("APIARI_DEVMODE_PATH") {
         return PathBuf::from(p);
     }
-    config_dir().join(".devmode")
+    state_dir().join(".devmode")
 }
 
-/// Check if dev-mode is currently active (file exists and not expired).
+/// State directory for runtime files (not config).
+fn state_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| ".".into())
+        .join(".local/state/apiari")
+}
+
+/// Check if dev-mode is currently active (file exists, not expired, valid TTL).
 pub fn is_active() -> bool {
     is_active_at(&devmode_path())
 }
 
 /// Check if dev-mode is active at a specific path.
 fn is_active_at(path: &Path) -> bool {
-    read_state_from(path)
+    read_validated_state_from(path)
         .map(|s| Utc::now() < s.expires_at)
         .unwrap_or(false)
 }
 
 /// Read the devmode state from disk, if present and valid.
 pub fn read_state() -> Option<DevModeState> {
-    read_state_from(&devmode_path())
+    read_validated_state_from(&devmode_path())
 }
 
-fn read_state_from(path: &Path) -> Option<DevModeState> {
+/// Read and validate state from a path. Returns `None` if the file is
+/// missing, unparseable, or has a TTL exceeding `MAX_TTL_MINUTES`.
+fn read_validated_state_from(path: &Path) -> Option<DevModeState> {
     let contents = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&contents).ok()
+    let state: DevModeState = serde_json::from_str(&contents).ok()?;
+    // Enforce maximum TTL — reject tampered expires_at values.
+    let max_expiry = state.enabled_at + Duration::minutes(MAX_TTL_MINUTES);
+    if state.expires_at > max_expiry {
+        // Tampered or invalid — remove and treat as off.
+        let _ = std::fs::remove_file(path);
+        return None;
+    }
+    Some(state)
 }
 
 /// Enable dev-mode with the default 30-minute timeout.
-pub fn enable() -> DevModeState {
+pub fn enable() -> Result<DevModeState> {
     enable_with_duration(DEFAULT_DURATION_MINUTES)
 }
 
 /// Enable dev-mode with a custom duration in minutes.
-pub fn enable_with_duration(minutes: i64) -> DevModeState {
+pub fn enable_with_duration(minutes: i64) -> Result<DevModeState> {
     enable_at(&devmode_path(), minutes)
 }
 
-fn enable_at(path: &Path, minutes: i64) -> DevModeState {
+fn enable_at(path: &Path, minutes: i64) -> Result<DevModeState> {
     let now = Utc::now();
     let state = DevModeState {
         enabled_at: now,
         expires_at: now + Duration::minutes(minutes),
     };
     if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+        std::fs::create_dir_all(parent)
+            .wrap_err_with(|| format!("failed to create devmode dir: {}", parent.display()))?;
     }
-    let _ = std::fs::write(path, serde_json::to_string_pretty(&state).unwrap());
-    state
+    let json =
+        serde_json::to_string_pretty(&state).wrap_err("failed to serialize devmode state")?;
+    std::fs::write(path, json)
+        .wrap_err_with(|| format!("failed to write devmode file: {}", path.display()))?;
+    Ok(state)
 }
 
 /// Disable dev-mode by removing the state file.
@@ -97,6 +127,69 @@ pub fn remaining_str(state: &DevModeState) -> String {
     }
 }
 
+/// Handle a `/devmode` subcommand. Returns the response text.
+///
+/// Shared by both the TUI and Telegram command handlers to avoid duplication.
+pub fn handle_command(args: &str) -> String {
+    match args.trim() {
+        "on" => match enable() {
+            Ok(state) => format!("\u{1f513} Dev mode enabled for {}.", remaining_str(&state)),
+            Err(e) => format!("\u{274c} Failed to enable dev mode: {e}"),
+        },
+        "off" => {
+            disable();
+            "\u{1f512} Dev mode disabled.".to_string()
+        }
+        "status" => {
+            if let Some(state) = read_state() {
+                if Utc::now() < state.expires_at {
+                    format!(
+                        "\u{1f513} Dev mode is ON — {} remaining.",
+                        remaining_str(&state)
+                    )
+                } else {
+                    disable();
+                    "\u{1f512} Dev mode is OFF (expired).".to_string()
+                }
+            } else {
+                "\u{1f512} Dev mode is OFF.".to_string()
+            }
+        }
+        _ => "Usage: /devmode on | off | status".to_string(),
+    }
+}
+
+/// Mutex shared by all tests that manipulate `APIARI_DEVMODE_PATH`.
+#[cfg(test)]
+pub static DEVMODE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// RAII guard that removes the APIARI_DEVMODE_PATH env var on drop.
+#[cfg(test)]
+pub struct DevmodeTestGuard {
+    pub _lock: std::sync::MutexGuard<'static, ()>,
+    pub _tmp: tempfile::TempDir,
+}
+
+#[cfg(test)]
+impl Drop for DevmodeTestGuard {
+    fn drop(&mut self) {
+        unsafe { std::env::remove_var("APIARI_DEVMODE_PATH") };
+    }
+}
+
+/// Set up an isolated devmode env for testing. Returns an RAII guard.
+#[cfg(test)]
+pub fn setup_test_env() -> DevmodeTestGuard {
+    let lock = DEVMODE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    let devmode_file = tmp.path().join(".devmode");
+    unsafe { std::env::set_var("APIARI_DEVMODE_PATH", &devmode_file) };
+    DevmodeTestGuard {
+        _lock: lock,
+        _tmp: tmp,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,7 +199,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join(".devmode");
         assert!(!is_active_at(&path));
-        enable_at(&path, 30);
+        enable_at(&path, 30).unwrap();
         assert!(is_active_at(&path));
         let _ = std::fs::remove_file(&path);
         assert!(!is_active_at(&path));
@@ -116,7 +209,7 @@ mod tests {
     fn test_expired_is_not_active() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join(".devmode");
-        enable_at(&path, 0);
+        enable_at(&path, 0).unwrap();
         assert!(!is_active_at(&path));
     }
 
@@ -130,5 +223,62 @@ mod tests {
         let s = remaining_str(&state);
         assert!(s.contains("m"), "should contain minutes: {s}");
         assert!(s.contains("s"), "should contain seconds: {s}");
+    }
+
+    #[test]
+    fn test_enable_returns_error_on_bad_path() {
+        let result = enable_at(Path::new("/nonexistent/deeply/nested/.devmode"), 30);
+        assert!(result.is_err(), "should fail on unwritable path");
+    }
+
+    #[test]
+    fn test_tampered_ttl_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(".devmode");
+        let now = Utc::now();
+        // Write a state with expires_at far in the future (beyond MAX_TTL_MINUTES)
+        let tampered = DevModeState {
+            enabled_at: now,
+            expires_at: now + Duration::hours(24),
+        };
+        std::fs::write(&path, serde_json::to_string_pretty(&tampered).unwrap()).unwrap();
+        // Should be treated as invalid
+        assert!(!is_active_at(&path), "tampered TTL should be rejected");
+        // File should have been removed
+        assert!(!path.exists(), "tampered devmode file should be removed");
+    }
+
+    #[test]
+    fn test_valid_ttl_accepted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(".devmode");
+        let now = Utc::now();
+        // Write a state within MAX_TTL_MINUTES
+        let valid = DevModeState {
+            enabled_at: now,
+            expires_at: now + Duration::minutes(MAX_TTL_MINUTES),
+        };
+        std::fs::write(&path, serde_json::to_string_pretty(&valid).unwrap()).unwrap();
+        assert!(is_active_at(&path), "valid TTL should be accepted");
+    }
+
+    #[test]
+    fn test_handle_command_off() {
+        let _guard = setup_test_env();
+        let text = handle_command("off");
+        assert!(text.contains("disabled"));
+    }
+
+    #[test]
+    fn test_handle_command_status_when_off() {
+        let _guard = setup_test_env();
+        let text = handle_command("status");
+        assert!(text.contains("OFF"));
+    }
+
+    #[test]
+    fn test_handle_command_invalid() {
+        let text = handle_command("banana");
+        assert!(text.contains("Usage"));
     }
 }

--- a/crates/apiari/src/buzz/coordinator/devmode.rs
+++ b/crates/apiari/src/buzz/coordinator/devmode.rs
@@ -1,0 +1,134 @@
+//! Dev-mode toggle — temporarily unlocks elevated Bash permissions.
+//!
+//! When dev-mode is active, the coordinator is allowed to run additional
+//! commands that are normally blocked (e.g. `gh repo create`, `git clone`,
+//! `git init`, `mkdir`, file writes under the workspace root).
+//!
+//! State is persisted as a JSON file at `~/.config/apiari/.devmode`.
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use crate::config::config_dir;
+
+/// Default dev-mode duration: 30 minutes.
+const DEFAULT_DURATION_MINUTES: i64 = 30;
+
+/// The devmode state file contents.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DevModeState {
+    pub enabled_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Path to the devmode state file.
+///
+/// In tests, set `APIARI_DEVMODE_PATH` to override the default location.
+pub fn devmode_path() -> PathBuf {
+    if let Ok(p) = std::env::var("APIARI_DEVMODE_PATH") {
+        return PathBuf::from(p);
+    }
+    config_dir().join(".devmode")
+}
+
+/// Check if dev-mode is currently active (file exists and not expired).
+pub fn is_active() -> bool {
+    is_active_at(&devmode_path())
+}
+
+/// Check if dev-mode is active at a specific path.
+fn is_active_at(path: &Path) -> bool {
+    read_state_from(path)
+        .map(|s| Utc::now() < s.expires_at)
+        .unwrap_or(false)
+}
+
+/// Read the devmode state from disk, if present and valid.
+pub fn read_state() -> Option<DevModeState> {
+    read_state_from(&devmode_path())
+}
+
+fn read_state_from(path: &Path) -> Option<DevModeState> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+/// Enable dev-mode with the default 30-minute timeout.
+pub fn enable() -> DevModeState {
+    enable_with_duration(DEFAULT_DURATION_MINUTES)
+}
+
+/// Enable dev-mode with a custom duration in minutes.
+pub fn enable_with_duration(minutes: i64) -> DevModeState {
+    enable_at(&devmode_path(), minutes)
+}
+
+fn enable_at(path: &Path, minutes: i64) -> DevModeState {
+    let now = Utc::now();
+    let state = DevModeState {
+        enabled_at: now,
+        expires_at: now + Duration::minutes(minutes),
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(path, serde_json::to_string_pretty(&state).unwrap());
+    state
+}
+
+/// Disable dev-mode by removing the state file.
+pub fn disable() {
+    let _ = std::fs::remove_file(devmode_path());
+}
+
+/// Format the remaining time as a human-readable string.
+pub fn remaining_str(state: &DevModeState) -> String {
+    let remaining = state.expires_at - Utc::now();
+    if remaining.num_seconds() <= 0 {
+        return "expired".to_string();
+    }
+    let mins = remaining.num_minutes();
+    let secs = remaining.num_seconds() % 60;
+    if mins > 0 {
+        format!("{}m {}s", mins, secs)
+    } else {
+        format!("{}s", secs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_enable_disable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(".devmode");
+        assert!(!is_active_at(&path));
+        enable_at(&path, 30);
+        assert!(is_active_at(&path));
+        let _ = std::fs::remove_file(&path);
+        assert!(!is_active_at(&path));
+    }
+
+    #[test]
+    fn test_expired_is_not_active() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(".devmode");
+        enable_at(&path, 0);
+        assert!(!is_active_at(&path));
+    }
+
+    #[test]
+    fn test_remaining_str_format() {
+        let now = Utc::now();
+        let state = DevModeState {
+            enabled_at: now,
+            expires_at: now + Duration::minutes(15) + Duration::seconds(30),
+        };
+        let s = remaining_str(&state);
+        assert!(s.contains("m"), "should contain minutes: {s}");
+        assert!(s.contains("s"), "should contain seconds: {s}");
+    }
+}

--- a/crates/apiari/src/buzz/coordinator/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/mod.rs
@@ -5,6 +5,7 @@
 //! and can proactively notify about signal changes.
 
 pub mod audit;
+pub mod devmode;
 pub mod memory;
 pub mod prompt;
 pub mod skills;

--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -28,6 +28,9 @@ pub fn default_preamble(name: &str) -> String {
            no git add/commit/push, no curl -o/wget into repos, no echo/cat/sed writing to files. \
            The ONLY writes allowed are to /tmp/ (for swarm --prompt-file) and your persistent \
            memory file (see Persistent Memory section if present).\n\
+         - `/devmode on` temporarily unlocks file creation, `gh repo create`, `git clone`, \
+           `git init`, and general file writes for 30 minutes. Use it when the user asks to \
+           create a new repo or needs to write files. Always turn it off when done: `/devmode off`.\n\
          - You CAN read code, investigate issues, check PR status, query signals, \
            and answer questions about the codebase.\n\
          - You already know your workspace context from this prompt. Do NOT use tools \

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1698,36 +1698,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                         let _ = channel.send_message(&OutboundMessage { chat_id, text, buttons: vec![], topic_id }).await;
                                     }
                                     "devmode" => {
-                                        use crate::buzz::coordinator::devmode;
-                                        let text = match args.trim() {
-                                            "on" => {
-                                                let state = devmode::enable();
-                                                format!(
-                                                    "\u{1f513} Dev mode enabled for {}.",
-                                                    devmode::remaining_str(&state)
-                                                )
-                                            }
-                                            "off" => {
-                                                devmode::disable();
-                                                "\u{1f512} Dev mode disabled.".to_string()
-                                            }
-                                            "status" => {
-                                                if let Some(state) = devmode::read_state() {
-                                                    if chrono::Utc::now() < state.expires_at {
-                                                        format!(
-                                                            "\u{1f513} Dev mode is ON — {} remaining.",
-                                                            devmode::remaining_str(&state)
-                                                        )
-                                                    } else {
-                                                        devmode::disable();
-                                                        "\u{1f512} Dev mode is OFF (expired).".to_string()
-                                                    }
-                                                } else {
-                                                    "\u{1f512} Dev mode is OFF.".to_string()
-                                                }
-                                            }
-                                            _ => "Usage: /devmode on | off | status".to_string(),
-                                        };
+                                        let text = crate::buzz::coordinator::devmode::handle_command(&args);
                                         if let Some(ref server) = socket_server {
                                             server.broadcast_activity("telegram", &slot.name, "assistant_message", &text);
                                         }
@@ -2321,36 +2292,7 @@ async fn handle_tui_command(
             true
         }
         "devmode" => {
-            use crate::buzz::coordinator::devmode;
-            let text = match args {
-                "on" => {
-                    let state = devmode::enable();
-                    format!(
-                        "\u{1f513} Dev mode enabled for {}.",
-                        devmode::remaining_str(&state)
-                    )
-                }
-                "off" => {
-                    devmode::disable();
-                    "\u{1f512} Dev mode disabled.".to_string()
-                }
-                "status" => {
-                    if let Some(state) = devmode::read_state() {
-                        if chrono::Utc::now() < state.expires_at {
-                            format!(
-                                "\u{1f513} Dev mode is ON — {} remaining.",
-                                devmode::remaining_str(&state)
-                            )
-                        } else {
-                            devmode::disable();
-                            "\u{1f512} Dev mode is OFF (expired).".to_string()
-                        }
-                    } else {
-                        "\u{1f512} Dev mode is OFF.".to_string()
-                    }
-                }
-                _ => "Usage: /devmode on | off | status".to_string(),
-            };
+            let text = crate::buzz::coordinator::devmode::handle_command(args);
             reply(responder, socket_server, &slot.name, &text);
             true
         }

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1457,12 +1457,13 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
 
                             // Check for slash commands in TUI chat
                             if let Some(rest) = user_text.strip_prefix('/') {
-                                let (command, _args) = match rest.split_once(' ') {
+                                let (command, args) = match rest.split_once(' ') {
                                     Some((cmd, args)) => (cmd, args.trim()),
                                     None => (rest, ""),
                                 };
                                 let handled = handle_tui_command(
                                     command,
+                                    args,
                                     slot,
                                     &client_req.responder,
                                     &socket_server,
@@ -1531,7 +1532,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                         }
                     }
 
-                    ChannelEvent::Command { chat_id, command, topic_id, .. } => {
+                    ChannelEvent::Command { chat_id, command, args, topic_id, .. } => {
                         let key = RouteKey { chat_id, topic_id };
                         let slot_idx = route_map.get(&key).copied()
                             .or_else(|| route_map.get(&RouteKey { chat_id, topic_id: None }).copied());
@@ -1696,8 +1697,44 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                         }
                                         let _ = channel.send_message(&OutboundMessage { chat_id, text, buttons: vec![], topic_id }).await;
                                     }
+                                    "devmode" => {
+                                        use crate::buzz::coordinator::devmode;
+                                        let text = match args.trim() {
+                                            "on" => {
+                                                let state = devmode::enable();
+                                                format!(
+                                                    "\u{1f513} Dev mode enabled for {}.",
+                                                    devmode::remaining_str(&state)
+                                                )
+                                            }
+                                            "off" => {
+                                                devmode::disable();
+                                                "\u{1f512} Dev mode disabled.".to_string()
+                                            }
+                                            "status" => {
+                                                if let Some(state) = devmode::read_state() {
+                                                    if chrono::Utc::now() < state.expires_at {
+                                                        format!(
+                                                            "\u{1f513} Dev mode is ON — {} remaining.",
+                                                            devmode::remaining_str(&state)
+                                                        )
+                                                    } else {
+                                                        devmode::disable();
+                                                        "\u{1f512} Dev mode is OFF (expired).".to_string()
+                                                    }
+                                                } else {
+                                                    "\u{1f512} Dev mode is OFF.".to_string()
+                                                }
+                                            }
+                                            _ => "Usage: /devmode on | off | status".to_string(),
+                                        };
+                                        if let Some(ref server) = socket_server {
+                                            server.broadcast_activity("telegram", &slot.name, "assistant_message", &text);
+                                        }
+                                        let _ = channel.send_message(&OutboundMessage { chat_id, text, buttons: vec![], topic_id }).await;
+                                    }
                                     "help" => {
-                                        let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/update — install latest apiari + swarm from crates.io\n/help — this message".to_string();
+                                        let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/devmode — toggle dev mode (on/off/status)\n/update — install latest apiari + swarm from crates.io\n/help — this message".to_string();
                                         if !slot.config.commands.is_empty() {
                                             text.push_str("\n\nCustom commands:");
                                             for cmd in &slot.config.commands {
@@ -2153,6 +2190,7 @@ fn remove_pid() {
 /// Handle a TUI slash command. Returns `true` if the command was handled.
 async fn handle_tui_command(
     command: &str,
+    args: &str,
     slot: &mut WorkspaceSlot,
     responder: &mpsc::UnboundedSender<socket::DaemonResponse>,
     socket_server: &Option<Arc<socket::DaemonSocketServer>>,
@@ -2282,8 +2320,42 @@ async fn handle_tui_command(
             reply(responder, socket_server, &slot.name, &text);
             true
         }
+        "devmode" => {
+            use crate::buzz::coordinator::devmode;
+            let text = match args {
+                "on" => {
+                    let state = devmode::enable();
+                    format!(
+                        "\u{1f513} Dev mode enabled for {}.",
+                        devmode::remaining_str(&state)
+                    )
+                }
+                "off" => {
+                    devmode::disable();
+                    "\u{1f512} Dev mode disabled.".to_string()
+                }
+                "status" => {
+                    if let Some(state) = devmode::read_state() {
+                        if chrono::Utc::now() < state.expires_at {
+                            format!(
+                                "\u{1f513} Dev mode is ON — {} remaining.",
+                                devmode::remaining_str(&state)
+                            )
+                        } else {
+                            devmode::disable();
+                            "\u{1f512} Dev mode is OFF (expired).".to_string()
+                        }
+                    } else {
+                        "\u{1f512} Dev mode is OFF.".to_string()
+                    }
+                }
+                _ => "Usage: /devmode on | off | status".to_string(),
+            };
+            reply(responder, socket_server, &slot.name, &text);
+            true
+        }
         "help" => {
-            let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/update — install latest apiari + swarm from crates.io\n/help — this message"
+            let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/devmode — toggle dev mode (on/off/status)\n/update — install latest apiari + swarm from crates.io\n/help — this message"
                 .to_string();
             if !slot.config.commands.is_empty() {
                 text.push_str("\n\nCustom commands:");

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -27,7 +27,7 @@ pub fn run() -> i32 {
         }
     };
 
-    match audit::classify_bash_command(&command) {
+    match audit::classify_bash_command_with_devmode(&command) {
         BashClassification::ReadOnly => 0,
         BashClassification::PotentiallyMutating { matched_pattern } => {
             eprintln!(


### PR DESCRIPTION
## Summary
- Adds `/devmode on|off|status` command to both TUI and Telegram handlers to temporarily unlock elevated Bash permissions in the coordinator
- Dev-mode state persisted as JSON at `~/.config/apiari/.devmode` with 30-minute auto-expiry
- When dev-mode is on, the validate-bash hook allows: `gh repo create`, `git clone`, `git init`, `mkdir`, `touch`, `cp`, `mv`, file redirects, `tee`, and `curl` downloads
- When off (default), these operations are blocked — `git clone`, `git init`, and `gh repo create` are now blocked by default (previously allowed)
- Coordinator system prompt updated with dev-mode usage instructions

## Test plan
- [x] `cargo fmt -p apiari` — passes
- [x] `cargo check -p apiari` — passes
- [x] `cargo test -p apiari` — all 443 tests pass
- [x] Tests cover: dev-mode on allows extra commands, off blocks them, expired state treated as off, dangerous commands still blocked in dev-mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)