### PR TITLE
feat: add opt-in tmux shell management for workspaces

### DIFF
--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -37,6 +37,7 @@ chrono-tz.workspace = true
 async-imap = "0.10"
 async-native-tls = "0.5"
 mail-parser = "0.9"
+unicode-width = "0.2"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ binary-ext }"

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -102,6 +102,10 @@ pub struct WorkspaceConfig {
     /// The TUI tries each in order, using the first that responds.
     #[serde(default)]
     pub daemon_endpoints: Vec<DaemonEndpoint>,
+
+    /// Shell management configuration (tmux integration).
+    #[serde(default)]
+    pub shells: ShellsConfig,
 }
 
 /// A single daemon TCP endpoint (host + port).
@@ -134,6 +138,30 @@ impl WorkspaceConfig {
             }];
         }
         Vec::new()
+    }
+}
+
+/// Shell management configuration (tmux integration).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShellsConfig {
+    /// Whether shell management is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Tmux session name. Defaults to "apiari-{workspace_name}".
+    #[serde(default)]
+    pub tmux_session: Option<String>,
+    /// Automatically create/kill tmux windows with workers.
+    #[serde(default)]
+    pub auto_worker_shells: bool,
+}
+
+impl Default for ShellsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            tmux_session: None,
+            auto_worker_shells: false,
+        }
     }
 }
 
@@ -1069,6 +1097,7 @@ max_session_turns = 0
             daemon_host: None,
             daemon_port: None,
             daemon_endpoints: vec![],
+            shells: ShellsConfig::default(),
         };
         assert_eq!(resolve_repos(&config), vec!["Org/Repo"]);
     }
@@ -1091,6 +1120,7 @@ max_session_turns = 0
             daemon_host: None,
             daemon_port: None,
             daemon_endpoints: vec![],
+            shells: ShellsConfig::default(),
         };
         assert!(resolve_repos(&config).is_empty());
     }
@@ -1117,6 +1147,7 @@ max_session_turns = 0
             daemon_host: None,
             daemon_port: None,
             daemon_endpoints: vec![],
+            shells: ShellsConfig::default(),
         };
 
         let buzz = to_buzz_config(&ws);
@@ -1368,6 +1399,7 @@ max_session_turns = 0
             daemon_host: None,
             daemon_port: None,
             daemon_endpoints: vec![],
+            shells: ShellsConfig::default(),
         }
     }
 

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -142,7 +142,7 @@ impl WorkspaceConfig {
 }
 
 /// Shell management configuration (tmux integration).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ShellsConfig {
     /// Whether shell management is enabled.
     #[serde(default)]
@@ -153,16 +153,6 @@ pub struct ShellsConfig {
     /// Automatically create/kill tmux windows with workers.
     #[serde(default)]
     pub auto_worker_shells: bool,
-}
-
-impl Default for ShellsConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            tmux_session: None,
-            auto_worker_shells: false,
-        }
-    }
 }
 
 /// Telegram bot configuration.

--- a/crates/apiari/src/main.rs
+++ b/crates/apiari/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod config_set;
 mod daemon;
 mod git_safety;
+pub mod shells;
 mod ui;
 mod validate_bash;
 

--- a/crates/apiari/src/shells/mod.rs
+++ b/crates/apiari/src/shells/mod.rs
@@ -80,21 +80,21 @@ impl TmuxManager {
     }
 
     /// Create a new tmux window with the given name in the given working directory.
