### PR TITLE
Add devmode status-check instructions to coordinator prompt

### DIFF
--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -33,7 +33,7 @@ pub fn default_preamble(name: &str) -> String {
            create a new repo or needs to write files. Always turn it off when done: `/devmode off`. \
            Check status with `/devmode` (no args) or `/devmode status`. \
            State file: `~/.local/state/apiari/.devmode` (JSON with `enabled_at` and `expires_at` UTC ISO 8601) — \
-           intentionally outside `~/.config/apiari/` to prevent self-enabling.\n\
+           you can also `cat` it directly. Intentionally outside `~/.config/apiari/` to prevent self-enabling.\n\
          - You CAN read code, investigate issues, check PR status, query signals, \
            and answer questions about the codebase.\n\
          - You already know your workspace context from this prompt. Do NOT use tools \


### PR DESCRIPTION
## Summary
- Adds instructions to the coordinator's devmode bullet on how to check current state (`/devmode` or `/devmode status`)
- Documents the state file path (`~/.local/state/apiari/.devmode`) and its JSON schema (`enabled_at` / `expires_at` UTC ISO 8601)
- Notes that the path is intentionally outside `~/.config/apiari/` to prevent self-enablement

## Test plan
- [x] `cargo fmt -p apiari` — no changes needed
- [x] `cargo test -p apiari -- devmode` — all 18 tests pass
- [x] Reviewed `audit.rs` for consistency — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)