### PR TITLE
feat: skills redesign + authority/capabilities model

### DIFF
--- a/crates/apiari/src/buzz/coordinator/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/mod.rs
@@ -181,6 +181,15 @@ impl Coordinator {
 
     /// Build session options with current signal context.
     pub fn build_options(&self, store: &SignalStore) -> Result<SessionOptions> {
+        self.build_options_with_playbooks(store, None)
+    }
+
+    /// Build session options with current signal context and optional hook-triggered playbooks.
+    pub fn build_options_with_playbooks(
+        &self,
+        store: &SignalStore,
+        hook_playbooks: Option<&str>,
+    ) -> Result<SessionOptions> {
         let signals = store.get_open_signals()?;
 
         let system_prompt = prompt::build_system_prompt(
@@ -189,6 +198,7 @@ impl Coordinator {
             self.extra_context.as_deref(),
             Some(&self.name),
             self.prompt_preamble.as_deref(),
+            hook_playbooks,
         );
 
         let mut opts = SessionOptions {

--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -45,12 +45,16 @@ pub fn default_preamble(name: &str) -> String {
 }
 
 /// Build the system prompt with signal and memory context.
+///
+/// `hook_playbooks` contains full playbook content triggered by signal hooks
+/// for this specific session.
 pub fn build_system_prompt(
     signals: &[SignalRecord],
     memory: &[MemoryEntry],
     extra_context: Option<&str>,
     name: Option<&str>,
     prompt_preamble: Option<&str>,
+    hook_playbooks: Option<&str>,
 ) -> String {
     let name = name.unwrap_or("Bee");
     let mut prompt = String::new();
@@ -166,11 +170,21 @@ pub fn build_system_prompt(
         prompt.push('\n');
     }
 
-    // Extra context
+    // Extra context (skills prompt — includes tool skills, context skill, playbook index, authority)
     if let Some(ctx) = extra_context {
         prompt.push_str("## Additional Context\n");
         prompt.push_str(ctx);
         prompt.push('\n');
+    }
+
+    // Hook-triggered playbook content (injected per-session when signal hooks fire)
+    if let Some(playbooks) = hook_playbooks {
+        prompt.push_str("\n## Active Playbooks\n");
+        prompt.push_str("The following playbook instructions were activated for this session:\n\n");
+        prompt.push_str(playbooks);
+        if !playbooks.ends_with('\n') {
+            prompt.push('\n');
+        }
     }
 
     prompt
@@ -232,7 +246,7 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_empty() {
-        let prompt = build_system_prompt(&[], &[], None, None, None);
+        let prompt = build_system_prompt(&[], &[], None, None, None, None);
         assert!(prompt.contains("No open signals"));
         assert!(prompt.contains("Bee"));
     }
@@ -243,7 +257,7 @@ mod tests {
             make_signal("sentry", "Server down", Severity::Critical),
             make_signal("github", "PR #42 failed CI", Severity::Warning),
         ];
-        let prompt = build_system_prompt(&signals, &[], None, None, None);
+        let prompt = build_system_prompt(&signals, &[], None, None, None, None);
         assert!(prompt.contains("Server down"));
         assert!(prompt.contains("PR #42 failed CI"));
         assert!(prompt.contains("[critical]"));
@@ -260,7 +274,7 @@ mod tests {
             ),
             make_memory(MemoryCategory::Decision, "Switched to WAL mode for SQLite"),
         ];
-        let prompt = build_system_prompt(&[], &memory, None, None, None);
+        let prompt = build_system_prompt(&[], &memory, None, None, None, None);
         assert!(prompt.contains("Preferences:"));
         assert!(prompt.contains("User prefers concise responses"));
         assert!(prompt.contains("Observations:"));
@@ -269,7 +283,7 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_with_extra_context() {
-        let prompt = build_system_prompt(&[], &[], Some("Running on macOS"), None, None);
+        let prompt = build_system_prompt(&[], &[], Some("Running on macOS"), None, None, None);
         assert!(prompt.contains("Additional Context"));
         assert!(prompt.contains("Running on macOS"));
     }
@@ -315,7 +329,7 @@ mod tests {
 
     #[test]
     fn test_custom_preamble_replaces_default() {
-        let prompt = build_system_prompt(&[], &[], None, None, Some("Custom identity."));
+        let prompt = build_system_prompt(&[], &[], None, None, Some("Custom identity."), None);
         // Custom preamble replaces default
         assert!(prompt.contains("Custom identity."));
         assert!(!prompt.contains("ops coordinator"));
@@ -330,6 +344,7 @@ mod tests {
             &[],
             &[],
             Some("## Swarm Workers\nUse swarm to dispatch."),
+            None,
             None,
             None,
         );
@@ -377,7 +392,7 @@ mod tests {
         };
         let other = make_signal("sentry", "Server error spike", Severity::Warning);
 
-        let prompt = build_system_prompt(&[ci_pass, ci_fail, other], &[], None, None, None);
+        let prompt = build_system_prompt(&[ci_pass, ci_fail, other], &[], None, None, None, None);
 
         // CI signals appear in dedicated section with titles as-is (no redundant prefix)
         assert!(prompt.contains("## Recent CI Activity"));
@@ -392,7 +407,7 @@ mod tests {
     #[test]
     fn test_no_ci_section_when_no_ci_signals() {
         let signals = vec![make_signal("sentry", "Bug", Severity::Error)];
-        let prompt = build_system_prompt(&signals, &[], None, None, None);
+        let prompt = build_system_prompt(&signals, &[], None, None, None, None);
         assert!(!prompt.contains("## Recent CI Activity"));
         assert!(prompt.contains("## Current Signals"));
         assert!(prompt.contains("Bug"));
@@ -405,7 +420,7 @@ mod tests {
             body: Some(long_body),
             ..make_signal("sentry", "Bug", Severity::Error)
         };
-        let prompt = build_system_prompt(&[signal], &[], None, None, None);
+        let prompt = build_system_prompt(&[signal], &[], None, None, None, None);
         assert!(prompt.contains("..."));
     }
 }

--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -414,6 +414,21 @@ mod tests {
     }
 
     #[test]
+    fn test_hook_playbooks_included_when_present() {
+        let playbook_content = "### Playbook: ci-triage\n\nStep 1: Check logs.\nStep 2: Fix it.";
+        let prompt = build_system_prompt(&[], &[], None, None, None, Some(playbook_content));
+        assert!(prompt.contains("## Active Playbooks"));
+        assert!(prompt.contains("ci-triage"));
+        assert!(prompt.contains("Step 1: Check logs."));
+    }
+
+    #[test]
+    fn test_hook_playbooks_absent_when_none() {
+        let prompt = build_system_prompt(&[], &[], None, None, None, None);
+        assert!(!prompt.contains("## Active Playbooks"));
+    }
+
+    #[test]
     fn test_signal_body_truncation() {
         let long_body = "x".repeat(300);
         let signal = SignalRecord {

--- a/crates/apiari/src/buzz/coordinator/skills/apiari.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/apiari.rs
@@ -1,0 +1,61 @@
+//! Apiari system skill — teaches the coordinator about apiari's own config
+//! system: skills, authority levels, capabilities, and signal hook wiring.
+
+use super::SkillContext;
+use crate::config::WorkspaceAuthority;
+
+/// Build the apiari system prompt. Always included.
+pub fn build_prompt(ctx: &SkillContext) -> String {
+    let root = ctx.workspace_root.display();
+    let authority_str = match ctx.authority {
+        WorkspaceAuthority::Observe => "observe",
+        WorkspaceAuthority::Autonomous => "autonomous",
+    };
+
+    format!(
+        "## Apiari System\n\
+         You are running inside apiari. This section explains how the apiari config \
+         system works so you can help users set things up.\n\n\
+         ### Authority & Capabilities\n\
+         The workspace authority level is `{authority_str}`. Authority is set in the workspace config:\n\
+         ```toml\n\
+         authority = \"autonomous\"   # full toolset (default)\n\
+         # authority = \"observe\"    # read-only tools only, no Bash or swarm dispatch\n\
+         ```\n\n\
+         Fine-grained capabilities:\n\
+         ```toml\n\
+         [capabilities]\n\
+         dispatch_workers = true   # default true in autonomous, false in observe\n\
+         merge_prs = false         # default false — must explicitly opt in\n\
+         # merge_prs = [\"develop\", \"staging\"]   # scope to specific branches\n\
+         ```\n\n\
+         ### Project Context\n\
+         `{root}/.apiari/context.md` is automatically loaded into every coordinator session. \
+         Users should put high-level project info here: what the project is, the tech stack, \
+         team ownership, key conventions, and anything the coordinator should always know. \
+         If the file does not exist, no context is loaded.\n\n\
+         ### Playbooks\n\
+         Markdown files in `{root}/.apiari/skills/*.md` are indexed as playbooks. \
+         The coordinator sees an index of names + first-line descriptions, but full content \
+         is NOT loaded by default. Full playbook content is injected only when a signal hook \
+         fires with a matching `skills` field.\n\n\
+         To create a playbook, add a `.md` file under `.apiari/skills/`. The first line \
+         (stripped of `#`) becomes the description in the index.\n\n\
+         ### Signal Hook → Playbook Wiring\n\
+         Connect a playbook to a signal hook with the `skills` field:\n\
+         ```toml\n\
+         [[coordinator.signal_hooks]]\n\
+         source = \"github_ci_fail\"\n\
+         action = \"Triage the CI failure\"   # one-sentence intent ONLY\n\
+         skills = [\"ci-triage\"]              # loads .apiari/skills/ci-triage.md\n\
+         ```\n\n\
+         The `action` field should be a single sentence describing the intent — \
+         the detailed process belongs in the playbook, not the hook. This keeps hooks \
+         declarative and playbooks reusable.\n\n\
+         ### Scaffolding\n\
+         `apiari init` creates the workspace config and scaffolds:\n\
+         - `.apiari/context.md` — template for project context\n\
+         - `.apiari/skills/` — empty directory for playbooks\n\n\
+         Users can also create these manually.\n",
+    )
+}

--- a/crates/apiari/src/buzz/coordinator/skills/config.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/config.rs
@@ -291,6 +291,8 @@ mod tests {
             has_telegram: true,
             prompt_preamble: None,
             default_agent: "claude".to_string(),
+            authority: crate::config::WorkspaceAuthority::Autonomous,
+            capabilities: crate::config::WorkspaceCapabilities::default(),
         }
     }
 
@@ -315,6 +317,8 @@ mod tests {
             script_names: vec![],
             prompt_preamble: None,
             default_agent: "claude".to_string(),
+            authority: crate::config::WorkspaceAuthority::Autonomous,
+            capabilities: crate::config::WorkspaceCapabilities::default(),
         }
     }
 

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -10,6 +10,7 @@
 //! - **Context** — what this workspace/project is (auto-loaded from `.apiari/context.md`)
 //! - **Playbook** — how to handle a situation (indexed from `.apiari/skills/*.md`)
 
+mod apiari;
 pub mod config;
 mod email;
 mod github;
@@ -171,8 +172,9 @@ pub fn build_skills_prompt(ctx: &SkillContext) -> String {
         );
     }
 
-    // Tool skills (auto-detected from watcher config)
+    // Tool skills (auto-detected from watcher config) + always-on apiari system skill
     let mut tool_sections = vec![
+        apiari::build_prompt(ctx),
         config::build_prompt(ctx),
         signals::build_prompt(ctx),
         memory::build_prompt(ctx),
@@ -325,6 +327,7 @@ mod tests {
         let prompt = build_skills_prompt(&test_ctx());
         assert!(prompt.contains("## Workspace"));
         assert!(prompt.contains("myproject"));
+        assert!(prompt.contains("## Apiari System"));
         assert!(prompt.contains("## Current Workspace Config"));
         assert!(prompt.contains("## Integration Setup Guides"));
         assert!(prompt.contains("## Signal Store"));
@@ -356,6 +359,22 @@ mod tests {
         ctx.repos.clear();
         let prompt = build_skills_prompt(&ctx);
         assert!(!prompt.contains("## GitHub"));
+    }
+
+    #[test]
+    fn test_apiari_skill_always_present() {
+        // Even with a minimal context (no watchers), the apiari system skill is included
+        let mut ctx = test_ctx();
+        ctx.has_sentry = false;
+        ctx.has_swarm = false;
+        ctx.repos.clear();
+        let prompt = build_skills_prompt(&ctx);
+        assert!(prompt.contains("## Apiari System"));
+        assert!(prompt.contains("authority"));
+        assert!(prompt.contains(".apiari/context.md"));
+        assert!(prompt.contains(".apiari/skills/"));
+        assert!(prompt.contains("skills = ["));
+        assert!(prompt.contains("apiari init"));
     }
 
     #[test]

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -21,9 +21,19 @@ mod sentry;
 mod signals;
 mod swarm;
 
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
 
 use crate::config::{WorkspaceAuthority, WorkspaceCapabilities};
+
+/// Check if a playbook name is safe (no path traversal).
+/// Only allows alphanumeric, hyphens, and underscores.
+fn is_valid_playbook_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
 
 /// Context derived from workspace config, used to build skill prompts.
 pub struct SkillContext {
@@ -83,22 +93,30 @@ pub fn index_playbooks(workspace_root: &Path) -> Vec<PlaybookEntry> {
     let mut playbooks = Vec::new();
     for entry in entries.filter_map(|e| e.ok()) {
         let path = entry.path();
+        // Skip symlinks to avoid following links outside the skills directory
+        if std::fs::symlink_metadata(&path)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(true)
+        {
+            continue;
+        }
         if path.extension().is_some_and(|ext| ext == "md") {
             let name = path
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or("")
                 .to_string();
-            if name.is_empty() {
+            if !is_valid_playbook_name(&name) {
                 continue;
             }
-            let description = std::fs::read_to_string(&path)
+            // Read only the first line using BufReader instead of the full file
+            let description = std::fs::File::open(&path)
                 .ok()
-                .and_then(|content| {
-                    content
-                        .lines()
-                        .next()
-                        .map(|line| line.trim_start_matches('#').trim().to_string())
+                .and_then(|file| {
+                    let mut reader = std::io::BufReader::new(file);
+                    let mut first_line = String::new();
+                    reader.read_line(&mut first_line).ok()?;
+                    Some(first_line.trim_start_matches('#').trim().to_string())
                 })
                 .unwrap_or_default();
             playbooks.push(PlaybookEntry { name, description });
@@ -109,7 +127,13 @@ pub fn index_playbooks(workspace_root: &Path) -> Vec<PlaybookEntry> {
 }
 
 /// Load the full content of a named playbook.
+///
+/// Returns `None` if the name contains invalid characters (path traversal prevention)
+/// or if the file doesn't exist.
 pub fn load_playbook(workspace_root: &Path, name: &str) -> Option<String> {
+    if !is_valid_playbook_name(name) {
+        return None;
+    }
     let path = workspace_root.join(format!(".apiari/skills/{name}.md"));
     std::fs::read_to_string(&path).ok()
 }
@@ -439,5 +463,110 @@ mod tests {
         assert!(tools.contains(&"NotebookEdit".to_string()));
         assert!(tools.contains(&"Task".to_string()));
         assert!(!tools.contains(&"Bash".to_string()));
+    }
+
+    #[test]
+    fn test_load_context_skill_returns_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let apiari_dir = dir.path().join(".apiari");
+        std::fs::create_dir_all(&apiari_dir).unwrap();
+        std::fs::write(
+            apiari_dir.join("context.md"),
+            "# My Project\nA cool project.",
+        )
+        .unwrap();
+        let content = load_context_skill(dir.path());
+        assert!(content.is_some());
+        assert!(content.unwrap().contains("My Project"));
+    }
+
+    #[test]
+    fn test_load_context_skill_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_context_skill(dir.path()).is_none());
+    }
+
+    #[test]
+    fn test_index_playbooks_reads_first_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills_dir = dir.path().join(".apiari/skills");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        std::fs::write(skills_dir.join("ci-triage.md"), "# CI Triage\nStep 1...").unwrap();
+        std::fs::write(skills_dir.join("deploy.md"), "Deploy checklist\nStep 1...").unwrap();
+
+        let playbooks = index_playbooks(dir.path());
+        assert_eq!(playbooks.len(), 2);
+        assert_eq!(playbooks[0].name, "ci-triage");
+        assert_eq!(playbooks[0].description, "CI Triage");
+        assert_eq!(playbooks[1].name, "deploy");
+        assert_eq!(playbooks[1].description, "Deploy checklist");
+    }
+
+    #[test]
+    fn test_index_playbooks_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let playbooks = index_playbooks(dir.path());
+        assert!(playbooks.is_empty());
+    }
+
+    #[test]
+    fn test_index_playbooks_skips_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills_dir = dir.path().join(".apiari/skills");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        std::fs::write(skills_dir.join("real.md"), "# Real playbook").unwrap();
+        // Create a symlink — should be skipped
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(skills_dir.join("real.md"), skills_dir.join("linked.md"))
+                .unwrap();
+        }
+        let playbooks = index_playbooks(dir.path());
+        // Only the real file should be indexed
+        assert_eq!(playbooks.len(), 1);
+        assert_eq!(playbooks[0].name, "real");
+    }
+
+    #[test]
+    fn test_load_playbook_returns_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills_dir = dir.path().join(".apiari/skills");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        std::fs::write(skills_dir.join("ci-triage.md"), "# CI Triage\nDo stuff.").unwrap();
+
+        let content = load_playbook(dir.path(), "ci-triage");
+        assert!(content.is_some());
+        assert!(content.unwrap().contains("CI Triage"));
+    }
+
+    #[test]
+    fn test_load_playbook_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_playbook(dir.path(), "nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_load_playbook_rejects_path_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let apiari_dir = dir.path().join(".apiari");
+        std::fs::create_dir_all(&apiari_dir).unwrap();
+        std::fs::write(apiari_dir.join("context.md"), "secret").unwrap();
+
+        // Attempting to traverse up should be rejected
+        assert!(load_playbook(dir.path(), "../context").is_none());
+        assert!(load_playbook(dir.path(), "foo/bar").is_none());
+        assert!(load_playbook(dir.path(), "").is_none());
+    }
+
+    #[test]
+    fn test_is_valid_playbook_name() {
+        assert!(is_valid_playbook_name("ci-triage"));
+        assert!(is_valid_playbook_name("deploy_prod"));
+        assert!(is_valid_playbook_name("step1"));
+        assert!(!is_valid_playbook_name("../context"));
+        assert!(!is_valid_playbook_name("foo/bar"));
+        assert!(!is_valid_playbook_name(""));
+        assert!(!is_valid_playbook_name("has spaces"));
+        assert!(!is_valid_playbook_name("has.dot"));
     }
 }

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -3,6 +3,12 @@
 //! Skills teach the coordinator what CLI tools and APIs are available
 //! based on the workspace configuration. Each skill contributes a block
 //! of prompt text; `build_skills_prompt()` aggregates them all.
+//!
+//! ## Skill Kinds
+//!
+//! - **Tool** — operational knowledge for external tools/CLIs (auto-detected from watcher config)
+//! - **Context** — what this workspace/project is (auto-loaded from `.apiari/context.md`)
+//! - **Playbook** — how to handle a situation (indexed from `.apiari/skills/*.md`)
 
 pub mod config;
 mod email;
@@ -15,7 +21,9 @@ mod sentry;
 mod signals;
 mod swarm;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use crate::config::{WorkspaceAuthority, WorkspaceCapabilities};
 
 /// Context derived from workspace config, used to build skill prompts.
 pub struct SkillContext {
@@ -41,40 +49,80 @@ pub struct SkillContext {
     pub prompt_preamble: Option<String>,
     /// Default swarm agent: "claude", "codex", "gemini", or "auto".
     pub default_agent: String,
+    /// Workspace authority level.
+    pub authority: WorkspaceAuthority,
+    /// Resolved capabilities (already adjusted for authority level).
+    pub capabilities: WorkspaceCapabilities,
+}
+
+/// A playbook entry indexed from `.apiari/skills/*.md`.
+#[derive(Debug, Clone)]
+pub struct PlaybookEntry {
+    /// Filename stem (e.g. "ci-triage" from "ci-triage.md").
+    pub name: String,
+    /// First line of the file, stripped of leading `#` and whitespace.
+    pub description: String,
+}
+
+/// Load the context skill from `.apiari/context.md` if it exists.
+pub fn load_context_skill(workspace_root: &Path) -> Option<String> {
+    let path = workspace_root.join(".apiari/context.md");
+    std::fs::read_to_string(&path).ok()
+}
+
+/// Index playbooks from `.apiari/skills/*.md`.
+///
+/// Returns a list of (name, first-line description) entries.
+pub fn index_playbooks(workspace_root: &Path) -> Vec<PlaybookEntry> {
+    let dir = workspace_root.join(".apiari/skills");
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut playbooks = Vec::new();
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "md") {
+            let name = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+            if name.is_empty() {
+                continue;
+            }
+            let description = std::fs::read_to_string(&path)
+                .ok()
+                .and_then(|content| {
+                    content
+                        .lines()
+                        .next()
+                        .map(|line| line.trim_start_matches('#').trim().to_string())
+                })
+                .unwrap_or_default();
+            playbooks.push(PlaybookEntry { name, description });
+        }
+    }
+    playbooks.sort_by(|a, b| a.name.cmp(&b.name));
+    playbooks
+}
+
+/// Load the full content of a named playbook.
+pub fn load_playbook(workspace_root: &Path, name: &str) -> Option<String> {
+    let path = workspace_root.join(format!(".apiari/skills/{name}.md"));
+    std::fs::read_to_string(&path).ok()
 }
 
 /// Build the combined skills prompt from workspace context.
 ///
-/// Each skill checks whether it's applicable (e.g. Sentry skill only
-/// included when `has_sentry` is true) and contributes instructions.
+/// Prompt is assembled in this order:
+/// 1. Workspace info + repos
+/// 2. Tool skills (auto from watcher config)
+/// 3. Context skill (from `.apiari/context.md`)
+/// 4. Playbook index (names + descriptions from `.apiari/skills/*.md`)
+/// 5. Authority level statement
 pub fn build_skills_prompt(ctx: &SkillContext) -> String {
-    // Always-on skills
-    let mut sections = vec![
-        config::build_prompt(ctx),
-        signals::build_prompt(ctx),
-        memory::build_prompt(ctx),
-        scripts::build_prompt(ctx),
-    ];
-
-    // Conditional skills
-    if let Some(s) = github::build_prompt(ctx) {
-        sections.push(s);
-    }
-    if let Some(s) = sentry::build_prompt(ctx) {
-        sections.push(s);
-    }
-    if let Some(s) = swarm::build_prompt(ctx) {
-        sections.push(s);
-    }
-    if let Some(s) = linear::build_prompt(ctx) {
-        sections.push(s);
-    }
-    if let Some(s) = email::build_prompt(ctx) {
-        sections.push(s);
-    }
-    if let Some(s) = notion::build_prompt(ctx) {
-        sections.push(s);
-    }
     let mut prompt = format!(
         "## Workspace\n\
          Name: {}\n\
@@ -99,9 +147,85 @@ pub fn build_skills_prompt(ctx: &SkillContext) -> String {
         );
     }
 
-    prompt.push_str("\n# Skills\nYou have the following tools and capabilities:\n\n");
+    // Tool skills (auto-detected from watcher config)
+    let mut tool_sections = vec![
+        config::build_prompt(ctx),
+        signals::build_prompt(ctx),
+        memory::build_prompt(ctx),
+        scripts::build_prompt(ctx),
+    ];
 
-    prompt.push_str(&sections.join("\n"));
+    if let Some(s) = github::build_prompt(ctx) {
+        tool_sections.push(s);
+    }
+    if let Some(s) = sentry::build_prompt(ctx) {
+        tool_sections.push(s);
+    }
+    if let Some(s) = swarm::build_prompt(ctx) {
+        tool_sections.push(s);
+    }
+    if let Some(s) = linear::build_prompt(ctx) {
+        tool_sections.push(s);
+    }
+    if let Some(s) = email::build_prompt(ctx) {
+        tool_sections.push(s);
+    }
+    if let Some(s) = notion::build_prompt(ctx) {
+        tool_sections.push(s);
+    }
+
+    prompt.push_str("\n# Skills\nYou have the following tools and capabilities:\n\n");
+    prompt.push_str(&tool_sections.join("\n"));
+
+    // Context skill (from .apiari/context.md)
+    if let Some(context) = load_context_skill(&ctx.workspace_root) {
+        prompt.push_str("\n## Project Context\n");
+        prompt.push_str(&context);
+        if !context.ends_with('\n') {
+            prompt.push('\n');
+        }
+    }
+
+    // Playbook index
+    let playbooks = index_playbooks(&ctx.workspace_root);
+    if !playbooks.is_empty() {
+        prompt.push_str("\n## Available Playbooks\n");
+        prompt.push_str(
+            "The following playbooks are available and will be loaded when relevant signal hooks fire:\n",
+        );
+        for pb in &playbooks {
+            if pb.description.is_empty() {
+                prompt.push_str(&format!("- {}\n", pb.name));
+            } else {
+                prompt.push_str(&format!("- {} — {}\n", pb.name, pb.description));
+            }
+        }
+    }
+
+    // Authority level statement
+    match ctx.authority {
+        WorkspaceAuthority::Observe => {
+            prompt.push_str(
+                "\n## Authority Level: Observe\n\
+                 You are in observe mode. You have read-only access to the workspace.\n\
+                 You CANNOT execute Bash commands, dispatch swarm workers, or make any changes.\n\
+                 Your tools are limited to: Read, Glob, Grep, WebSearch, WebFetch.\n",
+            );
+        }
+        WorkspaceAuthority::Autonomous => {
+            prompt.push_str(
+                "\n## Authority Level: Autonomous\n\
+                 You have full operational access to this workspace.\n",
+            );
+            if !ctx.capabilities.merge_prs.is_allowed(None) {
+                prompt.push_str(
+                    "Note: PR merging is disabled. Do NOT merge PRs — this capability must be \
+                     explicitly enabled in the workspace config (`[workspace.capabilities] merge_prs = true`).\n",
+                );
+            }
+        }
+    }
+
     prompt
 }
 
@@ -120,6 +244,22 @@ pub fn default_coordinator_tools() -> Vec<String> {
 /// Even if the model tries to use these, Claude CLI will refuse.
 pub fn default_coordinator_disallowed_tools() -> Vec<String> {
     ["Write", "Edit", "NotebookEdit", "Task"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Tools for observe mode — read-only only. No Bash.
+pub fn observe_coordinator_tools() -> Vec<String> {
+    ["Read", "Glob", "Grep", "WebSearch", "WebFetch"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Disallowed tools for observe mode — everything mutating.
+pub fn observe_coordinator_disallowed_tools() -> Vec<String> {
+    ["Write", "Edit", "NotebookEdit", "Task", "Bash"]
         .iter()
         .map(|s| s.to_string())
         .collect()
@@ -151,6 +291,8 @@ mod tests {
             has_telegram: false,
             prompt_preamble: None,
             default_agent: "claude".to_string(),
+            authority: WorkspaceAuthority::Autonomous,
+            capabilities: WorkspaceCapabilities::default(),
         }
     }
 

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -40,19 +40,14 @@ pub fn socket_path() -> PathBuf {
 }
 
 /// Workspace authority level — controls what the coordinator is allowed to do.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WorkspaceAuthority {
     /// Read-only tools only (Read, Glob, Grep, WebSearch, WebFetch). No Bash, no swarm dispatch.
     Observe,
     /// Full toolset (current behavior). This is the default.
+    #[default]
     Autonomous,
-}
-
-impl Default for WorkspaceAuthority {
-    fn default() -> Self {
-        Self::Autonomous
-    }
 }
 
 /// Workspace capabilities — fine-grained permission controls.

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -39,6 +39,93 @@ pub fn socket_path() -> PathBuf {
     config_dir().join("daemon.sock")
 }
 
+/// Workspace authority level — controls what the coordinator is allowed to do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkspaceAuthority {
+    /// Read-only tools only (Read, Glob, Grep, WebSearch, WebFetch). No Bash, no swarm dispatch.
+    Observe,
+    /// Full toolset (current behavior). This is the default.
+    Autonomous,
+}
+
+impl Default for WorkspaceAuthority {
+    fn default() -> Self {
+        Self::Autonomous
+    }
+}
+
+/// Workspace capabilities — fine-grained permission controls.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceCapabilities {
+    /// Whether the coordinator can dispatch swarm workers.
+    /// Default: true in autonomous, false in observe.
+    #[serde(default = "default_true")]
+    pub dispatch_workers: bool,
+
+    /// Whether the coordinator can merge PRs.
+    /// Default: false — must explicitly opt in.
+    /// Can be `true` (all branches) or a list of branch names.
+    #[serde(default)]
+    pub merge_prs: MergePrsCapability,
+}
+
+impl Default for WorkspaceCapabilities {
+    fn default() -> Self {
+        Self {
+            dispatch_workers: true,
+            merge_prs: MergePrsCapability::default(),
+        }
+    }
+}
+
+impl WorkspaceCapabilities {
+    /// Resolve capabilities for a given authority level.
+    /// In observe mode, dispatch_workers is always false.
+    pub fn resolved(&self, authority: WorkspaceAuthority) -> Self {
+        match authority {
+            WorkspaceAuthority::Observe => Self {
+                dispatch_workers: false,
+                merge_prs: MergePrsCapability::Bool(false),
+            },
+            WorkspaceAuthority::Autonomous => self.clone(),
+        }
+    }
+}
+
+/// Whether and how merge_prs is enabled.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum MergePrsCapability {
+    /// Simple boolean: true = all branches, false = disabled.
+    Bool(bool),
+    /// Scoped to specific target branches.
+    Branches(Vec<String>),
+}
+
+impl Default for MergePrsCapability {
+    fn default() -> Self {
+        Self::Bool(false)
+    }
+}
+
+impl MergePrsCapability {
+    /// Check if merging is allowed, optionally for a specific target branch.
+    pub fn is_allowed(&self, target_branch: Option<&str>) -> bool {
+        match self {
+            Self::Bool(b) => *b,
+            Self::Branches(branches) => {
+                if let Some(branch) = target_branch {
+                    branches.iter().any(|b| b == branch)
+                } else {
+                    // No specific branch requested — allowed if any branches are configured
+                    !branches.is_empty()
+                }
+            }
+        }
+    }
+}
+
 /// A fully self-contained workspace configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
@@ -48,6 +135,14 @@ pub struct WorkspaceConfig {
     /// Repository slugs (e.g. ["ApiariTools/swarm", "ApiariTools/apiari"]).
     #[serde(default)]
     pub repos: Vec<String>,
+
+    /// Workspace authority level (observe or autonomous). Default: autonomous.
+    #[serde(default)]
+    pub authority: WorkspaceAuthority,
+
+    /// Fine-grained capability controls.
+    #[serde(default)]
+    pub capabilities: WorkspaceCapabilities,
 
     /// Telegram configuration.
     #[serde(default)]
@@ -223,6 +318,10 @@ pub struct SignalHookConfig {
     /// Max seconds to wait in queue before dropping. Default: 120.
     #[serde(default = "default_hook_ttl")]
     pub ttl_secs: u64,
+    /// Playbook skills to load for this hook's coordinator session.
+    /// Names reference files in `.apiari/skills/{name}.md`.
+    #[serde(default)]
+    pub skills: Vec<String>,
 }
 
 fn default_hook_ttl() -> u64 {
@@ -236,18 +335,21 @@ fn default_signal_hooks() -> Vec<SignalHookConfig> {
             prompt: "Swarm activity: {events}".into(),
             action: Some("Assess the situation. If a worker opened a PR, check if Copilot has reviewed it and if so forward any comments to the worker. If a worker is stuck or failed, investigate and either send a fix or dispatch a new worker.".into()),
             ttl_secs: 300,
+            skills: vec![],
         },
         SignalHookConfig {
             source: "github_bot_review".into(),
             prompt: "Bot review received: {events}".into(),
             action: Some("Find the swarm worker whose branch matches this PR and forward the review comments directly to it so it can address them.".into()),
             ttl_secs: 300,
+            skills: vec![],
         },
         SignalHookConfig {
             source: "github".into(),
             prompt: "CI failed: {events}".into(),
             action: Some("Find the relevant swarm worker for this PR. If a worker exists, send it the CI error details so it can fix them. If no worker exists, dispatch a new one to fix the failure.".into()),
             ttl_secs: 300,
+            skills: vec![],
         },
     ]
 }
@@ -647,6 +749,7 @@ pub fn build_skill_context(
         .iter()
         .map(|s| s.name.clone())
         .collect();
+    let resolved_caps = config.capabilities.resolved(config.authority);
     crate::buzz::coordinator::skills::SkillContext {
         workspace_name: workspace_name.to_string(),
         workspace_root: config.root.clone(),
@@ -667,6 +770,8 @@ pub fn build_skill_context(
         has_telegram: config.telegram.is_some(),
         prompt_preamble: config.coordinator.prompt.clone(),
         default_agent: config.swarm.default_agent.clone(),
+        authority: config.authority,
+        capabilities: resolved_caps,
     }
 }
 
@@ -1075,6 +1180,8 @@ max_session_turns = 0
         let config = WorkspaceConfig {
             root: "/tmp/nonexistent".into(),
             repos: vec!["Org/Repo".to_string()],
+            authority: WorkspaceAuthority::default(),
+            capabilities: WorkspaceCapabilities::default(),
             telegram: None,
             coordinator: CoordinatorConfig::default(),
             watchers: WatchersConfig::default(),
@@ -1098,6 +1205,8 @@ max_session_turns = 0
         let config = WorkspaceConfig {
             root: "/tmp/nonexistent-dir-12345".into(),
             repos: vec![],
+            authority: WorkspaceAuthority::default(),
+            capabilities: WorkspaceCapabilities::default(),
             telegram: None,
             coordinator: CoordinatorConfig::default(),
             watchers: WatchersConfig::default(),
@@ -1120,6 +1229,8 @@ max_session_turns = 0
         let ws = WorkspaceConfig {
             root: "/tmp".into(),
             repos: vec![],
+            authority: WorkspaceAuthority::default(),
+            capabilities: WorkspaceCapabilities::default(),
             telegram: Some(TelegramConfig {
                 bot_token: "tok".into(),
                 chat_id: 123,
@@ -1370,6 +1481,8 @@ max_session_turns = 0
         WorkspaceConfig {
             root: "/nonexistent".into(),
             repos: ws_repos,
+            authority: WorkspaceAuthority::default(),
+            capabilities: WorkspaceCapabilities::default(),
             telegram: None,
             coordinator: CoordinatorConfig::default(),
             watchers: WatchersConfig {

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -21,7 +21,7 @@ use crate::buzz::conversation::ConversationStore;
 use crate::buzz::coordinator::prompt::format_signal_summary;
 use crate::buzz::coordinator::skills::{
     SkillContext, build_skills_prompt, default_coordinator_disallowed_tools,
-    default_coordinator_tools,
+    default_coordinator_tools, observe_coordinator_disallowed_tools, observe_coordinator_tools,
 };
 use crate::buzz::coordinator::{Coordinator, CoordinatorEvent};
 use crate::buzz::daemon::config as buzz_daemon_config;
@@ -128,6 +128,10 @@ enum CoordinatorJob {
         telegram: Option<(TelegramChannel, i64, Option<i64>)>,
         socket_server: Option<Arc<socket::DaemonSocketServer>>,
         slot_name: String,
+        /// Playbook skill names to load for this session.
+        skill_names: Vec<String>,
+        /// Workspace root for loading playbook files.
+        workspace_root: std::path::PathBuf,
     },
 }
 
@@ -568,6 +572,8 @@ async fn run_coordinator_task(
                 telegram,
                 socket_server,
                 slot_name,
+                skill_names,
+                workspace_root,
             } => {
                 let has_session = coordinator.has_session();
                 info!(
@@ -613,10 +619,37 @@ async fn run_coordinator_task(
                     notification.push_str("\n\n[Action] ");
                     notification.push_str(action_str);
                 }
+                // Load hook-triggered playbooks
+                let playbook_content = if !skill_names.is_empty() {
+                    let mut content = String::new();
+                    for name in &skill_names {
+                        if let Some(pb) =
+                            crate::buzz::coordinator::skills::load_playbook(&workspace_root, name)
+                        {
+                            if !content.is_empty() {
+                                content.push_str("\n---\n\n");
+                            }
+                            content.push_str(&format!("### Playbook: {name}\n\n"));
+                            content.push_str(&pb);
+                        } else {
+                            warn!("[{slot_name}] playbook not found: {name}");
+                        }
+                    }
+                    if content.is_empty() {
+                        None
+                    } else {
+                        Some(content)
+                    }
+                } else {
+                    None
+                };
+
                 let saved_turns = coordinator.max_turns();
                 coordinator.set_max_turns(3);
 
-                let mut opts = match coordinator.build_options(&store) {
+                let mut opts = match coordinator
+                    .build_options_with_playbooks(&store, playbook_content.as_deref())
+                {
                     Ok(opts) => opts,
                     Err(e) => {
                         warn!("[{slot_name}] failed to build coordinator options: {e}");
@@ -1577,6 +1610,8 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                             telegram: telegram_info,
                             socket_server: socket_server.clone(),
                             slot_name: slot.name.clone(),
+                            skill_names: hook.skills.clone(),
+                            workspace_root: slot.config.root.clone(),
                         });
                     }
 
@@ -2020,10 +2055,10 @@ pub async fn run_chat(workspace_name: &str, message: Option<String>) -> Result<(
     if let Some(ref preamble) = skill_ctx.prompt_preamble {
         coordinator.set_prompt_preamble(preamble.clone());
     }
-    let allowed = default_coordinator_tools();
-    let disallowed = default_coordinator_disallowed_tools();
+    let (allowed, disallowed) = tools_for_authority(ws.config.authority);
     info!(
-        "[{workspace_name}] coordinator allowed_tools: {allowed:?}, disallowed_tools: {disallowed:?}"
+        "[{workspace_name}] coordinator authority={:?} allowed_tools: {allowed:?}, disallowed_tools: {disallowed:?}",
+        ws.config.authority
     );
     coordinator.set_tools(allowed);
     coordinator.set_disallowed_tools(disallowed);
@@ -2237,9 +2272,11 @@ fn build_coordinator(ws_name: &str, config: &WorkspaceConfig) -> Coordinator {
     if let Some(ref preamble) = skill_ctx.prompt_preamble {
         coordinator.set_prompt_preamble(preamble.clone());
     }
-    let allowed = default_coordinator_tools();
-    let disallowed = default_coordinator_disallowed_tools();
-    info!("[{ws_name}] coordinator allowed_tools: {allowed:?}, disallowed_tools: {disallowed:?}");
+    let (allowed, disallowed) = tools_for_authority(config.authority);
+    info!(
+        "[{ws_name}] coordinator authority={:?} allowed_tools: {allowed:?}, disallowed_tools: {disallowed:?}",
+        config.authority
+    );
     coordinator.set_tools(allowed);
     coordinator.set_disallowed_tools(disallowed);
     coordinator.set_working_dir(config.root.clone());
@@ -2250,6 +2287,20 @@ fn build_coordinator(ws_name: &str, config: &WorkspaceConfig) -> Coordinator {
         workspace_root: config.root.clone(),
     }));
     coordinator
+}
+
+/// Return (allowed, disallowed) tool lists based on authority level.
+fn tools_for_authority(authority: crate::config::WorkspaceAuthority) -> (Vec<String>, Vec<String>) {
+    match authority {
+        crate::config::WorkspaceAuthority::Observe => (
+            observe_coordinator_tools(),
+            observe_coordinator_disallowed_tools(),
+        ),
+        crate::config::WorkspaceAuthority::Autonomous => (
+            default_coordinator_tools(),
+            default_coordinator_disallowed_tools(),
+        ),
+    }
 }
 
 /// Try to restore the last coordinator session from the database.

--- a/crates/apiari/src/init.rs
+++ b/crates/apiari/src/init.rs
@@ -111,7 +111,8 @@ What is this project? (1-2 sentences)
 
 ## Anything the coordinator should always know
 ";
-        std::fs::write(&context_path, context_template)?;
+        std::fs::write(&context_path, context_template)
+            .wrap_err_with(|| format!("failed to write {}", context_path.display()))?;
         println!("  \u{2713} Created .apiari/context.md \u{2014} fill this in with info about your project\n");
     }
 

--- a/crates/apiari/src/init.rs
+++ b/crates/apiari/src/init.rs
@@ -90,6 +90,31 @@ pub fn run_init(name_override: Option<&str>) -> Result<()> {
 
     println!("\n  \u{2713} Created {config_display}\n");
 
+    // Scaffold .apiari/ directory with context.md and skills/
+    let apiari_dir = cwd.join(".apiari");
+    let skills_dir = apiari_dir.join("skills");
+    std::fs::create_dir_all(&skills_dir)
+        .wrap_err_with(|| format!("failed to create {}", skills_dir.display()))?;
+
+    let context_path = apiari_dir.join("context.md");
+    if !context_path.exists() {
+        let context_template = "\
+# Project Name
+
+What is this project? (1-2 sentences)
+
+## Stack
+
+## Team / ownership
+
+## Key conventions
+
+## Anything the coordinator should always know
+";
+        std::fs::write(&context_path, context_template)?;
+        println!("  \u{2713} Created .apiari/context.md \u{2014} fill this in with info about your project\n");
+    }
+
     // Check if swarm is available in PATH
     let swarm_installed = std::process::Command::new("which")
         .arg("swarm")


### PR DESCRIPTION
## Summary

- **3 skill kinds**: Tool (auto-detected from watcher config, always loaded), Context (auto-loaded from `.apiari/context.md`), Playbook (indexed from `.apiari/skills/*.md`, loaded on-demand via signal hooks)
- **Authority levels**: `observe` (read-only tools only — no Bash, no swarm) vs `autonomous` (full toolset, default). Enforcement is structural — tools are withheld, not just prompt-instructed
- **Capabilities block**: `dispatch_workers` (default true in autonomous) and `merge_prs` (default false, must opt in — supports branch-scoped lists)
- **Signal hook `skills` field**: When a hook fires with `skills = ["ci-triage"]`, the full playbook content from `.apiari/skills/ci-triage.md` is injected into that follow-through session
- **`apiari init` scaffolding**: Creates `.apiari/context.md` with project template and `.apiari/skills/` directory
- **Prompt assembly**: System → Tool skills → Context → Playbook index → Authority statement → Hook-triggered playbooks

### Config examples

```toml
[workspace]
authority = "autonomous"   # or "observe"

[workspace.capabilities]
dispatch_workers = true
merge_prs = false           # or true, or ["develop", "staging"]
```

```toml
[[coordinator.signal_hooks]]
source = "github_ci_fail"
action = "Triage the CI failure"
skills = ["ci-triage"]
```

## Test plan

- [x] All 497 existing tests pass
- [x] `cargo check` clean
- [x] `cargo fmt` clean
- [ ] Manual: verify `apiari init` creates `.apiari/` scaffolding
- [ ] Manual: verify `authority = "observe"` restricts coordinator to read-only tools
- [ ] Manual: verify playbook indexing from `.apiari/skills/*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)