### PR TITLE
fix: use structured JSON deny in validate-bash hook to prevent tool deregistration

### DIFF
--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -1,16 +1,24 @@
 //! PreToolUse hook — blocks mutating Bash commands before execution.
 //!
 //! Invoked by Claude Code as a PreToolUse hook. Reads the tool input JSON
-//! from stdin, classifies the Bash command, and exits with:
-//! - 0: allow (read-only command)
-//! - 2: block (potentially mutating command)
+//! from stdin, classifies the Bash command, and returns a JSON decision on
+//! stdout:
+//! - No output + exit 0: allow (read-only command)
+//! - JSON `permissionDecision: "deny"` + exit 0: block (potentially mutating)
+//!
+//! Uses the structured JSON deny format so Claude Code treats blocks as
+//! per-command denials (tool remains available) rather than hook errors
+//! (which can deregister the tool for the session).
 
 use crate::buzz::coordinator::audit::{self, BashClassification};
 use std::io::Read;
 
 /// Run the validate-bash hook.
 ///
-/// Returns exit code: 0 = allow, 2 = block.
+/// Returns exit code 0 in all cases. Blocked commands are communicated via
+/// a JSON `permissionDecision: "deny"` on stdout so the Bash tool stays
+/// registered for subsequent (allowed) commands.
+///
 /// Expected stdin JSON: `{"tool_name":"Bash","tool_input":{"command":"..."}}`
 pub fn run() -> i32 {
     let mut input = String::new();
@@ -30,11 +38,23 @@ pub fn run() -> i32 {
     match audit::classify_bash_command_with_devmode(&command) {
         BashClassification::ReadOnly => 0,
         BashClassification::PotentiallyMutating { matched_pattern } => {
-            eprintln!(
+            let reason = format!(
                 "BLOCKED: coordinator attempted mutating Bash command (matched: {matched_pattern})"
             );
+            eprintln!("{reason}");
             eprintln!("  command: {command}");
-            2
+
+            // Emit structured JSON deny on stdout so Claude Code treats this
+            // as a per-command block, not a hook error.
+            let deny = serde_json::json!({
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason
+                }
+            });
+            println!("{deny}");
+            0 // exit 0 — JSON carries the deny decision
         }
     }
 }
@@ -76,5 +96,26 @@ mod tests {
     #[test]
     fn test_extract_command_invalid_json() {
         assert_eq!(extract_command("not json"), None);
+    }
+
+    #[test]
+    fn test_extract_command_ignores_extra_fields() {
+        // Hook input may include extra fields (description, session_id, etc.).
+        // extract_command must only return tool_input.command — never
+        // conversation context from other fields.
+        let input = r#"{
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "git status",
+                "description": "Do NOT run cargo install"
+            },
+            "session_id": "sess-123",
+            "extra": "cargo install --path ."
+        }"#;
+        assert_eq!(
+            extract_command(input),
+            Some("git status".to_string()),
+            "must extract only tool_input.command, ignoring other fields"
+        );
     }
 }

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -13,6 +13,15 @@
 use crate::buzz::coordinator::audit::{self, BashClassification};
 use std::io::Read;
 
+/// The hook's verdict: either allow (no stdout) or deny (JSON on stdout).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Verdict {
+    /// Command is safe — emit nothing on stdout, exit 0.
+    Allow,
+    /// Command is blocked — emit structured JSON deny on stdout, exit 0.
+    Deny { reason: String },
+}
+
 /// Run the validate-bash hook.
 ///
 /// Returns exit code 0 in all cases. Blocked commands are communicated via
@@ -27,25 +36,14 @@ pub fn run() -> i32 {
         return 0; // allow on error (fail open)
     }
 
