### PR TITLE
fix: preserve focused_panel across workspace tab switches

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1080,6 +1080,10 @@ impl App {
                     self.signal_selection = 0;
                 }
             }
+            // Clamp: if focused on Reviews but new workspace has no review queue, fall back
+            if self.focused_panel == Panel::Reviews && !self.has_review_queue() {
+                self.focused_panel = Panel::Signals;
+            }
             self.needs_redraw = true;
         }
     }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1072,8 +1072,10 @@ impl App {
                 }
                 _ => {
                     self.view = View::Dashboard;
-                    // Keep focused_panel in sync with zoomed panel
-                    self.focused_panel = self.zoomed_panel.unwrap_or(Panel::Workers);
+                    if let Some(zoomed) = self.zoomed_panel {
+                        self.focused_panel = zoomed;
+                    }
+                    // Otherwise preserve existing focused_panel
                     self.worker_selection = 0;
                     self.signal_selection = 0;
                 }


### PR DESCRIPTION
## Summary
- Fixed `switch_tab` in `app.rs` resetting `focused_panel` to `Panel::Workers` when switching workspaces with no zoom active
- Now only overrides `focused_panel` when `zoomed_panel` is `Some`, preserving Chat (or any other) focus across tab switches

## Test plan
- [ ] Switch workspaces while Chat panel is focused — verify focus stays on Chat
- [ ] Switch workspaces while zoomed into a panel — verify focus follows the zoomed panel
- [ ] Switch workspaces with Workers/Signals focused — verify normal behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)