### PR TITLE
chore: bump apiari version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apiari"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "apiari-claude-sdk",
  "apiari-swarm",
@@ -140,6 +140,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "tracing-subscriber",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/ApiariTools/apiari"


### PR DESCRIPTION
## Summary
- Bumps the `apiari` crate version from `0.2.0` to `0.2.1` in `crates/apiari/Cargo.toml`

## Test plan
- [x] `cargo check -p apiari` passes
- [x] `cargo fmt -p apiari -- --check` passes
- [x] `Cargo.lock` updated via `cargo update -p apiari`

🤖 Generated with [Claude Code](https://claude.com/claude-code)