### PR TITLE
feat: add follow-through decision tracing and fix stale TUI heartbeat

### DIFF
--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1521,19 +1521,19 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     // Broadcast watcher poll heartbeat to TUI clients so remote
                     // clients can update their "last updated" display even without
                     // direct SQLite access.
-                    if let Some(ref server) = socket_server {
-                        if let Ok(cursors) = slot.store.get_watcher_cursors() {
-                            let cursor_summary: Vec<String> = cursors
-                                .iter()
-                                .map(|(name, ts)| format!("{name}={ts}"))
-                                .collect();
-                            server.broadcast_activity(
-                                "daemon",
-                                &slot.name,
-                                "watcher_poll_complete",
-                                &cursor_summary.join(","),
-                            );
-                        }
+                    if let Some(ref server) = socket_server
+                        && let Ok(cursors) = slot.store.get_watcher_cursors()
+                    {
+                        let cursor_summary: Vec<String> = cursors
+                            .iter()
+                            .map(|(name, ts)| format!("{name}={ts}"))
+                            .collect();
+                        server.broadcast_activity(
+                            "daemon",
+                            &slot.name,
+                            "watcher_poll_complete",
+                            &cursor_summary.join(","),
+                        );
                     }
 
                     // Coordinator follow-through for signal hook events (non-blocking)

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -569,19 +569,26 @@ async fn run_coordinator_task(
                 socket_server,
                 slot_name,
             } => {
+                let has_session = coordinator.has_session();
                 info!(
-                    "[{slot_name}] processing signal follow-through model={}",
+                    "[follow-through] hook matched: source={source} signal_count={} has_session={has_session} ttl_secs={ttl_secs} model={}",
+                    signals.len(),
                     coordinator.model()
                 );
                 let elapsed = queued_at.elapsed().as_secs();
                 if elapsed >= ttl_secs {
                     info!(
-                        "[{slot_name}] dropping stale signal follow-through ({source}, queued {elapsed}s ago)"
+                        "[follow-through] skipped (TTL expired): source={source} signal_count={} queued_ago_secs={elapsed} ttl_secs={ttl_secs}",
+                        signals.len()
                     );
                     continue;
                 }
 
-                if !coordinator.has_session() {
+                if !has_session {
+                    info!(
+                        "[follow-through] skipped (no active coordinator session): source={source} signal_count={}",
+                        signals.len()
+                    );
                     continue;
                 }
 
@@ -631,10 +638,13 @@ async fn run_coordinator_task(
                 // as a side-effect).
                 let saved_session_token = coordinator.session_token().cloned();
 
+                let action_snippet = action
+                    .as_deref()
+                    .map(|a| a.chars().take(80).collect::<String>())
+                    .unwrap_or_default();
                 info!(
-                    "[{slot_name}] signal follow-through START source={source} signals={} has_action={} disallowed_tools={:?}",
+                    "[follow-through] executing: source={source} signal_count={} action=\"{action_snippet}\" disallowed_tools={:?}",
                     signals.len(),
-                    action.is_some(),
                     opts.disallowed_tools
                 );
 
@@ -671,7 +681,8 @@ async fn run_coordinator_task(
                     Ok(response) => {
                         let response = response.trim().to_string();
                         info!(
-                            "[{slot_name}] signal follow-through DONE source={source} response_len={} empty={}",
+                            "[follow-through] completed: source={source} signal_count={} response_len={} empty={}",
+                            signals.len(),
                             response.len(),
                             response.is_empty()
                         );
@@ -709,7 +720,10 @@ async fn run_coordinator_task(
                         }
                     }
                     Err(e) => {
-                        warn!("[{slot_name}] coordinator follow-through failed: {e}");
+                        warn!(
+                            "[follow-through] error: source={source} signal_count={} err={e}",
+                            signals.len()
+                        );
                     }
                 }
 
@@ -1504,13 +1518,32 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     // Periodically evict old notification log entries
                     slot.pipeline.evict_old_log_entries();
 
+                    // Broadcast watcher poll heartbeat to TUI clients so remote
+                    // clients can update their "last updated" display even without
+                    // direct SQLite access.
+                    if let Some(ref server) = socket_server {
+                        if let Ok(cursors) = slot.store.get_watcher_cursors() {
+                            let cursor_summary: Vec<String> = cursors
+                                .iter()
+                                .map(|(name, ts)| format!("{name}={ts}"))
+                                .collect();
+                            server.broadcast_activity(
+                                "daemon",
+                                &slot.name,
+                                "watcher_poll_complete",
+                                &cursor_summary.join(","),
+                            );
+                        }
+                    }
+
                     // Coordinator follow-through for signal hook events (non-blocking)
                     for (source, (signals, hook)) in &hook_events {
                         info!(
-                            "[{}] dispatching signal follow-through source={source} events={} has_action={}",
+                            "[follow-through] dispatching: workspace={} source={source} signal_count={} has_action={} ttl_secs={}",
                             slot.name,
                             signals.len(),
-                            hook.action.is_some()
+                            hook.action.is_some(),
+                            hook.ttl_secs,
                         );
                     }
                     for (source, (signals, hook)) in hook_events {

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1904,6 +1904,36 @@ impl App {
                     ws.coordinator_preview = Some(truncate_preview(text, 120));
                     ws.has_unread_response = true;
                 }
+                "watcher_poll_complete" => {
+                    // Update feed heartbeat timestamps from daemon's watcher cursors.
+                    // Text format: "watcher1=2024-01-01T00:00:00Z,watcher2=..."
+                    let now_utc = Utc::now();
+                    for entry in text.split(',') {
+                        if let Some((watcher, ts_str)) = entry.split_once('=') {
+                            if !is_top_level_watcher(watcher) {
+                                continue;
+                            }
+                            let when = chrono::DateTime::parse_from_rfc3339(ts_str)
+                                .map(|dt| dt.with_timezone(&Utc))
+                                .unwrap_or(now_utc);
+                            // Update or insert the heartbeat feed item for this watcher
+                            let feed_text = format!("{watcher} checked");
+                            if let Some(existing) = ws.feed.iter_mut().find(|item| {
+                                matches!(&item.kind, FeedKind::Heartbeat) && item.text == feed_text
+                            }) {
+                                existing.when = when;
+                            } else {
+                                ws.feed.push(FeedItem {
+                                    when,
+                                    kind: FeedKind::Heartbeat,
+                                    text: feed_text,
+                                });
+                            }
+                        }
+                    }
+                    // Re-sort so newest items are first
+                    ws.feed.sort_by(|a, b| b.when.cmp(&a.when));
+                }
                 _ => {
                     ws.chat_history.push(ChatLine::System(text.to_string()));
                 }


### PR DESCRIPTION
## Summary
- Add structured `tracing::info!` logs at every decision point in the signal follow-through path (`[follow-through]` prefix): hook matched, skipped (no session), skipped (TTL expired), executing, completed, and error
- Broadcast `watcher_poll_complete` Activity events to TUI clients after each watcher poll cycle so remote TUI clients can update their "last updated" heartbeat display without direct SQLite access
- Handle the new `watcher_poll_complete` activity kind in the TUI to update feed heartbeat timestamps in real-time

## Test plan
- [ ] Verify daemon logs show `[follow-through]` entries when signal hooks match
- [ ] Verify "skipped (no active coordinator session)" appears when no session is active
- [ ] Verify "skipped (TTL expired)" appears when follow-through is stale
- [ ] Verify TUI heartbeat display stays fresh after daemon reconnect
- [ ] Run `cargo check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)