### PR TITLE
fix: add per-watcher poll timeout and HTTP request timeouts

### DIFF
--- a/crates/apiari/src/buzz/watcher/linear.rs
+++ b/crates/apiari/src/buzz/watcher/linear.rs
@@ -8,10 +8,14 @@
 //! Read-only: no Linear mutation API calls are ever made.
 
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use color_eyre::Result;
 use tracing::{info, warn};
+
+/// HTTP request timeout for Linear API calls.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 use super::Watcher;
 use crate::buzz::config::{LinearReviewQueueEntry, LinearWatcherConfig};
@@ -198,7 +202,10 @@ impl LinearWatcher {
         let cursor_key = format!("linear_{}_seen", config.name);
         Self {
             config,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
             watcher_name,
             cursor_key,
             seen: HashMap::new(),

--- a/crates/apiari/src/buzz/watcher/linear.rs
+++ b/crates/apiari/src/buzz/watcher/linear.rs
@@ -205,7 +205,12 @@ impl LinearWatcher {
             client: reqwest::Client::builder()
                 .timeout(REQUEST_TIMEOUT)
                 .build()
-                .unwrap_or_else(|_| reqwest::Client::new()),
+                .unwrap_or_else(|e| {
+                    warn!(
+                        "failed to build reqwest client with timeout: {e}, falling back to default"
+                    );
+                    reqwest::Client::new()
+                }),
             watcher_name,
             cursor_key,
             seen: HashMap::new(),

--- a/crates/apiari/src/buzz/watcher/review_queue.rs
+++ b/crates/apiari/src/buzz/watcher/review_queue.rs
@@ -62,7 +62,12 @@ impl ReviewQueueWatcher {
             client: reqwest::Client::builder()
                 .timeout(REQUEST_TIMEOUT)
                 .build()
-                .unwrap_or_else(|_| reqwest::Client::new()),
+                .unwrap_or_else(|e| {
+                    warn!(
+                        "failed to build reqwest client with timeout: {e}, falling back to default"
+                    );
+                    reqwest::Client::new()
+                }),
             token: None,
         }
     }

--- a/crates/apiari/src/buzz/watcher/review_queue.rs
+++ b/crates/apiari/src/buzz/watcher/review_queue.rs
@@ -5,10 +5,14 @@
 //! priority) wins. Source: `github_review_queue`.
 
 use std::collections::HashSet;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use color_eyre::Result;
 use tracing::{info, warn};
+
+/// HTTP request timeout for GitHub API calls.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 use super::Watcher;
 use crate::buzz::config::{GithubWatcherConfig, ReviewQueueEntry};
@@ -55,7 +59,10 @@ impl ReviewQueueWatcher {
     pub fn new(config: &GithubWatcherConfig) -> Self {
         Self {
             queries: config.review_queue.clone(),
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
             token: None,
         }
     }

--- a/crates/apiari/src/buzz/watcher/sentry.rs
+++ b/crates/apiari/src/buzz/watcher/sentry.rs
@@ -45,7 +45,12 @@ impl SentryWatcher {
             client: reqwest::Client::builder()
                 .timeout(REQUEST_TIMEOUT)
                 .build()
-                .unwrap_or_else(|_| reqwest::Client::new()),
+                .unwrap_or_else(|e| {
+                    warn!(
+                        "failed to build reqwest client with timeout: {e}, falling back to default"
+                    );
+                    reqwest::Client::new()
+                }),
             seen_issues: HashMap::new(),
             fetched_ids: None,
         }

--- a/crates/apiari/src/buzz/watcher/sentry.rs
+++ b/crates/apiari/src/buzz/watcher/sentry.rs
@@ -4,12 +4,16 @@
 //! stale issues that reorder in Sentry's date-sorted results.
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use color_eyre::Result;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
+
+/// HTTP request timeout for Sentry API calls.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 use super::Watcher;
 use crate::buzz::config::SentryWatcherConfig;
@@ -38,7 +42,10 @@ impl SentryWatcher {
     pub fn new(config: SentryWatcherConfig) -> Self {
         Self {
             config,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
             seen_issues: HashMap::new(),
             fetched_ids: None,
         }

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1301,7 +1301,20 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                             continue;
                         }
                         let watcher_name = throttled.watcher().name().to_string();
-                        match throttled.watcher_mut().poll(&slot.store).await {
+                        let poll_result = tokio::time::timeout(
+                            std::time::Duration::from_secs(30),
+                            throttled.watcher_mut().poll(&slot.store),
+                        )
+                        .await;
+                        let poll_result = match poll_result {
+                            Ok(inner) => inner,
+                            Err(_) => {
+                                error!("[{}] [{}] poll timed out after 30s", slot.name, watcher_name);
+                                throttled.mark_polled();
+                                continue;
+                            }
+                        };
+                        match poll_result {
                             Ok(updates) => {
                                 if !updates.is_empty() {
                                     info!("[{}] [{}] polled {} update(s)", slot.name, watcher_name, updates.len());
@@ -1402,6 +1415,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                             }
                             Err(e) => {
                                 error!("[{}] [{}] poll failed: {e}", slot.name, watcher_name);
+                                let _ = slot.store.set_cursor(&watcher_name, &format!("error: {e}"));
                                 // Still mark polled on error to avoid hammering a failing source
                                 throttled.mark_polled();
                             }

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1310,6 +1310,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                             Ok(inner) => inner,
                             Err(_) => {
                                 error!("[{}] [{}] poll timed out after 30s", slot.name, watcher_name);
+                                let _ = slot.store.set_cursor(&watcher_name, "error: poll timed out");
                                 throttled.mark_polled();
                                 continue;
                             }
@@ -1415,7 +1416,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                             }
                             Err(e) => {
                                 error!("[{}] [{}] poll failed: {e}", slot.name, watcher_name);
-                                let _ = slot.store.set_cursor(&watcher_name, &format!("error: {e}"));
+                                let _ = slot.store.set_cursor(&watcher_name, "error: poll failed");
                                 // Still mark polled on error to avoid hammering a failing source
                                 throttled.mark_polled();
                             }


### PR DESCRIPTION
## Summary
- Wraps each watcher `.poll()` call with `tokio::time::timeout(30s)` in the daemon poll loop, so a hanging watcher cannot block subsequent watchers
- Adds 30s HTTP request timeout to `LinearWatcher`, `SentryWatcher`, and `ReviewQueueWatcher` reqwest clients (matching the existing `NotionWatcher` pattern)
- Writes error cursor (`set_cursor`) on poll failure so the TUI shows an error state instead of a stale/missing heartbeat

## Test plan
- [x] `cargo fmt -p apiari` passes
- [x] `cargo test -p apiari` passes (472 tests)
- [ ] Manual: configure a bad Linear API key → verify other watchers still poll on schedule
- [ ] Manual: verify TUI shows error state for failing watcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)