+    /// Returns `false` if tmux is unavailable or the path is not valid UTF-8.
     pub fn create_window(&self, name: &str, working_dir: &Path) -> bool {
         if !self.available {
             return false;
         }
+        let Some(dir_str) = working_dir.to_str() else {
+            tracing::warn!(
+                path = ?working_dir,
+                "cannot create tmux window: working directory is not valid UTF-8"
+            );
+            return false;
+        };
         self.ensure_session();
         Command::new("tmux")
-            .args([
-                "new-window",
-                "-t",
-                &self.session,
-                "-n",
-                name,
-                "-c",
-                &working_dir.to_string_lossy(),
-            ])
+            .args(["new-window", "-t", &self.session, "-n", name, "-c", dir_str])
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
@@ -113,14 +113,14 @@ impl TmuxManager {
             .unwrap_or(false)
     }
 
-    /// Capture a preview of the pane contents (last visible lines).
+    /// Capture a preview of the pane contents (last 5 lines only).
     pub fn capture_preview(&self, name: &str) -> Option<String> {
         if !self.available {
             return None;
         }
         let target = format!("{}:{}", self.session, name);
         let output = Command::new("tmux")
-            .args(["capture-pane", "-t", &target, "-p"])
+            .args(["capture-pane", "-t", &target, "-p", "-S", "-5"])
             .output()
             .ok()?;
         if !output.status.success() {

--- a/crates/apiari/src/shells/mod.rs
+++ b/crates/apiari/src/shells/mod.rs
@@ -37,6 +37,16 @@ impl TmuxManager {
         }
     }
 
+    /// Create a TmuxManager with a pre-determined availability flag.
+    /// Use this to avoid redundant `which tmux` checks when availability
+    /// has already been verified.
+    pub fn with_availability(session_name: &str, available: bool) -> Self {
+        Self {
+            session: session_name.to_string(),
+            available,
+        }
+    }
+
     /// Whether tmux is available on this system.
     pub fn is_available(&self) -> bool {
         self.available

--- a/crates/apiari/src/shells/mod.rs
+++ b/crates/apiari/src/shells/mod.rs
@@ -190,11 +190,10 @@ impl TmuxManager {
                 let mut parts = line.splitn(2, '\t');
                 let name = parts.next().unwrap_or("").to_string();
                 let working_dir = parts.next().unwrap_or("").to_string();
-                let preview = self.capture_preview(&name).unwrap_or_default();
                 ShellWindow {
                     name,
                     working_dir,
-                    preview,
+                    preview: String::new(),
                 }
             })
             .collect();

--- a/crates/apiari/src/shells/mod.rs
+++ b/crates/apiari/src/shells/mod.rs
@@ -1,0 +1,204 @@
+//! Tmux shell management for apiari workspaces.
+//!
+//! Provides opt-in tmux session/window management so each workspace can have
+//! persistent shell windows — created automatically with workers or manually
+//! by the user.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Information about a single tmux window.
+#[derive(Debug, Clone)]
+pub struct ShellWindow {
+    pub name: String,
+    pub working_dir: String,
+    pub preview: String,
+}
+
+/// Manages tmux sessions and windows for a workspace.
+#[derive(Debug, Clone)]
+pub struct TmuxManager {
+    session: String,
+    available: bool,
+}
+
+impl TmuxManager {
+    /// Create a new TmuxManager for the given session name.
+    /// Checks whether tmux is installed; all operations become no-ops if not.
+    pub fn new(session_name: &str) -> Self {
+        let available = Command::new("which")
+            .arg("tmux")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        Self {
+            session: session_name.to_string(),
+            available,
+        }
+    }
+
+    /// Whether tmux is available on this system.
+    pub fn is_available(&self) -> bool {
+        self.available
+    }
+
+    /// The session name this manager targets.
+    pub fn session_name(&self) -> &str {
+        &self.session
+    }
+
+    /// Ensure the tmux session exists. Creates it detached if not present.
+    pub fn ensure_session(&self) -> bool {
+        if !self.available {
+            return false;
+        }
+        // Check if session already exists
+        let exists = Command::new("tmux")
+            .args(["has-session", "-t", &self.session])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if exists {
+            return true;
+        }
+        // Create detached session
+        Command::new("tmux")
+            .args(["new-session", "-d", "-s", &self.session])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Create a new tmux window with the given name in the given working directory.
+    pub fn create_window(&self, name: &str, working_dir: &Path) -> bool {
+        if !self.available {
+            return false;
+        }
+        self.ensure_session();
+        Command::new("tmux")
+            .args([
+                "new-window",
+                "-t",
+                &self.session,
+                "-n",
+                name,
+                "-c",
+                &working_dir.to_string_lossy(),
+            ])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Kill a tmux window by name.
+    pub fn kill_window(&self, name: &str) -> bool {
+        if !self.available {
+            return false;
+        }
+        let target = format!("{}:{}", self.session, name);
+        Command::new("tmux")
+            .args(["kill-window", "-t", &target])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Capture a preview of the pane contents (last visible lines).
+    pub fn capture_preview(&self, name: &str) -> Option<String> {
+        if !self.available {
+            return None;
+        }
+        let target = format!("{}:{}", self.session, name);
+        let output = Command::new("tmux")
+            .args(["capture-pane", "-t", &target, "-p"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let text = String::from_utf8_lossy(&output.stdout);
+        // Return last non-empty line as preview
+        let preview = text
+            .lines()
+            .rev()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or("")
+            .to_string();
+        Some(preview)
+    }
+
+    /// Build the command to attach to a specific window.
+    /// Returns the args to pass to `tmux`. The caller is responsible for
+    /// spawning the process (sync for TUI suspend/resume).
+    pub fn attach_args(&self, name: &str) -> Vec<String> {
+        let target = format!("{}:{}", self.session, name);
+        vec![
+            "attach-session".into(),
+            "-t".into(),
+            self.session.clone(),
+            ";".into(),
+            "select-window".into(),
+            "-t".into(),
+            target,
+        ]
+    }
+
+    /// List all windows in the session.
+    pub fn list_windows(&self) -> Vec<ShellWindow> {
+        if !self.available {
+            return Vec::new();
+        }
+        // Check session exists first
+        let exists = Command::new("tmux")
+            .args(["has-session", "-t", &self.session])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !exists {
+            return Vec::new();
+        }
+
+        let output = match Command::new("tmux")
+            .args([
+                "list-windows",
+                "-t",
+                &self.session,
+                "-F",
+                "#{window_name}\t#{pane_current_path}",
+            ])
+            .output()
+        {
+            Ok(o) if o.status.success() => o,
+            _ => return Vec::new(),
+        };
+
+        let text = String::from_utf8_lossy(&output.stdout);
+        let mut windows: Vec<ShellWindow> = text
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|line| {
+                let mut parts = line.splitn(2, '\t');
+                let name = parts.next().unwrap_or("").to_string();
+                let working_dir = parts.next().unwrap_or("").to_string();
+                let preview = self.capture_preview(&name).unwrap_or_default();
+                ShellWindow {
+                    name,
+                    working_dir,
+                    preview,
+                }
+            })
+            .collect();
+
+        windows.sort_by(|a, b| a.name.cmp(&b.name));
+        windows
+    }
+
+    /// Resolve the session name for a workspace.
+    /// Uses the configured name if set, otherwise "apiari-{workspace_name}".
+    pub fn session_name_for(workspace_name: &str, config: &crate::config::ShellsConfig) -> String {
+        config
+            .tmux_session
+            .clone()
+            .unwrap_or_else(|| format!("apiari-{workspace_name}"))
+    }
+}

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1380,8 +1380,9 @@ impl App {
     }
 
     pub fn current_ws_has_shells(&self) -> bool {
-        self.current_ws()
-            .is_some_and(|ws| ws.config.shells.enabled && ws.tmux.is_some())
+        self.current_ws().is_some_and(|ws| {
+            ws.config.shells.enabled && ws.tmux.as_ref().is_some_and(|tmux| tmux.is_available())
+        })
     }
 
     pub fn back_to_dashboard(&mut self) {
@@ -2144,11 +2145,14 @@ impl App {
                     }
                 }
 
-                // Tmux auto-worker-shells: create/kill windows on worker lifecycle
+                // Tmux auto-worker-shells: create/kill windows on worker lifecycle.
+                // Note: create_window/kill_window are brief synchronous tmux CLI calls.
+                // The heavier list_windows is handled by the periodic async refresh.
                 if ws.config.shells.enabled
                     && ws.config.shells.auto_worker_shells
                     && !is_first_load
                     && let Some(ref tmux) = ws.tmux
+                    && tmux.is_available()
                 {
                     let old_ids: std::collections::HashSet<&String> =
                         ws.prev_worker_phases.keys().collect();

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -36,6 +36,7 @@ pub enum View {
 pub enum Panel {
     Home,
     Workers,
+    Shells,
     Signals,
     Reviews,
     Feed,
@@ -70,6 +71,7 @@ pub enum PendingAction {
     ResolveSignal(i64),  // signal db id
     ApproveReview { repo: String, pr_number: u64 },
     SnoozeSignal(i64), // signal db id
+    KillShell(String), // shell window name
 }
 
 /// Snooze duration options for the duration picker.
@@ -114,6 +116,8 @@ pub(super) struct WorkspaceRefreshInfo {
     pub(super) has_github_watcher: bool,
     pub(super) has_sentry_watcher: bool,
     pub(super) has_swarm_watcher: bool,
+    /// Tmux session name (Some if shells enabled).
+    pub(super) tmux_session: Option<String>,
 }
 
 /// Data returned from background extras refresh (per workspace).
@@ -129,6 +133,7 @@ pub(super) struct WorkspaceExtrasData {
 pub(super) enum AppUpdate {
     Workers(Vec<(String, Vec<WorkerInfo>)>),
     Signals(Vec<(String, Vec<SignalRecord>)>),
+    ShellWindows(Vec<(String, Vec<crate::shells::ShellWindow>)>),
     Extras {
         daemon_alive: bool,
         daemon_uptime_secs: Option<u64>,
@@ -279,6 +284,7 @@ impl OnboardingState {
             revealed_panels: [
                 Panel::Home,
                 Panel::Workers,
+                Panel::Shells,
                 Panel::Signals,
                 Panel::Reviews,
                 Panel::Feed,
@@ -416,6 +422,10 @@ pub struct WorkspaceState {
     pub thoughts: Vec<(String, String)>, // (category, content)
     /// True when this tab is a temporary placeholder for the add-workspace flow.
     pub is_setup_placeholder: bool,
+    /// Tmux shell manager (Some if shells are enabled for this workspace).
+    pub tmux: Option<crate::shells::TmuxManager>,
+    /// Cached shell windows (refreshed periodically).
+    pub shell_windows: Vec<crate::shells::ShellWindow>,
 }
 
 // ── App ───────────────────────────────────────────────────
@@ -439,6 +449,10 @@ pub struct App {
     // Worker detail
     pub worker_input: String,
     pub worker_input_active: bool,
+    // Shell management
+    pub shell_selection: usize,
+    pub shell_input_active: bool,
+    pub shell_input: String,
     /// When true, scroll/focus targets the activity pane (left) in WorkerDetail split.
     pub worker_activity_focused: bool,
     // Review comment input
@@ -492,28 +506,39 @@ impl App {
     ) -> Self {
         let ws_states: Vec<WorkspaceState> = workspaces
             .into_iter()
-            .map(|ws| WorkspaceState {
-                name: ws.name,
-                config: ws.config,
-                signals: Vec::new(),
-                workers: Vec::new(),
-                chat_history: Vec::new(),
-                input: String::new(),
-                cursor_pos: 0,
-                chat_scroll: ScrollState::new(),
-                streaming: false,
-                coordinator_preview: None,
-                has_unread_response: false,
-                coordinator_turns: 0,
-                sparkline_data: vec![0; 24],
-                watcher_health: Vec::new(),
-                feed: Vec::new(),
-                prev_worker_phases: std::collections::HashMap::new(),
-                prev_signal_ids: std::collections::HashSet::new(),
-                prev_pr_workers: std::collections::HashSet::new(),
-                feed_scroll: ScrollState::new(),
-                thoughts: Vec::new(),
-                is_setup_placeholder: false,
+            .map(|ws| {
+                let tmux = if ws.config.shells.enabled {
+                    let session =
+                        crate::shells::TmuxManager::session_name_for(&ws.name, &ws.config.shells);
+                    Some(crate::shells::TmuxManager::new(&session))
+                } else {
+                    None
+                };
+                WorkspaceState {
+                    name: ws.name,
+                    config: ws.config,
+                    signals: Vec::new(),
+                    workers: Vec::new(),
+                    chat_history: Vec::new(),
+                    input: String::new(),
+                    cursor_pos: 0,
+                    chat_scroll: ScrollState::new(),
+                    streaming: false,
+                    coordinator_preview: None,
+                    has_unread_response: false,
+                    coordinator_turns: 0,
+                    sparkline_data: vec![0; 24],
+                    watcher_health: Vec::new(),
+                    feed: Vec::new(),
+                    prev_worker_phases: std::collections::HashMap::new(),
+                    prev_signal_ids: std::collections::HashSet::new(),
+                    prev_pr_workers: std::collections::HashSet::new(),
+                    feed_scroll: ScrollState::new(),
+                    thoughts: Vec::new(),
+                    is_setup_placeholder: false,
+                    tmux,
+                    shell_windows: Vec::new(),
+                }
             })
             .collect();
 
@@ -553,6 +578,9 @@ impl App {
             chat_focused,
             worker_input: String::new(),
             worker_input_active: false,
+            shell_selection: 0,
+            shell_input_active: false,
+            shell_input: String::new(),
             worker_activity_focused: false,
             review_comment_active: false,
             review_comment_input: String::new(),
@@ -643,6 +671,8 @@ impl App {
             feed_scroll: ScrollState::new(),
             thoughts: Vec::new(),
             is_setup_placeholder: true,
+            tmux: None,
+            shell_windows: Vec::new(),
         };
 
         let setup = SetupState {
@@ -673,6 +703,9 @@ impl App {
             chat_focused: true,
             worker_input: String::new(),
             worker_input_active: false,
+            shell_selection: 0,
+            shell_input_active: false,
+            shell_input: String::new(),
             worker_activity_focused: false,
             review_comment_active: false,
             review_comment_input: String::new(),
@@ -760,6 +793,8 @@ impl App {
             feed_scroll: ScrollState::new(),
             thoughts: Vec::new(),
             is_setup_placeholder: true,
+            tmux: None,
+            shell_windows: Vec::new(),
         };
 
         ws_state.chat_history.push(ChatLine::Assistant(
@@ -920,6 +955,12 @@ impl App {
         };
 
         // Build real workspace state
+        let tmux = if ws.config.shells.enabled {
+            let session = crate::shells::TmuxManager::session_name_for(&ws.name, &ws.config.shells);
+            Some(crate::shells::TmuxManager::new(&session))
+        } else {
+            None
+        };
         let mut ws_state = WorkspaceState {
             name: ws.name,
             config: ws.config,
@@ -942,6 +983,8 @@ impl App {
             feed_scroll: ScrollState::new(),
             is_setup_placeholder: false,
             thoughts: Vec::new(),
+            tmux,
+            shell_windows: Vec::new(),
         };
 
         if is_add {
@@ -1094,9 +1137,19 @@ impl App {
     }
 
     pub fn next_panel(&mut self) {
+        let has_shells = self.current_ws_has_shells();
         self.focused_panel = match self.focused_panel {
             Panel::Home => Panel::Workers,
             Panel::Workers => {
+                if has_shells {
+                    Panel::Shells
+                } else if self.has_review_queue() {
+                    Panel::Reviews
+                } else {
+                    Panel::Signals
+                }
+            }
+            Panel::Shells => {
                 if self.has_review_queue() {
                     Panel::Reviews
                 } else {
@@ -1113,13 +1166,23 @@ impl App {
     }
 
     pub fn prev_panel(&mut self) {
+        let has_shells = self.current_ws_has_shells();
         self.focused_panel = match self.focused_panel {
             Panel::Home => Panel::Chat,
             Panel::Workers => Panel::Home,
-            Panel::Reviews => Panel::Workers,
+            Panel::Shells => Panel::Workers,
+            Panel::Reviews => {
+                if has_shells {
+                    Panel::Shells
+                } else {
+                    Panel::Workers
+                }
+            }
             Panel::Signals => {
                 if self.has_review_queue() {
                     Panel::Reviews
+                } else if has_shells {
+                    Panel::Shells
                 } else {
                     Panel::Workers
                 }
@@ -1138,6 +1201,12 @@ impl App {
                 let count = self.current_ws().map_or(0, |ws| ws.workers.len());
                 if count > 0 && self.worker_selection + 1 < count {
                     self.worker_selection += 1;
+                }
+            }
+            Panel::Shells => {
+                let count = self.current_ws().map_or(0, |ws| ws.shell_windows.len());
+                if count > 0 && self.shell_selection + 1 < count {
+                    self.shell_selection += 1;
                 }
             }
             Panel::Signals => {
@@ -1167,6 +1236,9 @@ impl App {
             Panel::Home => {}
             Panel::Workers => {
                 self.worker_selection = self.worker_selection.saturating_sub(1);
+            }
+            Panel::Shells => {
+                self.shell_selection = self.shell_selection.saturating_sub(1);
             }
             Panel::Signals => {
                 // Horizontal carousel: k/up = swipe right (next card)
@@ -1255,6 +1327,13 @@ impl App {
         } else if self.feed_selection >= feed_count {
             self.feed_selection = feed_count - 1;
         }
+
+        let shell_count = self.current_ws().map_or(0, |ws| ws.shell_windows.len());
+        if shell_count == 0 {
+            self.shell_selection = 0;
+        } else if self.shell_selection >= shell_count {
+            self.shell_selection = shell_count - 1;
+        }
     }
 
     // ── View transitions ──────────────────────────────────
@@ -1298,6 +1377,11 @@ impl App {
                 .as_ref()
                 .is_some_and(|gh| !gh.review_queue.is_empty())
         })
+    }
+
+    pub fn current_ws_has_shells(&self) -> bool {
+        self.current_ws()
+            .is_some_and(|ws| ws.config.shells.enabled && ws.tmux.is_some())
     }
 
     pub fn back_to_dashboard(&mut self) {
@@ -1347,7 +1431,7 @@ impl App {
     /// Drill into the currently selected panel item.
     pub fn drill_in(&mut self) {
         match self.focused_panel {
-            Panel::Home => {} // Home has no drill-in
+            Panel::Home | Panel::Shells => {} // Handled elsewhere or no drill-in
             Panel::Workers => {
                 if let Some(ws) = self.current_ws()
                     && self.worker_selection < ws.workers.len()
@@ -2060,6 +2144,33 @@ impl App {
                     }
                 }
 
+                // Tmux auto-worker-shells: create/kill windows on worker lifecycle
+                if ws.config.shells.enabled && ws.config.shells.auto_worker_shells && !is_first_load
+                {
+                    if let Some(ref tmux) = ws.tmux {
+                        let old_ids: std::collections::HashSet<&String> =
+                            ws.prev_worker_phases.keys().collect();
+                        let new_ids: std::collections::HashSet<&String> =
+                            new_workers.iter().map(|w| &w.id).collect();
+
+                        // New workers: create tmux windows
+                        for worker in &new_workers {
+                            if !old_ids.contains(&worker.id) {
+                                let wt_path =
+                                    ws.config.root.join(".swarm").join("wt").join(&worker.id);
+                                tmux.create_window(&worker.id, &wt_path);
+                            }
+                        }
+
+                        // Closed workers: kill tmux windows
+                        for old_id in &old_ids {
+                            if !new_ids.contains(*old_id) {
+                                tmux.kill_window(old_id);
+                            }
+                        }
+                    }
+                }
+
                 // Update tracking state
                 ws.prev_worker_phases = new_workers
                     .iter()
@@ -2262,6 +2373,14 @@ impl App {
                 has_github_watcher: ws.config.watchers.github.is_some(),
                 has_sentry_watcher: ws.config.watchers.sentry.is_some(),
                 has_swarm_watcher: ws.config.watchers.swarm.is_some(),
+                tmux_session: if ws.config.shells.enabled {
+                    Some(crate::shells::TmuxManager::session_name_for(
+                        &ws.name,
+                        &ws.config.shells,
+                    ))
+                } else {
+                    None
+                },
             })
             .collect()
     }
@@ -3353,6 +3472,8 @@ mod tests {
             feed_scroll: ScrollState::new(),
             thoughts: Vec::new(),
             is_setup_placeholder: false,
+            tmux: None,
+            shell_windows: Vec::new(),
         };
         app.workspaces = vec![ws];
         app.setup = None;

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -164,6 +164,12 @@ pub(super) enum AppUpdate {
         worker_id: String,
         entries: Vec<ConversationEntry>,
     },
+    /// Preview text for a single shell window (lazily captured).
+    ShellPreview {
+        workspace_name: String,
+        window_name: String,
+        preview: String,
+    },
 }
 
 // ── Worker info from state.json ───────────────────────────

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -12,6 +12,20 @@ use std::path::Path;
 use std::time::Instant;
 
 use apiari_tui::scroll::ScrollState;
+use std::path::PathBuf;
+
+/// A tmux operation to be executed asynchronously after apply_worker_update.
+pub(super) enum PendingShellOp {
+    Create {
+        tmux: crate::shells::TmuxManager,
+        name: String,
+        working_dir: PathBuf,
+    },
+    Kill {
+        tmux: crate::shells::TmuxManager,
+        name: String,
+    },
+}
 
 use crate::buzz::conversation::ConversationStore;
 use crate::config::{self, Workspace};
@@ -1379,10 +1393,16 @@ impl App {
         })
     }
 
+    /// Whether the current workspace has shells enabled in config.
+    /// The panel is shown even if tmux is not installed (with a helpful message).
     pub fn current_ws_has_shells(&self) -> bool {
-        self.current_ws().is_some_and(|ws| {
-            ws.config.shells.enabled && ws.tmux.as_ref().is_some_and(|tmux| tmux.is_available())
-        })
+        self.current_ws().is_some_and(|ws| ws.config.shells.enabled)
+    }
+
+    /// Whether tmux is actually available for the current workspace.
+    pub fn current_ws_tmux_available(&self) -> bool {
+        self.current_ws()
+            .is_some_and(|ws| ws.tmux.as_ref().is_some_and(|tmux| tmux.is_available()))
     }
 
     pub fn back_to_dashboard(&mut self) {
@@ -2093,7 +2113,12 @@ impl App {
     }
 
     /// Apply worker data from background refresh.
-    pub(super) fn apply_worker_update(&mut self, data: Vec<(String, Vec<WorkerInfo>)>) {
+    /// Returns any pending tmux operations that should be executed off the main thread.
+    pub(super) fn apply_worker_update(
+        &mut self,
+        data: Vec<(String, Vec<WorkerInfo>)>,
+    ) -> Vec<PendingShellOp> {
+        let mut shell_ops = Vec::new();
         for (name, new_workers) in data {
             if let Some(ws) = self.workspaces.iter_mut().find(|ws| ws.name == name) {
                 // Detect state changes and inject chat notifications
@@ -2145,9 +2170,7 @@ impl App {
                     }
                 }
 
-                // Tmux auto-worker-shells: create/kill windows on worker lifecycle.
-                // Note: create_window/kill_window are brief synchronous tmux CLI calls.
-                // The heavier list_windows is handled by the periodic async refresh.
+                // Tmux auto-worker-shells: collect create/kill ops for async execution.
                 if ws.config.shells.enabled
                     && ws.config.shells.auto_worker_shells
                     && !is_first_load
@@ -2159,18 +2182,25 @@ impl App {
                     let new_ids: std::collections::HashSet<&String> =
                         new_workers.iter().map(|w| &w.id).collect();
 
-                    // New workers: create tmux windows
+                    // New workers: queue create ops
                     for worker in &new_workers {
                         if !old_ids.contains(&worker.id) {
                             let wt_path = ws.config.root.join(".swarm").join("wt").join(&worker.id);
-                            tmux.create_window(&worker.id, &wt_path);
+                            shell_ops.push(PendingShellOp::Create {
+                                tmux: tmux.clone(),
+                                name: worker.id.clone(),
+                                working_dir: wt_path,
+                            });
                         }
                     }
 
-                    // Closed workers: kill tmux windows
+                    // Closed workers: queue kill ops
                     for old_id in &old_ids {
                         if !new_ids.contains(*old_id) {
-                            tmux.kill_window(old_id);
+                            shell_ops.push(PendingShellOp::Kill {
+                                tmux: tmux.clone(),
+                                name: (*old_id).clone(),
+                            });
                         }
                     }
                 }
@@ -2192,6 +2222,7 @@ impl App {
         self.last_worker_refresh = Instant::now();
         self.clamp_selections();
         self.needs_redraw = true;
+        shell_ops
     }
 
     /// Apply signal data from background refresh.

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -2145,28 +2145,28 @@ impl App {
                 }
 
                 // Tmux auto-worker-shells: create/kill windows on worker lifecycle
-                if ws.config.shells.enabled && ws.config.shells.auto_worker_shells && !is_first_load
+                if ws.config.shells.enabled
+                    && ws.config.shells.auto_worker_shells
+                    && !is_first_load
+                    && let Some(ref tmux) = ws.tmux
                 {
-                    if let Some(ref tmux) = ws.tmux {
-                        let old_ids: std::collections::HashSet<&String> =
-                            ws.prev_worker_phases.keys().collect();
-                        let new_ids: std::collections::HashSet<&String> =
-                            new_workers.iter().map(|w| &w.id).collect();
+                    let old_ids: std::collections::HashSet<&String> =
+                        ws.prev_worker_phases.keys().collect();
+                    let new_ids: std::collections::HashSet<&String> =
+                        new_workers.iter().map(|w| &w.id).collect();
 
-                        // New workers: create tmux windows
-                        for worker in &new_workers {
-                            if !old_ids.contains(&worker.id) {
-                                let wt_path =
-                                    ws.config.root.join(".swarm").join("wt").join(&worker.id);
-                                tmux.create_window(&worker.id, &wt_path);
-                            }
+                    // New workers: create tmux windows
+                    for worker in &new_workers {
+                        if !old_ids.contains(&worker.id) {
+                            let wt_path = ws.config.root.join(".swarm").join("wt").join(&worker.id);
+                            tmux.create_window(&worker.id, &wt_path);
                         }
+                    }
 
-                        // Closed workers: kill tmux windows
-                        for old_id in &old_ids {
-                            if !new_ids.contains(*old_id) {
-                                tmux.kill_window(old_id);
-                            }
+                    // Closed workers: kill tmux windows
+                    for old_id in &old_ids {
+                        if !new_ids.contains(*old_id) {
+                            tmux.kill_window(old_id);
                         }
                     }
                 }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -1873,6 +1873,7 @@ async fn handle_action(
         KeyAction::AttachShell(name) => {
             if let Some(ws) = app.current_ws()
                 && let Some(ref tmux) = ws.tmux
+                && tmux.is_available()
             {
                 let args = tmux.attach_args(&name);
                 // Suspend TUI, run tmux attach, then resume
@@ -1896,39 +1897,47 @@ async fn handle_action(
         KeyAction::CreateShell(name) => {
             if let Some(ws) = app.current_ws()
                 && let Some(ref tmux) = ws.tmux
+                && tmux.is_available()
             {
+                let tmux = tmux.clone();
                 let root = ws.config.root.clone();
-                tmux.ensure_session();
-                if tmux.create_window(&name, &root) {
+                let create_name = name.clone();
+                // Run blocking tmux commands off the async thread
+                let created = tokio::task::spawn_blocking(move || {
+                    tmux.ensure_session();
+                    tmux.create_window(&create_name, &root)
+                })
+                .await
+                .unwrap_or(false);
+                if created {
                     app.flash(format!("Created shell: {name}"));
                 } else {
                     app.flash("Failed to create shell");
                 }
-                // Refresh shell list
-                if let Some(ws) = app.current_ws_mut()
-                    && let Some(ref tmux) = ws.tmux
-                {
-                    ws.shell_windows = tmux.list_windows();
-                }
+                // Let periodic refresh pick up the new window list
             }
         }
         KeyAction::KillShell(name) => {
             if let Some(ws) = app.current_ws()
                 && let Some(ref tmux) = ws.tmux
+                && tmux.is_available()
             {
-                if tmux.kill_window(&name) {
+                let tmux = tmux.clone();
+                let kill_name = name.clone();
+                let killed = tokio::task::spawn_blocking(move || tmux.kill_window(&kill_name))
+                    .await
+                    .unwrap_or(false);
+                if killed {
                     app.flash(format!("Killed shell: {name}"));
+                    // Remove from local list immediately for responsive UI
+                    if let Some(ws) = app.current_ws_mut() {
+                        ws.shell_windows.retain(|w| w.name != name);
+                    }
+                    let count = app.current_ws().map_or(0, |ws| ws.shell_windows.len());
+                    app.shell_selection = app.shell_selection.min(count.saturating_sub(1));
                 } else {
                     app.flash("Failed to kill shell");
                 }
-                // Refresh shell list
-                if let Some(ws) = app.current_ws_mut()
-                    && let Some(ref tmux) = ws.tmux
-                {
-                    ws.shell_windows = tmux.list_windows();
-                }
-                let count = app.current_ws().map_or(0, |ws| ws.shell_windows.len());
-                app.shell_selection = app.shell_selection.min(count.saturating_sub(1));
             }
         }
         KeyAction::OpenSettings
@@ -1963,9 +1972,12 @@ async fn background_refresh_task(
         });
     }
 
+    // Cache tmux availability across refresh ticks
+    let mut tmux_available: Option<bool> = None;
+
     // Do initial data refresh immediately
     do_worker_refresh(&update_tx, &workspace_infos).await;
-    do_shell_refresh(&update_tx, &workspace_infos).await;
+    do_shell_refresh(&update_tx, &workspace_infos, &mut tmux_available).await;
     do_signal_refresh(&update_tx, &workspace_infos, &db_path).await;
     do_extras_refresh(&update_tx, &workspace_infos, &db_path, &pid_path).await;
 
@@ -1988,7 +2000,7 @@ async fn background_refresh_task(
         tokio::select! {
             _ = worker_interval.tick() => {
                 do_worker_refresh(&update_tx, &workspace_infos).await;
-                do_shell_refresh(&update_tx, &workspace_infos).await;
+                do_shell_refresh(&update_tx, &workspace_infos, &mut tmux_available).await;
             }
             _ = signal_interval.tick() => {
                 do_signal_refresh(&update_tx, &workspace_infos, &db_path).await;
@@ -2009,14 +2021,39 @@ async fn do_worker_refresh(tx: &mpsc::Sender<AppUpdate>, infos: &[app::Workspace
     }
 }
 
-async fn do_shell_refresh(tx: &mpsc::Sender<AppUpdate>, infos: &[app::WorkspaceRefreshInfo]) {
+async fn do_shell_refresh(
+    tx: &mpsc::Sender<AppUpdate>,
+    infos: &[app::WorkspaceRefreshInfo],
+    tmux_available: &mut Option<bool>,
+) {
+    // Cache tmux availability across ticks to avoid repeated `which tmux` calls.
+    let available = match *tmux_available {
+        Some(v) => v,
+        None => {
+            let v = tokio::task::spawn_blocking(|| {
+                std::process::Command::new("which")
+                    .arg("tmux")
+                    .output()
+                    .map(|o| o.status.success())
+                    .unwrap_or(false)
+            })
+            .await
+            .unwrap_or(false);
+            *tmux_available = Some(v);
+            v
+        }
+    };
+    if !available {
+        return;
+    }
+
     let infos = infos.to_vec();
     if let Ok(result) = tokio::task::spawn_blocking(move || {
         infos
             .iter()
             .filter_map(|info| {
                 let session = info.tmux_session.as_ref()?;
-                let mgr = crate::shells::TmuxManager::new(session);
+                let mgr = crate::shells::TmuxManager::with_availability(session, true);
                 let windows = mgr.list_windows();
                 Some((info.name.clone(), windows))
             })
@@ -2813,5 +2850,137 @@ mod tests {
         handle_worker_detail_key(&mut app, key(KeyCode::Char('j')), 0);
         let act_offset = app.workspaces[0].workers[0].activity_scroll.offset;
         assert!(act_offset > 0 || !app.workspaces[0].workers[0].activity_scroll.auto_scroll);
+    }
+
+    // ── Shell panel tests ────────────────────────────────
+
+    #[test]
+    fn test_current_ws_has_shells_false_by_default() {
+        let app = test_app();
+        // Default test app has shells disabled and tmux=None
+        assert!(!app.current_ws_has_shells());
+    }
+
+    #[test]
+    fn test_current_ws_has_shells_requires_available_tmux() {
+        let mut app = test_app();
+        app.workspaces[0].config.shells.enabled = true;
+        // tmux is None → should be false
+        assert!(!app.current_ws_has_shells());
+
+        // Set tmux but with available=false
+        app.workspaces[0].tmux = Some(crate::shells::TmuxManager::with_availability("test", false));
+        assert!(!app.current_ws_has_shells());
+
+        // Set tmux with available=true
+        app.workspaces[0].tmux = Some(crate::shells::TmuxManager::with_availability("test", true));
+        assert!(app.current_ws_has_shells());
+    }
+
+    #[test]
+    fn test_next_panel_skips_shells_when_disabled() {
+        let mut app = test_app();
+        // shells disabled (default) — Workers should skip to Signals
+        app.focused_panel = Panel::Workers;
+        app.next_panel();
+        assert_ne!(app.focused_panel, Panel::Shells);
+    }
+
+    #[test]
+    fn test_next_panel_includes_shells_when_enabled() {
+        let mut app = test_app();
+        app.workspaces[0].config.shells.enabled = true;
+        app.workspaces[0].tmux = Some(crate::shells::TmuxManager::with_availability("test", true));
+
+        app.focused_panel = Panel::Workers;
+        app.next_panel();
+        assert_eq!(app.focused_panel, Panel::Shells);
+    }
+
+    #[test]
+    fn test_prev_panel_includes_shells_when_enabled() {
+        let mut app = test_app();
+        app.workspaces[0].config.shells.enabled = true;
+        app.workspaces[0].tmux = Some(crate::shells::TmuxManager::with_availability("test", true));
+
+        app.focused_panel = Panel::Signals;
+        app.prev_panel();
+        // Should go to Reviews or Shells depending on review queue — no reviews, so Shells
+        assert_eq!(app.focused_panel, Panel::Shells);
+    }
+
+    #[test]
+    fn test_shell_selection_nav() {
+        let mut app = test_app();
+        app.workspaces[0].shell_windows = vec![
+            crate::shells::ShellWindow {
+                name: "a".into(),
+                working_dir: "/tmp".into(),
+                preview: String::new(),
+            },
+            crate::shells::ShellWindow {
+                name: "b".into(),
+                working_dir: "/tmp".into(),
+                preview: String::new(),
+            },
+            crate::shells::ShellWindow {
+                name: "c".into(),
+                working_dir: "/tmp".into(),
+                preview: String::new(),
+            },
+        ];
+        app.focused_panel = Panel::Shells;
+        assert_eq!(app.shell_selection, 0);
+
+        app.select_next_in_panel();
+        assert_eq!(app.shell_selection, 1);
+
+        app.select_next_in_panel();
+        assert_eq!(app.shell_selection, 2);
+
+        // Should not go past last item
+        app.select_next_in_panel();
+        assert_eq!(app.shell_selection, 2);
+
+        app.select_prev_in_panel();
+        assert_eq!(app.shell_selection, 1);
+
+        app.select_prev_in_panel();
+        assert_eq!(app.shell_selection, 0);
+
+        // Should not go below 0
+        app.select_prev_in_panel();
+        assert_eq!(app.shell_selection, 0);
+    }
+
+    #[test]
+    fn test_shell_panel_d_key_triggers_kill_confirm() {
+        let mut app = test_app();
+        app.workspaces[0].shell_windows = vec![crate::shells::ShellWindow {
+            name: "my-shell".into(),
+            working_dir: "/tmp".into(),
+            preview: String::new(),
+        }];
+        app.focused_panel = Panel::Shells;
+
+        let action = handle_dashboard_key(&mut app, key(KeyCode::Char('d')));
+
+        assert!(matches!(action, KeyAction::Redraw));
+        assert!(matches!(
+            app.pending_action,
+            Some(PendingAction::KillShell(ref name)) if name == "my-shell"
+        ));
+        assert!(matches!(app.mode, Mode::Confirm));
+    }
+
+    #[test]
+    fn test_shell_panel_n_key_activates_input() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Shells;
+
+        handle_dashboard_key(&mut app, key(KeyCode::Char('n')));
+
+        assert!(app.shell_input_active);
+        assert!(app.shell_input.is_empty());
     }
 }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -517,7 +517,21 @@ async fn event_loop(
             Some(update) = update_rx.recv() => {
                 match update {
                     AppUpdate::Workers(data) => {
-                        app.apply_worker_update(data);
+                        let shell_ops = app.apply_worker_update(data);
+                        if !shell_ops.is_empty() {
+                            tokio::task::spawn_blocking(move || {
+                                for op in shell_ops {
+                                    match op {
+                                        app::PendingShellOp::Create { tmux, name, working_dir } => {
+                                            tmux.create_window(&name, &working_dir);
+                                        }
+                                        app::PendingShellOp::Kill { tmux, name } => {
+                                            tmux.kill_window(&name);
+                                        }
+                                    }
+                                }
+                            });
+                        }
                         // Refresh conversation in background when viewing worker detail
                         if let View::WorkerDetail(idx) = app.view
                             && let Some(ws) = app.current_ws()
@@ -848,7 +862,7 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
                 }
                 return KeyAction::Redraw;
             }
-            KeyCode::Char('n') => {
+            KeyCode::Char('n') if app.current_ws_tmux_available() => {
                 app.shell_input_active = true;
                 app.shell_input.clear();
                 app.needs_redraw = true;
@@ -2862,19 +2876,27 @@ mod tests {
     }
 
     #[test]
-    fn test_current_ws_has_shells_requires_available_tmux() {
+    fn test_current_ws_has_shells_only_checks_config() {
         let mut app = test_app();
         app.workspaces[0].config.shells.enabled = true;
-        // tmux is None → should be false
-        assert!(!app.current_ws_has_shells());
+        // Panel shows even without tmux — config is all that matters
+        assert!(app.current_ws_has_shells());
+    }
+
+    #[test]
+    fn test_current_ws_tmux_available() {
+        let mut app = test_app();
+        app.workspaces[0].config.shells.enabled = true;
+        // tmux is None → not available
+        assert!(!app.current_ws_tmux_available());
 
         // Set tmux but with available=false
         app.workspaces[0].tmux = Some(crate::shells::TmuxManager::with_availability("test", false));
-        assert!(!app.current_ws_has_shells());
+        assert!(!app.current_ws_tmux_available());
 
         // Set tmux with available=true
         app.workspaces[0].tmux = Some(crate::shells::TmuxManager::with_availability("test", true));
-        assert!(app.current_ws_has_shells());
+        assert!(app.current_ws_tmux_available());
     }
 
     #[test]
@@ -2890,7 +2912,6 @@ mod tests {
     fn test_next_panel_includes_shells_when_enabled() {
         let mut app = test_app();
         app.workspaces[0].config.shells.enabled = true;
-        app.workspaces[0].tmux = Some(crate::shells::TmuxManager::with_availability("test", true));
 
         app.focused_panel = Panel::Workers;
         app.next_panel();
@@ -2901,7 +2922,6 @@ mod tests {
     fn test_prev_panel_includes_shells_when_enabled() {
         let mut app = test_app();
         app.workspaces[0].config.shells.enabled = true;
-        app.workspaces[0].tmux = Some(crate::shells::TmuxManager::with_availability("test", true));
 
         app.focused_panel = Panel::Signals;
         app.prev_panel();
@@ -2976,11 +2996,25 @@ mod tests {
     #[test]
     fn test_shell_panel_n_key_activates_input() {
         let mut app = test_app();
+        app.workspaces[0].config.shells.enabled = true;
+        app.workspaces[0].tmux = Some(crate::shells::TmuxManager::with_availability("test", true));
         app.focused_panel = Panel::Shells;
 
         handle_dashboard_key(&mut app, key(KeyCode::Char('n')));
 
         assert!(app.shell_input_active);
         assert!(app.shell_input.is_empty());
+    }
+
+    #[test]
+    fn test_shell_panel_n_key_noop_without_tmux() {
+        let mut app = test_app();
+        app.workspaces[0].config.shells.enabled = true;
+        // tmux not available
+        app.focused_panel = Panel::Shells;
+
+        handle_dashboard_key(&mut app, key(KeyCode::Char('n')));
+
+        assert!(!app.shell_input_active, "n should be ignored without tmux");
     }
 }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -555,15 +555,42 @@ async fn event_loop(
                         app.apply_signal_update(data);
                     }
                     AppUpdate::ShellWindows(data) => {
-                        for (name, windows) in data {
-                            if let Some(ws) = app.workspaces.iter_mut().find(|ws| ws.name == name) {
-                                ws.shell_windows = windows;
+                        for (name, windows) in &data {
+                            if let Some(ws) = app.workspaces.iter_mut().find(|ws| ws.name == *name) {
+                                ws.shell_windows = windows.clone();
                             }
                         }
                         app.shell_selection = app.shell_selection.min(
                             app.current_ws()
                                 .map_or(0, |ws| ws.shell_windows.len().saturating_sub(1)),
                         );
+                        // Lazily capture preview for the selected window only
+                        if let Some(ws) = app.current_ws()
+                            && let Some(shell) = ws.shell_windows.get(app.shell_selection)
+                            && let Some(ref tmux) = ws.tmux
+                            && tmux.is_available()
+                        {
+                            let tmux = tmux.clone();
+                            let ws_name = ws.name.clone();
+                            let win_name = shell.name.clone();
+                            let tx = update_tx.clone();
+                            tokio::task::spawn_blocking(move || {
+                                let preview = tmux.capture_preview(&win_name).unwrap_or_default();
+                                let _ = tx.blocking_send(AppUpdate::ShellPreview {
+                                    workspace_name: ws_name,
+                                    window_name: win_name,
+                                    preview,
+                                });
+                            });
+                        }
+                        app.needs_redraw = true;
+                    }
+                    AppUpdate::ShellPreview { workspace_name, window_name, preview } => {
+                        if let Some(ws) = app.workspaces.iter_mut().find(|ws| ws.name == workspace_name)
+                            && let Some(shell) = ws.shell_windows.iter_mut().find(|s| s.name == window_name)
+                        {
+                            shell.preview = preview;
+                        }
                         app.needs_redraw = true;
                     }
                     AppUpdate::Extras { daemon_alive, daemon_uptime_secs, per_workspace } => {
@@ -793,7 +820,7 @@ fn handle_paste(app: &mut App, text: &str) {
     } else if app.review_comment_active {
         app.review_comment_input.push_str(text);
     } else if app.shell_input_active {
-        app.shell_input.push_str(text);
+        app.shell_input.push_str(&sanitize_shell_name_input(text));
     }
     app.needs_redraw = true;
 }
@@ -1401,6 +1428,19 @@ fn handle_review_comment_key(app: &mut App, key: crossterm::event::KeyEvent) -> 
 
 // ── Shell name input keys ─────────────────────────────────
 
+/// Characters that are invalid in tmux window names:
+/// ':', '.' (session:window separators), and control/whitespace chars.
+fn is_valid_shell_name_char(c: char) -> bool {
+    !c.is_control() && c != ':' && c != '.'
+}
+
+/// Strip control chars and tmux-special chars from pasted text for shell names.
+fn sanitize_shell_name_input(text: &str) -> String {
+    text.chars()
+        .filter(|c| is_valid_shell_name_char(*c))
+        .collect()
+}
+
 fn handle_shell_input_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
     match key.code {
         KeyCode::Enter => {
@@ -1420,7 +1460,7 @@ fn handle_shell_input_key(app: &mut App, key: crossterm::event::KeyEvent) -> Key
             app.shell_input.pop();
             app.needs_redraw = true;
         }
-        KeyCode::Char(c) => {
+        KeyCode::Char(c) if is_valid_shell_name_char(c) => {
             app.shell_input.push(c);
             app.needs_redraw = true;
         }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -2426,6 +2426,8 @@ mod tests {
             feed_scroll: apiari_tui::scroll::ScrollState::new(),
             thoughts: Vec::new(),
             is_setup_placeholder: false,
+            tmux: None,
+            shell_windows: Vec::new(),
         };
         let ws_name = ws.name.clone();
         App {
@@ -2471,6 +2473,9 @@ mod tests {
             last_signal_refresh: std::time::Instant::now(),
             snooze_selection: 0,
             signals_debug_mode: false,
+            shell_selection: 0,
+            shell_input_active: false,
+            shell_input: String::new(),
         }
     }
 

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -841,10 +841,10 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
     if app.focused_panel == Panel::Shells {
         match key.code {
             KeyCode::Enter => {
-                if let Some(ws) = app.current_ws() {
-                    if let Some(shell) = ws.shell_windows.get(app.shell_selection) {
-                        return KeyAction::AttachShell(shell.name.clone());
-                    }
+                if let Some(ws) = app.current_ws()
+                    && let Some(shell) = ws.shell_windows.get(app.shell_selection)
+                {
+                    return KeyAction::AttachShell(shell.name.clone());
                 }
                 return KeyAction::Redraw;
             }
@@ -855,12 +855,12 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
                 return KeyAction::Redraw;
             }
             KeyCode::Char('d') | KeyCode::Delete => {
-                if let Some(ws) = app.current_ws() {
-                    if let Some(shell) = ws.shell_windows.get(app.shell_selection) {
-                        let name = shell.name.clone();
-                        app.pending_action = Some(PendingAction::KillShell(name));
-                        app.mode = Mode::Confirm;
-                    }
+                if let Some(ws) = app.current_ws()
+                    && let Some(shell) = ws.shell_windows.get(app.shell_selection)
+                {
+                    let name = shell.name.clone();
+                    app.pending_action = Some(PendingAction::KillShell(name));
+                    app.mode = Mode::Confirm;
                 }
                 return KeyAction::Redraw;
             }
@@ -1871,64 +1871,64 @@ async fn handle_action(
             }
         }
         KeyAction::AttachShell(name) => {
-            if let Some(ws) = app.current_ws() {
-                if let Some(ref tmux) = ws.tmux {
-                    let args = tmux.attach_args(&name);
-                    // Suspend TUI, run tmux attach, then resume
-                    disable_raw_mode().ok();
-                    stdout()
-                        .execute(crossterm::event::DisableBracketedPaste)
-                        .ok();
-                    stdout().execute(crossterm::event::DisableMouseCapture).ok();
-                    stdout().execute(LeaveAlternateScreen).ok();
+            if let Some(ws) = app.current_ws()
+                && let Some(ref tmux) = ws.tmux
+            {
+                let args = tmux.attach_args(&name);
+                // Suspend TUI, run tmux attach, then resume
+                disable_raw_mode().ok();
+                stdout()
+                    .execute(crossterm::event::DisableBracketedPaste)
+                    .ok();
+                stdout().execute(crossterm::event::DisableMouseCapture).ok();
+                stdout().execute(LeaveAlternateScreen).ok();
 
-                    let _ = std::process::Command::new("tmux").args(&args).status();
+                let _ = std::process::Command::new("tmux").args(&args).status();
 
-                    stdout().execute(EnterAlternateScreen).ok();
-                    stdout().execute(crossterm::event::EnableMouseCapture).ok();
-                    stdout()
-                        .execute(crossterm::event::EnableBracketedPaste)
-                        .ok();
-                    enable_raw_mode().ok();
-                }
+                stdout().execute(EnterAlternateScreen).ok();
+                stdout().execute(crossterm::event::EnableMouseCapture).ok();
+                stdout()
+                    .execute(crossterm::event::EnableBracketedPaste)
+                    .ok();
+                enable_raw_mode().ok();
             }
         }
         KeyAction::CreateShell(name) => {
-            if let Some(ws) = app.current_ws() {
-                if let Some(ref tmux) = ws.tmux {
-                    let root = ws.config.root.clone();
-                    tmux.ensure_session();
-                    if tmux.create_window(&name, &root) {
-                        app.flash(format!("Created shell: {name}"));
-                    } else {
-                        app.flash("Failed to create shell");
-                    }
-                    // Refresh shell list
-                    if let Some(ws) = app.current_ws_mut() {
-                        if let Some(ref tmux) = ws.tmux {
-                            ws.shell_windows = tmux.list_windows();
-                        }
-                    }
+            if let Some(ws) = app.current_ws()
+                && let Some(ref tmux) = ws.tmux
+            {
+                let root = ws.config.root.clone();
+                tmux.ensure_session();
+                if tmux.create_window(&name, &root) {
+                    app.flash(format!("Created shell: {name}"));
+                } else {
+                    app.flash("Failed to create shell");
+                }
+                // Refresh shell list
+                if let Some(ws) = app.current_ws_mut()
+                    && let Some(ref tmux) = ws.tmux
+                {
+                    ws.shell_windows = tmux.list_windows();
                 }
             }
         }
         KeyAction::KillShell(name) => {
-            if let Some(ws) = app.current_ws() {
-                if let Some(ref tmux) = ws.tmux {
-                    if tmux.kill_window(&name) {
-                        app.flash(format!("Killed shell: {name}"));
-                    } else {
-                        app.flash("Failed to kill shell");
-                    }
-                    // Refresh shell list
-                    if let Some(ws) = app.current_ws_mut() {
-                        if let Some(ref tmux) = ws.tmux {
-                            ws.shell_windows = tmux.list_windows();
-                        }
-                    }
-                    let count = app.current_ws().map_or(0, |ws| ws.shell_windows.len());
-                    app.shell_selection = app.shell_selection.min(count.saturating_sub(1));
+            if let Some(ws) = app.current_ws()
+                && let Some(ref tmux) = ws.tmux
+            {
+                if tmux.kill_window(&name) {
+                    app.flash(format!("Killed shell: {name}"));
+                } else {
+                    app.flash("Failed to kill shell");
                 }
+                // Refresh shell list
+                if let Some(ws) = app.current_ws_mut()
+                    && let Some(ref tmux) = ws.tmux
+                {
+                    ws.shell_windows = tmux.list_windows();
+                }
+                let count = app.current_ws().map_or(0, |ws| ws.shell_windows.len());
+                app.shell_selection = app.shell_selection.min(count.saturating_sub(1));
             }
         }
         KeyAction::OpenSettings
@@ -2023,10 +2023,9 @@ async fn do_shell_refresh(tx: &mpsc::Sender<AppUpdate>, infos: &[app::WorkspaceR
             .collect::<Vec<_>>()
     })
     .await
+        && !result.is_empty()
     {
-        if !result.is_empty() {
-            let _ = tx.send(AppUpdate::ShellWindows(result)).await;
-        }
+        let _ = tx.send(AppUpdate::ShellWindows(result)).await;
     }
 }
 

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -88,6 +88,9 @@ enum KeyAction {
         body: String,
     },
     SnoozeSignal(i64, chrono::DateTime<chrono::Utc>),
+    AttachShell(String),
+    CreateShell(String),
+    KillShell(String),
     SetupComplete,
     AddWorkspace,
     OpenSettings,
@@ -537,6 +540,18 @@ async fn event_loop(
                     AppUpdate::Signals(data) => {
                         app.apply_signal_update(data);
                     }
+                    AppUpdate::ShellWindows(data) => {
+                        for (name, windows) in data {
+                            if let Some(ws) = app.workspaces.iter_mut().find(|ws| ws.name == name) {
+                                ws.shell_windows = windows;
+                            }
+                        }
+                        app.shell_selection = app.shell_selection.min(
+                            app.current_ws()
+                                .map_or(0, |ws| ws.shell_windows.len().saturating_sub(1)),
+                        );
+                        app.needs_redraw = true;
+                    }
                     AppUpdate::Extras { daemon_alive, daemon_uptime_secs, per_workspace } => {
                         app.apply_extras_update(daemon_alive, daemon_uptime_secs, per_workspace);
                     }
@@ -709,6 +724,7 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
                         PendingAction::ApproveReview { repo, pr_number } => {
                             return KeyAction::ApproveReview { repo, pr_number };
                         }
+                        PendingAction::KillShell(name) => return KeyAction::KillShell(name),
                         PendingAction::SnoozeSignal(_) => unreachable!(),
                     }
                 }
@@ -726,6 +742,11 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
     // ── Review comment input ──
     if app.review_comment_active {
         return handle_review_comment_key(app, key);
+    }
+
+    // ── Shell name input ──
+    if app.shell_input_active {
+        return handle_shell_input_key(app, key);
     }
 
     // ── Help overlay ──
@@ -757,6 +778,8 @@ fn handle_paste(app: &mut App, text: &str) {
         app.worker_input.push_str(text);
     } else if app.review_comment_active {
         app.review_comment_input.push_str(text);
+    } else if app.shell_input_active {
+        app.shell_input.push_str(text);
     }
     app.needs_redraw = true;
 }
@@ -811,6 +834,37 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
                 app.needs_redraw = true;
             }
             return KeyAction::Redraw;
+        }
+    }
+
+    // Shells panel: intercept Enter/n/d/Delete
+    if app.focused_panel == Panel::Shells {
+        match key.code {
+            KeyCode::Enter => {
+                if let Some(ws) = app.current_ws() {
+                    if let Some(shell) = ws.shell_windows.get(app.shell_selection) {
+                        return KeyAction::AttachShell(shell.name.clone());
+                    }
+                }
+                return KeyAction::Redraw;
+            }
+            KeyCode::Char('n') => {
+                app.shell_input_active = true;
+                app.shell_input.clear();
+                app.needs_redraw = true;
+                return KeyAction::Redraw;
+            }
+            KeyCode::Char('d') | KeyCode::Delete => {
+                if let Some(ws) = app.current_ws() {
+                    if let Some(shell) = ws.shell_windows.get(app.shell_selection) {
+                        let name = shell.name.clone();
+                        app.pending_action = Some(PendingAction::KillShell(name));
+                        app.mode = Mode::Confirm;
+                    }
+                }
+                return KeyAction::Redraw;
+            }
+            _ => {} // fall through to common dashboard keys
         }
     }
 
@@ -1331,6 +1385,36 @@ fn handle_review_comment_key(app: &mut App, key: crossterm::event::KeyEvent) -> 
     KeyAction::Redraw
 }
 
+// ── Shell name input keys ─────────────────────────────────
+
+fn handle_shell_input_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
+    match key.code {
+        KeyCode::Enter => {
+            let name = std::mem::take(&mut app.shell_input);
+            app.shell_input_active = false;
+            app.needs_redraw = true;
+            if !name.trim().is_empty() {
+                return KeyAction::CreateShell(name.trim().to_string());
+            }
+        }
+        KeyCode::Esc => {
+            app.shell_input.clear();
+            app.shell_input_active = false;
+            app.needs_redraw = true;
+        }
+        KeyCode::Backspace => {
+            app.shell_input.pop();
+            app.needs_redraw = true;
+        }
+        KeyCode::Char(c) => {
+            app.shell_input.push(c);
+            app.needs_redraw = true;
+        }
+        _ => {}
+    }
+    KeyAction::Redraw
+}
+
 // ── Signal detail keys ───────────────────────────────────
 
 fn handle_signal_detail_key(
@@ -1786,6 +1870,67 @@ async fn handle_action(
                 }
             }
         }
+        KeyAction::AttachShell(name) => {
+            if let Some(ws) = app.current_ws() {
+                if let Some(ref tmux) = ws.tmux {
+                    let args = tmux.attach_args(&name);
+                    // Suspend TUI, run tmux attach, then resume
+                    disable_raw_mode().ok();
+                    stdout()
+                        .execute(crossterm::event::DisableBracketedPaste)
+                        .ok();
+                    stdout().execute(crossterm::event::DisableMouseCapture).ok();
+                    stdout().execute(LeaveAlternateScreen).ok();
+
+                    let _ = std::process::Command::new("tmux").args(&args).status();
+
+                    stdout().execute(EnterAlternateScreen).ok();
+                    stdout().execute(crossterm::event::EnableMouseCapture).ok();
+                    stdout()
+                        .execute(crossterm::event::EnableBracketedPaste)
+                        .ok();
+                    enable_raw_mode().ok();
+                }
+            }
+        }
+        KeyAction::CreateShell(name) => {
+            if let Some(ws) = app.current_ws() {
+                if let Some(ref tmux) = ws.tmux {
+                    let root = ws.config.root.clone();
+                    tmux.ensure_session();
+                    if tmux.create_window(&name, &root) {
+                        app.flash(format!("Created shell: {name}"));
+                    } else {
+                        app.flash("Failed to create shell");
+                    }
+                    // Refresh shell list
+                    if let Some(ws) = app.current_ws_mut() {
+                        if let Some(ref tmux) = ws.tmux {
+                            ws.shell_windows = tmux.list_windows();
+                        }
+                    }
+                }
+            }
+        }
+        KeyAction::KillShell(name) => {
+            if let Some(ws) = app.current_ws() {
+                if let Some(ref tmux) = ws.tmux {
+                    if tmux.kill_window(&name) {
+                        app.flash(format!("Killed shell: {name}"));
+                    } else {
+                        app.flash("Failed to kill shell");
+                    }
+                    // Refresh shell list
+                    if let Some(ws) = app.current_ws_mut() {
+                        if let Some(ref tmux) = ws.tmux {
+                            ws.shell_windows = tmux.list_windows();
+                        }
+                    }
+                    let count = app.current_ws().map_or(0, |ws| ws.shell_windows.len());
+                    app.shell_selection = app.shell_selection.min(count.saturating_sub(1));
+                }
+            }
+        }
         KeyAction::OpenSettings
         | KeyAction::SetupComplete
         | KeyAction::AddWorkspace
@@ -1820,6 +1965,7 @@ async fn background_refresh_task(
 
     // Do initial data refresh immediately
     do_worker_refresh(&update_tx, &workspace_infos).await;
+    do_shell_refresh(&update_tx, &workspace_infos).await;
     do_signal_refresh(&update_tx, &workspace_infos, &db_path).await;
     do_extras_refresh(&update_tx, &workspace_infos, &db_path, &pid_path).await;
 
@@ -1842,6 +1988,7 @@ async fn background_refresh_task(
         tokio::select! {
             _ = worker_interval.tick() => {
                 do_worker_refresh(&update_tx, &workspace_infos).await;
+                do_shell_refresh(&update_tx, &workspace_infos).await;
             }
             _ = signal_interval.tick() => {
                 do_signal_refresh(&update_tx, &workspace_infos, &db_path).await;
@@ -1859,6 +2006,27 @@ async fn do_worker_refresh(tx: &mpsc::Sender<AppUpdate>, infos: &[app::Workspace
         tokio::task::spawn_blocking(move || app::load_all_workers_blocking(&infos)).await
     {
         let _ = tx.send(AppUpdate::Workers(result)).await;
+    }
+}
+
+async fn do_shell_refresh(tx: &mpsc::Sender<AppUpdate>, infos: &[app::WorkspaceRefreshInfo]) {
+    let infos = infos.to_vec();
+    if let Ok(result) = tokio::task::spawn_blocking(move || {
+        infos
+            .iter()
+            .filter_map(|info| {
+                let session = info.tmux_session.as_ref()?;
+                let mgr = crate::shells::TmuxManager::new(session);
+                let windows = mgr.list_windows();
+                Some((info.name.clone(), windows))
+            })
+            .collect::<Vec<_>>()
+    })
+    .await
+    {
+        if !result.is_empty() {
+            let _ = tx.send(AppUpdate::ShellWindows(result)).await;
+        }
     }
 }
 

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -1127,11 +1127,16 @@ fn draw_shells_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
             Span::styled(&shell.name, name_style),
         ]));
 
-        // Show preview line (trimmed to fit)
+        // Show preview line (trimmed to fit, char-aware to avoid UTF-8 panic)
         if !shell.preview.is_empty() {
             let max_w = inner.width.saturating_sub(4) as usize;
-            let preview = if shell.preview.len() > max_w {
-                &shell.preview[..max_w]
+            let preview: &str = if shell.preview.chars().count() > max_w {
+                let end = shell
+                    .preview
+                    .char_indices()
+                    .nth(max_w)
+                    .map_or(shell.preview.len(), |(i, _)| i);
+                &shell.preview[..end]
             } else {
                 &shell.preview
             };

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -117,6 +117,11 @@ pub fn draw(frame: &mut Frame, app: &App) {
     if app.review_comment_active {
         draw_review_comment_input(frame, size, app);
     }
+
+    // Shell name input overlay
+    if app.shell_input_active {
+        draw_shell_name_input(frame, size, app);
+    }
 }
 
 // ── Tab bar ──────────────────────────────────────────────
@@ -180,6 +185,7 @@ fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
         match panel {
             Panel::Home => draw_home_panel(frame, app, ws, area),
             Panel::Workers => draw_workers_panel(frame, app, ws, area),
+            Panel::Shells => draw_shells_panel(frame, app, ws, area),
             Panel::Signals => draw_signals_card(frame, app, ws, area),
             Panel::Reviews => draw_reviews_pane(frame, app, ws, area),
             Panel::Feed => draw_feed_panel(frame, app, ws, area),
@@ -225,6 +231,7 @@ fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
     let wide = items.width >= 80;
     let medium = items.width >= 60;
     let has_reviews = app.has_review_queue();
+    let has_shells = app.current_ws_has_shells();
 
     if medium {
         let cols = Layout::default()
@@ -233,8 +240,20 @@ fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
             .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
             .split(items);
 
-        draw_workers_panel(frame, app, ws, cols[0]);
-        dim_areas.push((Panel::Workers, cols[0]));
+        // Left column: Workers, and optionally Shells below
+        if has_shells {
+            let left_rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+                .split(cols[0]);
+            draw_workers_panel(frame, app, ws, left_rows[0]);
+            dim_areas.push((Panel::Workers, left_rows[0]));
+            draw_shells_panel(frame, app, ws, left_rows[1]);
+            dim_areas.push((Panel::Shells, left_rows[1]));
+        } else {
+            draw_workers_panel(frame, app, ws, cols[0]);
+            dim_areas.push((Panel::Workers, cols[0]));
+        }
 
         if wide {
             if has_reviews {
@@ -1052,6 +1071,77 @@ fn draw_workers_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, ar
         let is_sel = panel_focused && app.worker_selection == i;
         render_worker_item(&mut lines, worker, is_sel, i, inner.width as usize);
     }
+    frame.render_widget(Paragraph::new(lines), inner);
+
+    if !panel_focused {
+        dim_area(frame, inner);
+    }
+}
+
+// ── Shells panel ──────────────────────────────────────────
+
+fn draw_shells_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area: Rect) {
+    let panel_focused = app.focused_panel == Panel::Shells;
+
+    let hint = if panel_focused {
+        Some("n:new  enter:attach  d:kill")
+    } else {
+        None
+    };
+    let title = format!("Shells ({})", ws.shell_windows.len());
+    let block = panel_block(&title, panel_focused, hint);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if ws.shell_windows.is_empty() {
+        let lines = vec![
+            Line::from(vec![
+                Span::raw(" "),
+                Span::styled("No shell windows", theme::muted()),
+            ]),
+            Line::from(vec![
+                Span::raw(" "),
+                Span::styled("Press n to create one", theme::key_desc()),
+            ]),
+        ];
+        frame.render_widget(Paragraph::new(lines), inner);
+        if !panel_focused {
+            dim_area(frame, inner);
+        }
+        return;
+    }
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, shell) in ws.shell_windows.iter().enumerate() {
+        let is_sel = panel_focused && app.shell_selection == i;
+        let marker = if is_sel { "> " } else { "  " };
+        let name_style = if is_sel {
+            theme::highlight()
+        } else {
+            Style::default().fg(theme::POLLEN)
+        };
+        let preview_style = theme::muted();
+
+        lines.push(Line::from(vec![
+            Span::raw(marker),
+            Span::styled(&shell.name, name_style),
+        ]));
+
+        // Show preview line (trimmed to fit)
+        if !shell.preview.is_empty() {
+            let max_w = inner.width.saturating_sub(4) as usize;
+            let preview = if shell.preview.len() > max_w {
+                &shell.preview[..max_w]
+            } else {
+                &shell.preview
+            };
+            lines.push(Line::from(vec![
+                Span::raw("    "),
+                Span::styled(preview, preview_style),
+            ]));
+        }
+    }
+
     frame.render_widget(Paragraph::new(lines), inner);
 
     if !panel_focused {
@@ -2461,6 +2551,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                 let panel_name = match app.focused_panel {
                     Panel::Home => "Home",
                     Panel::Workers => "Workers",
+                    Panel::Shells => "Shells",
                     Panel::Signals => "Signals",
                     Panel::Reviews => "Reviews",
                     Panel::Feed => "Feed",
@@ -2886,6 +2977,7 @@ fn draw_confirm_overlay(frame: &mut Frame, area: Rect, action: &PendingAction, a
                 PendingAction::ApproveReview { repo, pr_number } => {
                     format!("Approve PR #{pr_number} in {repo}?")
                 }
+                PendingAction::KillShell(name) => format!("Kill shell '{name}'?"),
                 PendingAction::SnoozeSignal(_) => unreachable!(),
             };
 
@@ -3006,6 +3098,39 @@ fn draw_review_comment_input(frame: &mut Frame, area: Rect, app: &App) {
         Line::from(vec![
             Span::styled("  enter", theme::key_hint()),
             Span::styled(":send  ", theme::key_desc()),
+            Span::styled("esc", theme::key_hint()),
+            Span::styled(":cancel", theme::key_desc()),
+        ]),
+    ];
+
+    let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, inner);
+}
+
+fn draw_shell_name_input(frame: &mut Frame, area: Rect, app: &App) {
+    let w = (area.width.saturating_sub(4)).min(40);
+    let h = 5u16;
+    let x = (area.width.saturating_sub(w)) / 2;
+    let y = (area.height.saturating_sub(h)) / 2;
+    let popup = Rect::new(x, y, w, h);
+
+    frame.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::border_active())
+        .title(Span::styled(" New Shell ", theme::accent()));
+
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let input_text = format!(" {}_", app.shell_input);
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![Span::styled(input_text, theme::text())]),
+        Line::from(vec![
+            Span::styled("  enter", theme::key_hint()),
+            Span::styled(":create  ", theme::key_desc()),
             Span::styled("esc", theme::key_hint()),
             Span::styled(":cancel", theme::key_desc()),
         ]),

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -10,6 +10,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
 use apiari_tui::conversation;
+use unicode_width::UnicodeWidthChar;
 
 use super::app::{self, App, ChatLine, Mode, Panel, PendingAction, View};
 use super::theme;
@@ -1082,8 +1083,9 @@ fn draw_workers_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, ar
 
 fn draw_shells_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area: Rect) {
     let panel_focused = app.focused_panel == Panel::Shells;
+    let tmux_available = ws.tmux.as_ref().is_some_and(|tmux| tmux.is_available());
 
-    let hint = if panel_focused {
+    let hint = if panel_focused && tmux_available {
         Some("n:new  enter:attach  d:kill")
     } else {
         None
@@ -1092,6 +1094,24 @@ fn draw_shells_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
     let block = panel_block(&title, panel_focused, hint);
     let inner = block.inner(area);
     frame.render_widget(block, area);
+
+    if !tmux_available {
+        let lines = vec![
+            Line::from(vec![
+                Span::raw(" "),
+                Span::styled("tmux not found", Style::default().fg(theme::NECTAR)),
+            ]),
+            Line::from(vec![
+                Span::raw(" "),
+                Span::styled("Install tmux to manage shells", theme::muted()),
+            ]),
+        ];
+        frame.render_widget(Paragraph::new(lines), inner);
+        if !panel_focused {
+            dim_area(frame, inner);
+        }
+        return;
+    }
 
     if ws.shell_windows.is_empty() {
         let lines = vec![
@@ -1127,19 +1147,20 @@ fn draw_shells_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
             Span::styled(&shell.name, name_style),
         ]));
 
-        // Show preview line (trimmed to fit, char-aware to avoid UTF-8 panic)
+        // Show preview line (trimmed to fit using display column width)
         if !shell.preview.is_empty() {
             let max_w = inner.width.saturating_sub(4) as usize;
-            let preview: &str = if shell.preview.chars().count() > max_w {
-                let end = shell
-                    .preview
-                    .char_indices()
-                    .nth(max_w)
-                    .map_or(shell.preview.len(), |(i, _)| i);
-                &shell.preview[..end]
-            } else {
-                &shell.preview
-            };
+            let mut width = 0;
+            let mut end_byte = shell.preview.len();
+            for (i, ch) in shell.preview.char_indices() {
+                let cw = ch.width().unwrap_or(0);
+                if width + cw > max_w {
+                    end_byte = i;
+                    break;
+                }
+                width += cw;
+            }
+            let preview = &shell.preview[..end_byte];
             lines.push(Line::from(vec![
                 Span::raw("    "),
                 Span::styled(preview, preview_style),


### PR DESCRIPTION
## Summary
- Adds a new `[shells]` config block (`enabled`, `tmux_session`, `auto_worker_shells`) to workspace TOML config
- Implements `TmuxManager` in `crates/apiari/src/shells/mod.rs` with full tmux session/window lifecycle management
- Auto-creates/kills tmux windows when workers spawn/close (when `auto_worker_shells = true`)
- Adds a **Shells panel** to the TUI dashboard with keybindings: `Enter` (attach), `n` (new shell), `d`/`Delete` (kill)
- Implements jump-in UX: suspends the TUI, runs `tmux attach`, resumes TUI on detach
- All tmux operations gracefully no-op when tmux is not installed
- Background shell preview refresh every 2s

## Test plan
- [ ] Verify `cargo check -p apiari` passes
- [ ] Verify TUI renders Shells panel when `shells.enabled = true` in workspace config
- [ ] Test with tmux installed: create/attach/kill shells via TUI
- [ ] Test without tmux installed: confirm graceful no-ops, no crashes
- [ ] Test `auto_worker_shells`: verify windows auto-create on worker spawn and auto-kill on close
- [ ] Verify backward compatibility: existing configs without `[shells]` block load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)