### PR TITLE
feat: add gemini as a supported swarm agent option

### DIFF
--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -39,7 +39,7 @@ pub struct SkillContext {
     /// Custom prompt preamble loaded from prompt_file.
     /// If set, replaces the default identity/role sections in the system prompt.
     pub prompt_preamble: Option<String>,
-    /// Default swarm agent: "claude", "codex", or "auto".
+    /// Default swarm agent: "claude", "codex", "gemini", or "auto".
     pub default_agent: String,
 }
 

--- a/crates/apiari/src/buzz/coordinator/skills/swarm.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/swarm.rs
@@ -25,8 +25,11 @@ pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
         "codex" => "Default agent is codex. Use `--agent codex` for autonomous tasks, \
                     or `--agent codex-tui` for persistent sessions."
             .to_string(),
+        "gemini" => "Default agent is gemini. Use `--agent gemini` for autonomous tasks, \
+                     or `--agent gemini-tui` for persistent sessions."
+            .to_string(),
         "auto" => "Agent selection: auto. If `claude` is available, use `--agent claude`; \
-                   otherwise use `--agent codex`. For persistent sessions, append `-tui`."
+                   otherwise use `--agent codex` or `--agent gemini`. For persistent sessions, append `-tui`."
             .to_string(),
         _ => "Default agent is claude. Use `--agent claude` for autonomous tasks, \
               or `--agent claude-tui` for persistent sessions."

--- a/crates/apiari/src/buzz/coordinator/skills/swarm.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/swarm.rs
@@ -28,9 +28,11 @@ pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
         "gemini" => "Default agent is gemini. Use `--agent gemini` for autonomous tasks, \
                      or `--agent gemini-tui` for persistent sessions."
             .to_string(),
-        "auto" => "Agent selection: auto. If `claude` is available, use `--agent claude`; \
-                   otherwise use `--agent codex` or `--agent gemini`. For persistent sessions, append `-tui`."
-            .to_string(),
+        "auto" => {
+            "Agent selection: auto. Use `--agent claude`, `--agent codex`, or `--agent gemini` — \
+                   whichever is available. For persistent sessions, append `-tui`."
+                .to_string()
+        }
         _ => "Default agent is claude. Use `--agent claude` for autonomous tasks, \
               or `--agent claude-tui` for persistent sessions."
             .to_string(),
@@ -39,7 +41,7 @@ pub fn build_prompt(ctx: &SkillContext) -> Option<String> {
     Some(format!(
         "## Swarm Workers\n\
          You dispatch coding tasks to swarm workers. Workers run in their own git worktrees \
-         with a Claude agent that writes code, commits, and opens PRs.\n\n\
+         with an LLM agent that writes code, commits, and opens PRs.\n\n\
          IMPORTANT: When the user asks you to implement, fix, build, or code anything, \
          use `swarm create` to dispatch it. Do NOT write code yourself — \
          not via Edit/Write tools, and not via Bash (no echo, sed, curl -o, etc.).\n\n\

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -842,7 +842,7 @@ pub struct PipelineRuleConfig {
 /// Swarm agent configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SwarmConfig {
-    /// Default agent for swarm workers: "claude", "codex", or "auto".
+    /// Default agent for swarm workers: "claude", "codex", "gemini", or "auto".
     /// When "auto", prefers claude if both binaries are available.
     #[serde(default = "default_swarm_agent")]
     pub default_agent: String,

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -843,7 +843,7 @@ pub struct PipelineRuleConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SwarmConfig {
     /// Default agent for swarm workers: "claude", "codex", "gemini", or "auto".
-    /// When "auto", prefers claude if both binaries are available.
+    /// When "auto", selects an available agent automatically based on the environment.
     #[serde(default = "default_swarm_agent")]
     pub default_agent: String,
 }


### PR DESCRIPTION
## Summary
- Adds `gemini` as a recognized `--agent` option in the coordinator's swarm skill prompt (alongside `claude` and `codex`)
- Updates the `auto` agent selection text to mention gemini as a fallback
- Updates doc comments on `default_agent` fields in `SkillContext` and `SwarmConfig`

## Test plan
- [x] `cargo fmt -p apiari` passes
- [x] `cargo test -p apiari` passes (462 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)