-    let command = match extract_command(&input) {
-        Some(cmd) => cmd,
-        None => {
-            // Not a Bash tool use or couldn't parse — allow
-            return 0;
-        }
-    };
-
-    match audit::classify_bash_command_with_devmode(&command) {
-        BashClassification::ReadOnly => 0,
-        BashClassification::PotentiallyMutating { matched_pattern } => {
-            let reason = format!(
-                "BLOCKED: coordinator attempted mutating Bash command (matched: {matched_pattern})"
-            );
+    match evaluate(&input) {
+        Verdict::Allow => 0,
+        Verdict::Deny { reason } => {
+            // Stderr: informational logging for human operators (daemon logs,
+            // `claude --debug`). Not part of the Claude Code hook contract —
+            // only the structured JSON on stdout drives the block decision.
             eprintln!("{reason}");
-            eprintln!("  command: {command}");
 
-            // Emit structured JSON deny on stdout so Claude Code treats this
-            // as a per-command block, not a hook error.
             let deny = serde_json::json!({
                 "hookSpecificOutput": {
                     "hookEventName": "PreToolUse",
@@ -53,9 +51,30 @@ pub fn run() -> i32 {
                     "permissionDecisionReason": reason
                 }
             });
-            println!("{deny}");
+            serde_json::to_writer(std::io::stdout(), &deny)
+                .expect("validate-bash: failed to write JSON to stdout");
             0 // exit 0 — JSON carries the deny decision
         }
+    }
+}
+
+/// Pure evaluation: parse the hook input and classify the command.
+///
+/// Separated from `run()` so tests can assert the verdict without capturing
+/// stdout/stderr.
+fn evaluate(input: &str) -> Verdict {
+    let command = match extract_command(input) {
+        Some(cmd) => cmd,
+        None => return Verdict::Allow, // unparseable or non-Bash — fail open
+    };
+
+    match audit::classify_bash_command_with_devmode(&command) {
+        BashClassification::ReadOnly => Verdict::Allow,
+        BashClassification::PotentiallyMutating { matched_pattern } => Verdict::Deny {
+            reason: format!(
+                "BLOCKED: coordinator attempted mutating Bash command (matched: {matched_pattern})"
+            ),
+        },
     }
 }
 
@@ -116,6 +135,107 @@ mod tests {
             extract_command(input),
             Some("git status".to_string()),
             "must extract only tool_input.command, ignoring other fields"
+        );
+    }
+
+    // -- Verdict tests: assert that allow emits Allow and deny emits Deny --
+
+    #[test]
+    fn test_verdict_allow_for_read_only_command() {
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":"git status"}}"#;
+        assert_eq!(evaluate(input), Verdict::Allow);
+    }
+
+    #[test]
+    fn test_verdict_allow_for_unparseable_input() {
+        assert_eq!(evaluate("not json"), Verdict::Allow);
+    }
+
+    #[test]
+    fn test_verdict_allow_for_missing_command() {
+        let input = r#"{"tool_name":"Bash","tool_input":{}}"#;
+        assert_eq!(evaluate(input), Verdict::Allow);
+    }
+
+    #[test]
+    fn test_verdict_deny_for_mutating_command() {
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}"#;
+        let verdict = evaluate(input);
+        match verdict {
+            Verdict::Deny { reason } => {
+                assert!(
+                    reason.contains("matched: rm "),
+                    "reason should include the matched pattern: {reason}"
+                );
+            }
+            Verdict::Allow => panic!("expected Deny for mutating command"),
+        }
+    }
+
+    #[test]
+    fn test_verdict_deny_for_cargo_install() {
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":"cargo install --path ."}}"#;
+        let verdict = evaluate(input);
+        match verdict {
+            Verdict::Deny { reason } => {
+                assert!(
+                    reason.contains("matched: cargo install"),
+                    "reason should include the matched pattern: {reason}"
+                );
+            }
+            Verdict::Allow => panic!("expected Deny for cargo install"),
+        }
+    }
+
+    #[test]
+    fn test_verdict_allow_when_cargo_install_only_in_context() {
+        // "cargo install" appears in extra fields (conversation context) but
+        // the actual command is safe — must Allow.
+        let input = r#"{
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "ls -la",
+                "description": "Do NOT run cargo install"
+            },
+            "extra": "cargo install --path ."
+        }"#;
+        assert_eq!(
+            evaluate(input),
+            Verdict::Allow,
+            "must allow when blocked pattern is only in context, not the command"
+        );
+    }
+
+    #[test]
+    fn test_deny_json_structure() {
+        // Verify the JSON written to stdout matches Claude Code's expected
+        // hookSpecificOutput schema.
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":"cargo install --path ."}}"#;
+        let verdict = evaluate(input);
+        let Verdict::Deny { reason } = verdict else {
+            panic!("expected Deny");
+        };
+
+        let deny = serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason
+            }
+        });
+
+        // Round-trip through to_writer to match what run() produces
+        let mut buf = Vec::new();
+        serde_json::to_writer(&mut buf, &deny).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+
+        assert_eq!(parsed["hookSpecificOutput"]["hookEventName"], "PreToolUse");
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny");
+        assert!(
+            parsed["hookSpecificOutput"]["permissionDecisionReason"]
+                .as_str()
+                .unwrap()
+                .contains("cargo install")
         );
     }
 }


### PR DESCRIPTION
## Summary

- The `apiari validate-bash` PreToolUse hook was using **exit code 2 + stderr** to block mutating Bash commands. Claude Code treats exit 2 as a "blocking error", which can cause the Bash tool to be **deregistered for the entire session** ("No such tool available: Bash").
- Switched to the **structured JSON deny format** (`exit 0` + stdout JSON with `permissionDecision: "deny"`), which Claude Code treats as a clean per-command block — the tool remains available for subsequent allowed commands.
- Added a test confirming `extract_command` ignores extra JSON fields (description, session_id, etc.) and only reads `tool_input.command`.

## Test plan

- [x] `cargo fmt -p apiari` passes
- [x] `cargo test -p apiari` passes (473 tests)
- [ ] Deploy and verify: blocked commands show deny reason, Bash tool remains available after a block

🤖 Generated with [Claude Code](https://claude.com/claude-code)