### PR TITLE
feat: depend on apiari-swarm lib for real swarm types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout apiari-swarm
-        uses: actions/checkout@v4
-        with:
-          repository: ApiariTools/swarm
-          path: swarm
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Checkout apiari-swarm
+        uses: actions/checkout@v4
+        with:
+          repository: ApiariTools/swarm
+          path: swarm
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ name = "apiari"
 version = "0.1.8"
 dependencies = [
  "apiari-claude-sdk",
+ "apiari-swarm",
  "apiari-tui",
  "async-imap",
  "async-native-tls",
@@ -158,6 +159,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "apiari-codex-sdk"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79be628101e24b4c4931b307a249dde336201a82a7e28679584017c1d6ee1ecd"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "apiari-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c92973a3eafa1ef613316114483924aeed5791d56f26b0a42e77cc0c9ecb42b"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "apiari-gemini-sdk"
+version = "0.1.0"
+source = "git+https://github.com/ApiariTools/gemini-sdk.git#e635ff6d51c2316982c2a8a4c14b47ee0c8ac0b0"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "apiari-swarm"
+version = "0.1.2"
+dependencies = [
+ "apiari-claude-sdk",
+ "apiari-codex-sdk",
+ "apiari-common",
+ "apiari-gemini-sdk",
+ "apiari-tui",
+ "async-trait",
+ "chrono",
+ "clap",
+ "color-eyre",
+ "crossterm",
+ "dirs",
+ "futures",
+ "libc",
+ "mockall",
+ "pulldown-cmark 0.13.3",
+ "ratatui",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-test",
+ "toml",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "apiari-tui"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,7 +235,7 @@ checksum = "612f2e215d90aaaa077b5101f0c953e45527e5ae2298f9d099c1964e7a3d41d6"
 dependencies = [
  "chrono",
  "crossterm",
- "pulldown-cmark",
+ "pulldown-cmark 0.12.2",
  "ratatui",
  "serde",
  "serde_json",
@@ -624,6 +694,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +808,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
@@ -858,6 +952,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures"
@@ -1556,6 +1656,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1717,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -1838,6 +1971,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,6 +2026,19 @@ name = "pulldown-cmark"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags",
  "getopts",
@@ -2438,6 +2616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2668,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2542,6 +2757,28 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2654,6 +2891,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,8 @@ dependencies = [
 [[package]]
 name = "apiari-gemini-sdk"
 version = "0.1.0"
-source = "git+https://github.com/ApiariTools/gemini-sdk.git#e635ff6d51c2316982c2a8a4c14b47ee0c8ac0b0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63489ff45634612cbf5bfa1b2e5271257c49cdbec0427c18479fe9fa2a470987"
 dependencies = [
  "libc",
  "serde",
@@ -197,29 +198,25 @@ dependencies = [
 
 [[package]]
 name = "apiari-swarm"
-version = "0.1.2"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f084ef4c1723d6d398926db4da8250f6acfd29f4dd1ad76fe216ca5a47c3231"
 dependencies = [
  "apiari-claude-sdk",
  "apiari-codex-sdk",
  "apiari-common",
  "apiari-gemini-sdk",
- "apiari-tui",
  "async-trait",
  "chrono",
  "clap",
  "color-eyre",
- "crossterm",
  "dirs",
  "futures",
  "libc",
- "mockall",
  "pulldown-cmark 0.13.3",
- "ratatui",
  "serde",
  "serde_json",
- "tempfile",
  "tokio",
- "tokio-test",
  "toml",
  "tracing",
  "tracing-appender",
@@ -810,12 +807,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,12 +943,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures"
@@ -1656,33 +1641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,32 +1933,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "predicates"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
-dependencies = [
- "anstyle",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "prettyplease"
@@ -2616,12 +2548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2757,28 +2683,6 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,5 @@ apiari-common = "0.1.0"
 apiari-tui = "0.1.0"
 apiari-claude-sdk = "0.1.0"
 apiari-codex-sdk = "0.1.0"
-apiari-gemini-sdk = { git = "https://github.com/ApiariTools/gemini-sdk.git" }
 chrono-tz = "0.9"
-apiari-swarm = { path = "swarm", version = "0.1.2", default-features = false }
+apiari-swarm = { version = "0.1.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,6 @@ apiari-common = "0.1.0"
 apiari-tui = "0.1.0"
 apiari-claude-sdk = "0.1.0"
 apiari-codex-sdk = "0.1.0"
+apiari-gemini-sdk = { git = "https://github.com/ApiariTools/gemini-sdk.git" }
 chrono-tz = "0.9"
-apiari-swarm = { path = "swarm", version = "0.1.2" }
+apiari-swarm = { path = "swarm", version = "0.1.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ apiari-tui = "0.1.0"
 apiari-claude-sdk = "0.1.0"
 apiari-codex-sdk = "0.1.0"
 chrono-tz = "0.9"
+apiari-swarm = { path = "swarm", version = "0.1.2" }

--- a/README.md
+++ b/README.md
@@ -46,12 +46,8 @@ Apiari runs a persistent daemon that dispatches and monitors AI coding agents (C
 
 ## Install
 
-Apiari is installed from source (not yet on crates.io):
-
 ```sh
-git clone https://github.com/ApiariTools/apiari.git
-cd apiari
-cargo install --path crates/apiari
+cargo install apiari
 ```
 
 On macOS, codesign the binary so it can access the keychain and network:

--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 apiari-claude-sdk.workspace = true
+apiari-swarm.workspace = true
 apiari-tui.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/apiari/src/buzz/watcher/swarm.rs
+++ b/crates/apiari/src/buzz/watcher/swarm.rs
@@ -1,11 +1,12 @@
 //! Swarm watcher — monitors `.swarm/state.json` for worker state changes.
 //!
-//! Simplified from hive's SwarmWatcher: emits SignalUpdates for worker
-//! lifecycle events. The coordinator decides what to notify about.
+//! Uses the real types from `apiari-swarm` to deserialize state.
+//! Emits SignalUpdates for worker lifecycle events. The coordinator decides
+//! what to notify about.
 
+use apiari_swarm::core::state::{SwarmState, WorkerPhase};
 use async_trait::async_trait;
 use color_eyre::Result;
-use serde::Deserialize;
 use std::collections::HashMap;
 use tracing::info;
 
@@ -14,45 +15,10 @@ use crate::buzz::config::SwarmWatcherConfig;
 use crate::buzz::signal::store::SignalStore;
 use crate::buzz::signal::{Severity, SignalStatus, SignalUpdate};
 
-/// Minimal swarm state deserialization.
-#[derive(Debug, Clone, Deserialize)]
-struct SwarmState {
-    #[serde(default)]
-    worktrees: Vec<WorktreeEntry>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)]
-struct WorktreeEntry {
-    id: String,
-    #[serde(default)]
-    repo: Option<String>,
-    #[serde(default)]
-    branch: Option<String>,
-    #[serde(default)]
-    summary: Option<String>,
-    #[serde(default)]
-    pr: Option<PrInfo>,
-    #[serde(default)]
-    agent_kind: Option<String>,
-    #[serde(default)]
-    agent_session_status: Option<String>,
-    #[serde(default)]
-    created_at: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct PrInfo {
-    #[serde(default)]
-    url: Option<String>,
-    #[serde(default)]
-    title: Option<String>,
-}
-
 /// Tracked state for a worktree between polls.
 #[derive(Debug, Clone)]
 struct TrackedWorker {
-    status: Option<String>,
+    phase: WorkerPhase,
     has_pr: bool,
 }
 
@@ -99,8 +65,8 @@ impl Watcher for SwarmWatcher {
                 self.tracked.insert(
                     wt.id.clone(),
                     TrackedWorker {
-                        status: wt.agent_session_status.clone(),
-                        has_pr: wt.pr.as_ref().and_then(|p| p.url.as_ref()).is_some(),
+                        phase: wt.phase.clone(),
+                        has_pr: wt.pr.is_some(),
                     },
                 );
             }
@@ -116,9 +82,12 @@ impl Watcher for SwarmWatcher {
         for wt in &state.worktrees {
             let id = &wt.id;
             let prev = self.tracked.get(id);
-            let current_status = wt.agent_session_status.as_deref();
-            let has_pr = wt.pr.as_ref().and_then(|p| p.url.as_ref()).is_some();
-            let repo = wt.repo.as_deref().unwrap_or("unknown");
+            let has_pr = wt.pr.is_some();
+            let repo = wt
+                .repo_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("unknown");
             let summary = wt.summary.as_deref().unwrap_or("");
 
             if prev.is_none() {
@@ -136,12 +105,7 @@ impl Watcher for SwarmWatcher {
 
             // PR opened transition
             if has_pr && prev.is_some_and(|p| !p.has_pr) {
-                let pr_url = wt.pr.as_ref().and_then(|p| p.url.as_deref()).unwrap_or("");
-                let pr_title = wt
-                    .pr
-                    .as_ref()
-                    .and_then(|p| p.title.as_deref())
-                    .unwrap_or("PR opened");
+                let pr = wt.pr.as_ref().unwrap();
 
                 let mut signal = SignalUpdate::new(
                     "swarm",
@@ -149,38 +113,35 @@ impl Watcher for SwarmWatcher {
                     format!("PR opened: {id}"),
                     Severity::Info,
                 )
-                .with_body(format!("{pr_title}\n{pr_url}"));
+                .with_body(format!("{}\n{}", pr.title, pr.url));
 
-                if !pr_url.is_empty() {
-                    signal = signal.with_url(pr_url);
+                if !pr.url.is_empty() {
+                    signal = signal.with_url(&pr.url);
                 }
 
                 signals.push(signal);
             }
 
-            // Agent waiting transition
-            if current_status == Some("waiting")
-                && prev.is_some_and(|p| p.status.as_deref() != Some("waiting"))
+            // Agent waiting transition (using phase instead of agent_session_status)
+            if wt.phase == WorkerPhase::Waiting
+                && prev.is_some_and(|p| p.phase != WorkerPhase::Waiting)
             {
-                let is_tui = wt.agent_kind.as_deref() == Some("claude-tui");
-                if !is_tui {
-                    signals.push(
-                        SignalUpdate::new(
-                            "swarm",
-                            format!("swarm-waiting-{id}"),
-                            format!("Worker waiting: {id}"),
-                            Severity::Warning,
-                        )
-                        .with_body(format!("Agent in {id} is waiting for input\nrepo: {repo}")),
-                    );
-                }
+                signals.push(
+                    SignalUpdate::new(
+                        "swarm",
+                        format!("swarm-waiting-{id}"),
+                        format!("Worker waiting: {id}"),
+                        Severity::Warning,
+                    )
+                    .with_body(format!("Agent in {id} is waiting for input\nrepo: {repo}")),
+                );
             }
 
             // Update tracked state
             self.tracked.insert(
                 id.clone(),
                 TrackedWorker {
-                    status: wt.agent_session_status.clone(),
+                    phase: wt.phase.clone(),
                     has_pr,
                 },
             );
@@ -257,51 +218,66 @@ impl Watcher for SwarmWatcher {
 mod tests {
     use super::*;
 
+    /// Helper to build a minimal valid WorktreeState JSON object.
+    fn wt_json(id: &str, extras: &str) -> String {
+        let base = format!(
+            r#"{{
+                "id": "{id}",
+                "branch": "swarm/{id}",
+                "prompt": "test task",
+                "agent_kind": "claude",
+                "repo_path": "/tmp/myrepo",
+                "worktree_path": "/tmp/.swarm/wt/{id}",
+                "created_at": "2026-01-01T00:00:00-05:00"
+            }}"#
+        );
+        if extras.is_empty() {
+            return base;
+        }
+        // Insert extras before the closing brace
+        let trimmed = base.trim_end();
+        format!("{},\n{extras}\n}}", &trimmed[..trimmed.len() - 1])
+    }
+
+    /// Build a state.json string from a list of worktree JSON objects.
+    fn state_json(worktrees: &[String]) -> String {
+        format!(
+            r#"{{"session_name": "test", "worktrees": [{}]}}"#,
+            worktrees.join(",")
+        )
+    }
+
     #[test]
     fn test_parse_swarm_state() {
-        let json = r#"{
-            "worktrees": [
-                {
-                    "id": "hive-1",
-                    "repo": "hive",
-                    "branch": "swarm/fix-bug",
-                    "summary": "Fix a bug",
-                    "pr": {"url": "https://github.com/org/repo/pull/1", "title": "Fix bug"},
-                    "agent_kind": "claude",
-                    "agent_session_status": "running"
-                }
-            ]
-        }"#;
-        let state: SwarmState = serde_json::from_str(json).unwrap();
+        let wt = wt_json(
+            "hive-1",
+            r#""summary": "Fix a bug",
+                "pr": {"number": 1, "title": "Fix bug", "state": "OPEN", "url": "https://github.com/org/repo/pull/1"},
+                "phase": "running""#,
+        );
+        let json = state_json(&[wt]);
+        let state: SwarmState = serde_json::from_str(&json).unwrap();
         assert_eq!(state.worktrees.len(), 1);
         let wt = &state.worktrees[0];
         assert_eq!(wt.id, "hive-1");
-        assert_eq!(wt.repo.as_deref(), Some("hive"));
-        assert!(wt.pr.as_ref().unwrap().url.is_some());
+        assert!(wt.pr.is_some());
     }
 
     #[test]
     fn test_parse_empty_state() {
-        let json = r#"{"worktrees": []}"#;
-        let state: SwarmState = serde_json::from_str(json).unwrap();
+        let json = r#"{"session_name": "test", "worktrees": []}"#;
+        let state: SwarmState = serde_json::from_str(&json).unwrap();
         assert!(state.worktrees.is_empty());
     }
 
     #[test]
     fn test_parse_state_missing_optional_fields() {
-        let json = r#"{
-            "worktrees": [
-                {
-                    "id": "wt-1",
-                    "repo": "test"
-                }
-            ]
-        }"#;
-        let state: SwarmState = serde_json::from_str(json).unwrap();
+        let wt = wt_json("wt-1", "");
+        let json = state_json(&[wt]);
+        let state: SwarmState = serde_json::from_str(&json).unwrap();
         let wt = &state.worktrees[0];
         assert!(wt.pr.is_none());
-        assert!(wt.agent_kind.is_none());
-        assert!(wt.agent_session_status.is_none());
+        assert_eq!(wt.phase, WorkerPhase::Running); // default
     }
 
     /// Parse a real state.json snapshot from swarm to guard against format drift.
@@ -346,19 +322,11 @@ mod tests {
 
         let wt = &state.worktrees[0];
         assert_eq!(wt.id, "swarm-042c");
-        assert_eq!(wt.repo.as_deref(), None); // swarm uses repo_path, not repo
-        assert_eq!(wt.agent_kind.as_deref(), Some("claude"));
-        assert_eq!(wt.agent_session_status.as_deref(), Some("waiting"));
+        assert_eq!(wt.phase, WorkerPhase::Waiting);
 
         let pr = wt.pr.as_ref().unwrap();
-        assert_eq!(
-            pr.url.as_deref(),
-            Some("https://github.com/ApiariTools/swarm/pull/64")
-        );
-        assert_eq!(
-            pr.title.as_deref(),
-            Some("fix(ci): add apiari-tui to workspace")
-        );
+        assert_eq!(pr.url, "https://github.com/ApiariTools/swarm/pull/64");
+        assert_eq!(pr.title, "fix(ci): add apiari-tui to workspace");
     }
 
     /// End-to-end: write state files, poll the watcher, verify signals emitted.
@@ -377,11 +345,8 @@ mod tests {
         let mut watcher = SwarmWatcher::new(config);
 
         // Phase 1: worker running — init poll, no signals
-        std::fs::write(
-            &state_path,
-            r#"{"worktrees": [{"id": "w1", "repo": "myrepo", "agent_session_status": "running"}]}"#,
-        )
-        .unwrap();
+        let wt = wt_json("w1", r#""phase": "running""#);
+        std::fs::write(&state_path, state_json(&[wt])).unwrap();
         let signals = watcher.poll(&store).await.unwrap();
         assert!(signals.is_empty(), "init poll should emit nothing");
 
@@ -390,21 +355,19 @@ mod tests {
         assert!(signals.is_empty(), "no transition = no signals");
 
         // Phase 3: worker transitions to waiting — should emit
-        std::fs::write(
-            &state_path,
-            r#"{"worktrees": [{"id": "w1", "repo": "myrepo", "agent_session_status": "waiting"}]}"#,
-        )
-        .unwrap();
+        let wt = wt_json("w1", r#""phase": "waiting""#);
+        std::fs::write(&state_path, state_json(&[wt])).unwrap();
         let signals = watcher.poll(&store).await.unwrap();
         assert_eq!(signals.len(), 1);
         assert!(signals[0].title.contains("waiting"));
 
         // Phase 4: PR opens — should emit
-        std::fs::write(
-            &state_path,
-            r#"{"worktrees": [{"id": "w1", "repo": "myrepo", "agent_session_status": "waiting", "pr": {"url": "https://github.com/org/repo/pull/1", "title": "My PR"}}]}"#,
-        )
-        .unwrap();
+        let wt = wt_json(
+            "w1",
+            r#""phase": "waiting",
+                "pr": {"number": 1, "title": "My PR", "state": "OPEN", "url": "https://github.com/org/repo/pull/1"}"#,
+        );
+        std::fs::write(&state_path, state_json(&[wt])).unwrap();
         let signals = watcher.poll(&store).await.unwrap();
         assert_eq!(signals.len(), 1);
         assert!(signals[0].title.contains("PR opened"));
@@ -414,62 +377,26 @@ mod tests {
         );
 
         // Phase 5: new worker spawns — should emit
-        std::fs::write(
-            &state_path,
-            r#"{"worktrees": [
-                {"id": "w1", "repo": "myrepo", "agent_session_status": "waiting", "pr": {"url": "https://github.com/org/repo/pull/1", "title": "My PR"}},
-                {"id": "w2", "repo": "other", "agent_session_status": "running"}
-            ]}"#,
-        )
-        .unwrap();
+        let wt1 = wt_json(
+            "w1",
+            r#""phase": "waiting",
+                "pr": {"number": 1, "title": "My PR", "state": "OPEN", "url": "https://github.com/org/repo/pull/1"}"#,
+        );
+        let wt2 = wt_json("w2", r#""phase": "running""#);
+        std::fs::write(&state_path, state_json(&[wt1, wt2])).unwrap();
         let signals = watcher.poll(&store).await.unwrap();
         assert_eq!(signals.len(), 1);
         assert!(signals[0].title.contains("spawned"));
 
         // Phase 6: worker closed — should resolve spawned/waiting/pr + emit closed
-        std::fs::write(
-            &state_path,
-            r#"{"worktrees": [{"id": "w1", "repo": "myrepo", "agent_session_status": "waiting", "pr": {"url": "https://github.com/org/repo/pull/1", "title": "My PR"}}]}"#,
-        )
-        .unwrap();
+        let wt1 = wt_json(
+            "w1",
+            r#""phase": "waiting",
+                "pr": {"number": 1, "title": "My PR", "state": "OPEN", "url": "https://github.com/org/repo/pull/1"}"#,
+        );
+        std::fs::write(&state_path, state_json(&[wt1])).unwrap();
         let signals = watcher.poll(&store).await.unwrap();
         assert_eq!(signals.len(), 4); // 3 resolved (spawned/waiting/pr) + 1 closed
         assert!(signals.iter().all(|s| s.title.contains("closed")));
-    }
-
-    /// claude-tui workers should NOT emit waiting signals.
-    #[tokio::test]
-    async fn test_poll_skips_tui_waiting() {
-        let dir = tempfile::tempdir().unwrap();
-        let state_path = dir.path().join("state.json");
-        let db_path = dir.path().join("test.db");
-
-        let store = SignalStore::open(&db_path, "test").unwrap();
-        let config = SwarmWatcherConfig {
-            enabled: true,
-            state_path: state_path.clone(),
-            interval_secs: 15,
-        };
-        let mut watcher = SwarmWatcher::new(config);
-
-        // Init: running
-        std::fs::write(
-            &state_path,
-            r#"{"worktrees": [{"id": "w1", "agent_kind": "claude-tui", "agent_session_status": "running"}]}"#,
-        )
-        .unwrap();
-        watcher.poll(&store).await.unwrap();
-
-        // Transition to waiting — should NOT emit because claude-tui
-        std::fs::write(
-            &state_path,
-            r#"{"worktrees": [{"id": "w1", "agent_kind": "claude-tui", "agent_session_status": "waiting"}]}"#,
-        )
-        .unwrap();
-        let signals = watcher.poll(&store).await.unwrap();
-        assert!(
-            signals.is_empty(),
-            "claude-tui waiting should be suppressed"
-        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `apiari-swarm` as a workspace dependency (path = "swarm")
- Replace duplicate minimal `SwarmState`/`WorktreeEntry`/`PrInfo` structs in the swarm watcher with real types from `apiari_swarm::core::state`
- Use `WorkerPhase` enum instead of `agent_session_status` string for waiting detection
- Use `repo_path` (PathBuf) instead of `repo` (Option<String>) for repo name extraction
- Simplify README install instructions from source build to `cargo install apiari`
- Remove `claude-tui` special-casing (legacy agent kind, now aliased to Claude in swarm)

## Dependencies

**This PR depends on the swarm lib.rs PR** that adds `lib.rs` to `apiari-swarm` and exposes `core::state` types publicly. CI will not pass until that PR is merged and the `swarm/` path dep resolves.

## Test plan

- [ ] Merge swarm lib.rs PR first
- [ ] Verify `cargo check -p apiari` passes with swarm path dep resolved
- [ ] Verify `cargo test -p apiari` passes (updated test JSON matches real WorktreeState schema)
- [ ] Verify swarm watcher detects phase transitions (waiting, PR opened, worker closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)