### PR TITLE
fix: block Bash tool for signal follow-throughs

### DIFF
--- a/crates/apiari/src/buzz/coordinator/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/mod.rs
@@ -149,6 +149,16 @@ impl Coordinator {
         self.session_token = Some(token);
     }
 
+    /// Get current disallowed tools.
+    pub fn disallowed_tools(&self) -> &[String] {
+        &self.disallowed_tools
+    }
+
+    /// Get the model name.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
     /// Get current max turns.
     pub fn max_turns(&self) -> u32 {
         self.max_turns

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -596,33 +596,30 @@ async fn run_coordinator_task(
                     notification.push_str("\n\n[Action] ");
                     notification.push_str(action_str);
                 }
-                // Restrict to read-only for signal follow-throughs — no Bash allowed
-                let saved_disallowed = coordinator.disallowed_tools().to_vec();
-                let mut restricted = saved_disallowed.clone();
-                if !restricted.iter().any(|t| t == "Bash") {
-                    restricted.push("Bash".to_string());
+                let saved_turns = coordinator.max_turns();
+                coordinator.set_max_turns(3);
+
+                let mut opts = match coordinator.build_options(&store) {
+                    Ok(opts) => opts,
+                    Err(e) => {
+                        warn!("[{slot_name}] failed to build coordinator options: {e}");
+                        coordinator.set_max_turns(saved_turns);
+                        continue;
+                    }
+                };
+
+                // Restrict to read-only for signal follow-throughs — no Bash allowed.
+                // Push directly into opts so coordinator state is never mutated.
+                if !opts.disallowed_tools.iter().any(|t| t == "Bash") {
+                    opts.disallowed_tools.push("Bash".to_string());
                 }
-                coordinator.set_disallowed_tools(restricted);
 
                 info!(
                     "[{slot_name}] signal follow-through START source={source} signals={} has_action={} disallowed_tools={:?}",
                     signals.len(),
                     action.is_some(),
-                    coordinator.disallowed_tools()
+                    opts.disallowed_tools
                 );
-
-                let saved_turns = coordinator.max_turns();
-                coordinator.set_max_turns(3);
-
-                let opts = match coordinator.build_options(&store) {
-                    Ok(opts) => opts,
-                    Err(e) => {
-                        warn!("[{slot_name}] failed to build coordinator options: {e}");
-                        coordinator.set_max_turns(saved_turns);
-                        coordinator.set_disallowed_tools(saved_disallowed);
-                        continue;
-                    }
-                };
 
                 let name_for_cb = slot_name.clone();
                 let source_for_cb = source.clone();
@@ -632,8 +629,13 @@ async fn run_coordinator_task(
                             command,
                             matched_pattern,
                         } => {
+                            let sanitized: String = command
+                                .chars()
+                                .take(120)
+                                .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+                                .collect();
                             warn!(
-                                "[{name_for_cb}] signal follow-through bash MUTATING ({matched_pattern}): {command}"
+                                "[{name_for_cb}] signal follow-through bash MUTATING ({matched_pattern}): {sanitized}"
                             );
                         }
                         CoordinatorEvent::FilesModified { files } => {
@@ -695,7 +697,6 @@ async fn run_coordinator_task(
                 }
 
                 coordinator.set_max_turns(saved_turns);
-                coordinator.set_disallowed_tools(saved_disallowed);
             }
         }
     }

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -569,6 +569,10 @@ async fn run_coordinator_task(
                 socket_server,
                 slot_name,
             } => {
+                info!(
+                    "[{slot_name}] processing signal follow-through model={}",
+                    coordinator.model()
+                );
                 let elapsed = queued_at.elapsed().as_secs();
                 if elapsed >= ttl_secs {
                     info!(
@@ -592,9 +596,19 @@ async fn run_coordinator_task(
                     notification.push_str("\n\n[Action] ");
                     notification.push_str(action_str);
                 }
+                // Restrict to read-only for signal follow-throughs — no Bash allowed
+                let saved_disallowed = coordinator.disallowed_tools().to_vec();
+                let mut restricted = saved_disallowed.clone();
+                if !restricted.iter().any(|t| t == "Bash") {
+                    restricted.push("Bash".to_string());
+                }
+                coordinator.set_disallowed_tools(restricted);
+
                 info!(
-                    "[{slot_name}] triggering coordinator follow-through ({source}, {} event(s))",
-                    signals.len()
+                    "[{slot_name}] signal follow-through START source={source} signals={} has_action={} disallowed_tools={:?}",
+                    signals.len(),
+                    action.is_some(),
+                    coordinator.disallowed_tools()
                 );
 
                 let saved_turns = coordinator.max_turns();
@@ -605,16 +619,43 @@ async fn run_coordinator_task(
                     Err(e) => {
                         warn!("[{slot_name}] failed to build coordinator options: {e}");
                         coordinator.set_max_turns(saved_turns);
+                        coordinator.set_disallowed_tools(saved_disallowed);
                         continue;
                     }
                 };
 
+                let name_for_cb = slot_name.clone();
+                let source_for_cb = source.clone();
                 match coordinator
-                    .handle_message_with_options(&notification, opts, |_| {})
+                    .handle_message_with_options(&notification, opts, |event| match event {
+                        CoordinatorEvent::BashAudit {
+                            command,
+                            matched_pattern,
+                        } => {
+                            warn!(
+                                "[{name_for_cb}] signal follow-through bash MUTATING ({matched_pattern}): {command}"
+                            );
+                        }
+                        CoordinatorEvent::FilesModified { files } => {
+                            let file_list: Vec<String> = files
+                                .iter()
+                                .map(|(repo, file)| format!("{repo}/{file}"))
+                                .collect();
+                            warn!(
+                                "[{name_for_cb}] signal follow-through MUTATED FILES source={source_for_cb} files={file_list:?}"
+                            );
+                        }
+                        _ => {}
+                    })
                     .await
                 {
                     Ok(response) => {
                         let response = response.trim().to_string();
+                        info!(
+                            "[{slot_name}] signal follow-through DONE source={source} response_len={} empty={}",
+                            response.len(),
+                            response.is_empty()
+                        );
                         if !response.is_empty() && response.to_lowercase() != "ack" {
                             // TUI-first: try broadcasting to TUI clients.
                             // If nobody received it (0 receivers), fall back to Telegram.
@@ -654,6 +695,7 @@ async fn run_coordinator_task(
                 }
 
                 coordinator.set_max_turns(saved_turns);
+                coordinator.set_disallowed_tools(saved_disallowed);
             }
         }
     }
@@ -1424,6 +1466,14 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     slot.pipeline.evict_old_log_entries();
 
                     // Coordinator follow-through for signal hook events (non-blocking)
+                    for (source, (signals, hook)) in &hook_events {
+                        info!(
+                            "[{}] dispatching signal follow-through source={source} events={} has_action={}",
+                            slot.name,
+                            signals.len(),
+                            hook.action.is_some()
+                        );
+                    }
                     for (source, (signals, hook)) in hook_events {
                         let telegram_info = slot.config.telegram.as_ref().and_then(|tg| {
                             telegram_channels.get(&tg.bot_token).map(|ch| {


### PR DESCRIPTION
## Summary
- **Security fix**: Signal follow-throughs (triggered by signal hooks in the coordinator) were running the claude CLI daemon subprocess with unrestricted Bash access. The `validate-bash` hook only applies inside Claude Code sessions, not when the daemon spawns claude CLI directly. This allowed the coordinator to run `git commit`, `git push`, `gh pr create`, etc., creating unexpected PRs.
- **Fix**: Add `Bash` to `disallowed_tools` for `SignalFollowThrough` jobs before building options, restoring the original list after completion. This ensures follow-throughs are read-only.
- **Observability**: Add structured `tracing` logs throughout the signal follow-through lifecycle (START with disallowed tools list, DONE with response length, MUTATED FILES warning, dispatch-site log, and model info), plus event callbacks for `BashAudit` and `FilesModified` that were previously swallowed by `|_| {}`.

## Test plan
- [ ] Verify `cargo check -p apiari` passes (done locally)
- [ ] Verify `cargo fmt -p apiari` passes (done locally)
- [ ] Trigger a signal hook and confirm the follow-through logs show `Bash` in `disallowed_tools`
- [ ] Confirm regular `TelegramMessage` and `TuiChat` coordinator jobs are unaffected (no Bash restriction)
- [ ] Confirm follow-throughs can still read/analyze signals but cannot execute Bash commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)