### PR TITLE
chore: remove codesign and cargo binstall requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@ Apiari runs a persistent daemon that dispatches and monitors AI coding agents (C
 cargo install apiari
 ```
 
-On macOS, codesign the binary so it can access the keychain and network:
-
-```sh
-codesign -f -s - ~/.cargo/bin/apiari
-```
-
 ## Quick Start
 
 ```sh
@@ -153,7 +147,7 @@ restart = false                     # restart daemon after script runs
 
 [[commands]]
 name = "update"
-script = "cd /Users/you/projects/my-app && git pull && cargo install --path crates/apiari && if command -v codesign >/dev/null 2>&1; then codesign -f -s - ~/.cargo/bin/apiari; fi"
+script = "cd /Users/you/projects/my-app && git pull && cargo install --path crates/apiari"
 description = "Pull latest and reinstall"
 restart = true
 ```

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1630,9 +1630,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
 
                                         let script = "source /Users/josh/.cargo/env 2>/dev/null; \
                                             /Users/josh/.cargo/bin/cargo install --force apiari 2>&1 && \
-                                            codesign -f -s - /Users/josh/.cargo/bin/apiari 2>&1 && \
-                                            /Users/josh/.cargo/bin/cargo install --force swarm 2>&1 && \
-                                            codesign -f -s - /Users/josh/.cargo/bin/swarm 2>&1";
+                                            /Users/josh/.cargo/bin/cargo install --force swarm 2>&1";
 
                                         let output = tokio::process::Command::new("sh")
                                             .arg("-c")
@@ -2330,9 +2328,7 @@ async fn handle_tui_command(
 
             let script = "source /Users/josh/.cargo/env 2>/dev/null; \
                 /Users/josh/.cargo/bin/cargo install --force apiari 2>&1 && \
-                codesign -f -s - /Users/josh/.cargo/bin/apiari 2>&1 && \
-                /Users/josh/.cargo/bin/cargo install --force swarm 2>&1 && \
-                codesign -f -s - /Users/josh/.cargo/bin/swarm 2>&1";
+                /Users/josh/.cargo/bin/cargo install --force swarm 2>&1";
 
             let output = tokio::process::Command::new("sh")
                 .arg("-c")

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1628,9 +1628,9 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                         };
                                         let _ = channel.send_message(&updating_msg).await;
 
-                                        let script = "source /Users/josh/.cargo/env 2>/dev/null; \
-                                            /Users/josh/.cargo/bin/cargo install --force apiari 2>&1 && \
-                                            /Users/josh/.cargo/bin/cargo install --force swarm 2>&1";
+                                        let script = ". \"$HOME/.cargo/env\" 2>/dev/null; \
+                                            cargo install --force apiari 2>&1 && \
+                                            cargo install --force apiari-swarm 2>&1";
 
                                         let output = tokio::process::Command::new("sh")
                                             .arg("-c")
@@ -2326,9 +2326,9 @@ async fn handle_tui_command(
                 text: "Updating apiari + swarm from crates.io...\n".to_string(),
             });
 
-            let script = "source /Users/josh/.cargo/env 2>/dev/null; \
-                /Users/josh/.cargo/bin/cargo install --force apiari 2>&1 && \
-                /Users/josh/.cargo/bin/cargo install --force swarm 2>&1";
+            let script = ". \"$HOME/.cargo/env\" 2>/dev/null; \
+                cargo install --force apiari 2>&1 && \
+                cargo install --force apiari-swarm 2>&1";
 
             let output = tokio::process::Command::new("sh")
                 .arg("-c")

--- a/crates/apiari/src/init.rs
+++ b/crates/apiari/src/init.rs
@@ -102,43 +102,10 @@ pub fn run_init(name_override: Option<&str>) -> Result<()> {
     if swarm_installed {
         println!("  \u{2713} swarm already installed\n");
     } else {
-        println!("  swarm is not installed. Installing via cargo binstall...\n");
-
-        // Ensure cargo-binstall is available
-        let has_binstall = std::process::Command::new("cargo")
-            .args(["binstall", "--help"])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-
-        if !has_binstall {
-            println!("  Installing cargo-binstall first...\n");
-            let bs_status = std::process::Command::new("cargo")
-                .args(["install", "cargo-binstall"])
-                .stdout(std::process::Stdio::inherit())
-                .stderr(std::process::Stdio::inherit())
-                .status();
-            match bs_status {
-                Ok(s) if s.success() => {
-                    println!("\n  \u{2713} cargo-binstall installed\n");
-                }
-                Ok(_) => {
-                    eprintln!("\n  Failed to install cargo-binstall. You can retry manually:");
-                    eprintln!("  cargo install cargo-binstall\n");
-                    return Ok(());
-                }
-                Err(e) => {
-                    eprintln!("\n  Could not run cargo install: {e}");
-                    eprintln!("  Install manually: cargo install cargo-binstall\n");
-                    return Ok(());
-                }
-            }
-        }
+        println!("  swarm is not installed. Installing via cargo install...\n");
 
         let install_status = std::process::Command::new("cargo")
-            .args(["binstall", "-y", "apiari-swarm"])
+            .args(["install", "apiari-swarm"])
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit())
             .status();
@@ -148,11 +115,11 @@ pub fn run_init(name_override: Option<&str>) -> Result<()> {
             }
             Ok(_) => {
                 eprintln!("\n  Failed to install apiari-swarm. You can retry manually:");
-                eprintln!("  cargo binstall -y apiari-swarm\n");
+                eprintln!("  cargo install apiari-swarm\n");
             }
             Err(e) => {
-                eprintln!("\n  Could not run cargo binstall: {e}");
-                eprintln!("  Install manually: cargo binstall -y apiari-swarm\n");
+                eprintln!("\n  Could not run cargo install: {e}");
+                eprintln!("  Install manually: cargo install apiari-swarm\n");
             }
         }
     }


### PR DESCRIPTION
## Summary
- Removed all `codesign` steps from README.md, daemon update commands, and example configs
- Replaced `cargo binstall` with `cargo install` in the `apiari init` swarm installation flow
- Removed `cargo-binstall` bootstrap logic from init (no longer needed)

Users install from their own terminal now, so codesign is unnecessary and binstall adds needless complexity.

## Test plan
- [x] `cargo check -p apiari` passes
- [x] `cargo fmt -p apiari` clean
- [ ] Verify `apiari init` installs swarm correctly via `cargo install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)