### PR TITLE
fix: fire signal follow-throughs with action even without active session

### DIFF
--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -584,12 +584,22 @@ async fn run_coordinator_task(
                     continue;
                 }
 
-                if !has_session {
+                let has_action = action
+                    .as_deref()
+                    .map(|a| !a.trim().is_empty())
+                    .unwrap_or(false);
+                if !has_action && !has_session {
                     info!(
-                        "[follow-through] skipped (no active coordinator session): source={source} signal_count={}",
+                        "[follow-through] skipped (no session, no action): source={source} signal_count={}",
                         signals.len()
                     );
                     continue;
+                }
+                if has_action && !has_session {
+                    info!(
+                        "[follow-through] firing without active session (action hook): source={source} signal_count={}",
+                        signals.len()
+                    );
                 }
 
                 let mut notification = if let Some(ref tpl) = prompt_override {


### PR DESCRIPTION
## Summary
- The `has_session()` guard in the signal follow-through loop was skipping ALL follow-throughs when no user was actively chatting with the coordinator
- Action-based hooks (e.g. `github_ci_failure`, `github_bot_review`) should always fire since the coordinator starts a fresh session to execute the action
- Now only notification-only hooks (no `action` field) are gated on `has_session()`
- Added tracing for both skip (no session + no action) and fire-without-session (action hook) cases

## Test plan
- [ ] Verify that hooks with an `action` field fire even when no Telegram/TUI session is active
- [ ] Verify that notification-only hooks (no `action`) are still skipped when no session is active
- [ ] Verify tracing output shows correct log lines for both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)