### PR TITLE
feat: first-class coordinator write access to .apiari/

### DIFF
--- a/crates/apiari/src/buzz/coordinator/audit.rs
+++ b/crates/apiari/src/buzz/coordinator/audit.rs
@@ -342,6 +342,9 @@ fn contains_pattern(command: &str, pattern: &str) -> bool {
 /// - Claude Code project memory paths (`~/.claude/.../memory/`) — the
 ///   coordinator is allowed to update its own persistent memory.
 /// - `~/.config/apiari/` — workspace config files managed by the coordinator.
+/// - `.apiari/` (workspace root) — coordinator-owned config files
+///   (`context.md`, `skills/*.md`). Both relative `.apiari/` paths and
+///   absolute paths resolving under `{cwd}/.apiari/` are accepted.
 fn is_allowed_write_target(path: &str) -> bool {
     if path.starts_with("/tmp/") || path == "/tmp" {
         return true;
@@ -352,6 +355,12 @@ fn is_allowed_write_target(path: &str) -> bool {
         || path.starts_with("~/.claude/")
         || path.contains("$HOME/.claude/");
     if has_claude && (path.contains("/memory/") || path.ends_with("/memory")) {
+        return true;
+    }
+    // Workspace .apiari/ directory — coordinator-owned config files.
+    // Relative paths like `.apiari/context.md` are resolved against CWD (= workspace root).
+    // Block path traversal (no `..` allowed).
+    if is_apiari_dir_target(path) {
         return true;
     }
     // Apiari config directory.
@@ -366,6 +375,25 @@ fn is_allowed_write_target(path: &str) -> bool {
         return false;
     }
     (is_home_anchored && in_apiari_config) || path == "~/.config/apiari"
+}
+
+/// Check if a path targets the workspace `.apiari/` directory.
+///
+/// Accepts:
+/// - Relative: `.apiari/...` (relative to CWD = workspace root)
+/// - Absolute: `/.../something/.apiari/...` (must contain `/.apiari/` segment)
+///
+/// Rejects paths containing `..` to prevent traversal attacks.
+fn is_apiari_dir_target(path: &str) -> bool {
+    if path.contains("..") {
+        return false;
+    }
+    // Relative path: .apiari/ or .apiari
+    if path == ".apiari" || path.starts_with(".apiari/") {
+        return true;
+    }
+    // Absolute path containing /.apiari/ segment
+    path.contains("/.apiari/") || path.ends_with("/.apiari")
 }
 
 /// Check if the destination/target of a write command is an allowed path.
@@ -1107,5 +1135,89 @@ if len(data) > 0:
                 "mkdir should be blocked when dev-mode is expired"
             );
         });
+    }
+
+    // -- .apiari/ directory write exception tests --
+
+    #[test]
+    fn test_apiari_dir_redirect_relative_allowed() {
+        let result = classify_bash_command("echo '# Context' > .apiari/context.md");
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "redirect to .apiari/ relative path should be ReadOnly"
+        );
+    }
+
+    #[test]
+    fn test_apiari_dir_redirect_absolute_allowed() {
+        let result =
+            classify_bash_command("echo '# Context' > /Users/josh/project/.apiari/context.md");
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "redirect to absolute .apiari/ path should be ReadOnly"
+        );
+    }
+
+    #[test]
+    fn test_apiari_dir_mkdir_allowed() {
+        let result = classify_bash_command("mkdir -p .apiari/skills");
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "mkdir for .apiari/skills should be ReadOnly"
+        );
+    }
+
+    #[test]
+    fn test_apiari_dir_touch_allowed() {
+        let result = classify_bash_command("touch .apiari/skills/ci-triage.md");
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "touch in .apiari/skills/ should be ReadOnly"
+        );
+    }
+
+    #[test]
+    fn test_apiari_dir_tee_allowed() {
+        let result = classify_bash_command("echo '# Playbook' | tee .apiari/skills/ci-triage.md");
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "tee to .apiari/ should be ReadOnly"
+        );
+    }
+
+    #[test]
+    fn test_apiari_dir_cp_allowed() {
+        let result = classify_bash_command("cp /tmp/context.md .apiari/context.md");
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "cp to .apiari/ should be ReadOnly"
+        );
+    }
+
+    #[test]
+    fn test_apiari_dir_traversal_blocked() {
+        let result = classify_bash_command("echo 'bad' > .apiari/../src/main.rs");
+        assert!(
+            result.is_mutating(),
+            "path traversal out of .apiari/ should be blocked"
+        );
+    }
+
+    #[test]
+    fn test_apiari_dir_heredoc_allowed() {
+        let cmd =
+            "cat > .apiari/context.md << 'EOF'\n# Project Context\nThis is a Rust project.\nEOF";
+        let result = classify_bash_command(cmd);
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "heredoc to .apiari/ should be ReadOnly"
+        );
     }
 }

--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -326,8 +326,12 @@ mod tests {
             "preamble missing 'no git add/commit/push'"
         );
         assert!(
-            preamble.contains("ONLY writes allowed are to /tmp/"),
+            preamble.contains("ONLY Bash writes allowed are to /tmp/"),
             "preamble missing '/tmp/ exception'"
+        );
+        assert!(
+            preamble.contains(".apiari/context.md"),
+            "preamble missing '.apiari/ write scope'"
         );
     }
 

--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -26,8 +26,12 @@ pub fn default_preamble(name: &str) -> String {
            swarm status, curl APIs, sqlite3, ls, etc.).\n\
          - You must NEVER use Bash to modify the workspace: no creating/editing/deleting files, \
            no git add/commit/push, no curl -o/wget into repos, no echo/cat/sed writing to files. \
-           The ONLY writes allowed are to /tmp/ (for swarm --prompt-file) and your persistent \
-           memory file (see Persistent Memory section if present).\n\
+           The ONLY Bash writes allowed are to /tmp/ (for swarm --prompt-file), your persistent \
+           memory file (see Persistent Memory section if present), and `.apiari/` (see below).\n\
+         - You MAY use Write, Edit, or Bash to create and update files under `.apiari/`: \
+           specifically `.apiari/context.md` and `.apiari/skills/*.md`. These are coordinator-owned \
+           config files (project context and playbooks), NOT code. Do NOT write to any other \
+           workspace paths — all code changes must go through swarm workers.\n\
          - `/devmode on` temporarily unlocks file creation, `gh repo create`, `git clone`, \
            `git init`, and general file writes for 30 minutes. Use it when the user asks to \
            create a new repo or needs to write files. Always turn it off when done: `/devmode off`. \

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -445,7 +445,7 @@ mod tests {
     #[test]
     fn test_disallowed_tools_exact() {
         let tools = default_coordinator_disallowed_tools();
-        let expected = vec!["Write", "Edit", "NotebookEdit", "Task"];
+        let expected = vec!["NotebookEdit", "Task"];
         assert_eq!(
             tools, expected,
             "disallowed tools must be exactly {expected:?}"
@@ -453,10 +453,20 @@ mod tests {
     }
 
     #[test]
-    fn test_allowed_tools_no_write_capable() {
+    fn test_allowed_tools_include_write_edit() {
         let tools = default_coordinator_tools();
-        let write_capable = ["Write", "Edit", "NotebookEdit", "Task", "TodoWrite"];
-        for tool in &write_capable {
+        // Write and Edit are allowed for .apiari/ config files
+        assert!(
+            tools.contains(&"Write".to_string()),
+            "allowed tools must contain Write"
+        );
+        assert!(
+            tools.contains(&"Edit".to_string()),
+            "allowed tools must contain Edit"
+        );
+        // NotebookEdit and Task must NOT be allowed
+        let still_blocked = ["NotebookEdit", "Task", "TodoWrite"];
+        for tool in &still_blocked {
             assert!(
                 !tools.contains(&tool.to_string()),
                 "allowed tools must not contain {tool}"
@@ -477,18 +487,18 @@ mod tests {
     #[test]
     fn test_default_coordinator_tools() {
         let tools = default_coordinator_tools();
-        assert_eq!(tools.len(), 6);
+        assert_eq!(tools.len(), 8);
         assert!(tools.contains(&"Bash".to_string()));
         assert!(tools.contains(&"Read".to_string()));
-        assert!(!tools.contains(&"Write".to_string()));
-        assert!(!tools.contains(&"Edit".to_string()));
+        assert!(tools.contains(&"Write".to_string()));
+        assert!(tools.contains(&"Edit".to_string()));
     }
 
     #[test]
     fn test_default_coordinator_disallowed_tools() {
         let tools = default_coordinator_disallowed_tools();
-        assert!(tools.contains(&"Write".to_string()));
-        assert!(tools.contains(&"Edit".to_string()));
+        assert!(!tools.contains(&"Write".to_string()));
+        assert!(!tools.contains(&"Edit".to_string()));
         assert!(tools.contains(&"NotebookEdit".to_string()));
         assert!(tools.contains(&"Task".to_string()));
         assert!(!tools.contains(&"Bash".to_string()));

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -257,19 +257,29 @@ pub fn build_skills_prompt(ctx: &SkillContext) -> String {
 
 /// Default tools the coordinator is allowed to use (auto-approve).
 ///
-/// No Write/Edit — code changes go through swarm workers.
+/// Write/Edit are included for `.apiari/` config files only — the coordinator
+/// prompt constrains their use to `.apiari/context.md` and `.apiari/skills/*.md`.
 pub fn default_coordinator_tools() -> Vec<String> {
-    ["Bash", "Read", "Glob", "Grep", "WebSearch", "WebFetch"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect()
+    [
+        "Bash",
+        "Read",
+        "Write",
+        "Edit",
+        "Glob",
+        "Grep",
+        "WebSearch",
+        "WebFetch",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
 }
 
 /// Tools explicitly blocked for the coordinator (hard enforcement).
 ///
 /// Even if the model tries to use these, Claude CLI will refuse.
 pub fn default_coordinator_disallowed_tools() -> Vec<String> {
-    ["Write", "Edit", "NotebookEdit", "Task"]
+    ["NotebookEdit", "Task"]
         .iter()
         .map(|s| s.to_string())
         .collect()

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -2263,8 +2263,31 @@ fn build_skill_context(workspace_name: &str, config: &WorkspaceConfig) -> SkillC
     ctx
 }
 
+/// Ensure the `.apiari/` scaffold exists in the workspace root.
+///
+/// Creates `.apiari/context.md` (minimal stub) and `.apiari/skills/` if they
+/// don't already exist. This lets the coordinator assume these paths are
+/// available for writing from the start.
+fn ensure_apiari_scaffold(workspace_root: &std::path::Path, ws_name: &str) {
+    let apiari_dir = workspace_root.join(".apiari");
+    let skills_dir = apiari_dir.join("skills");
+    let context_file = apiari_dir.join("context.md");
+
+    if let Err(e) = std::fs::create_dir_all(&skills_dir) {
+        warn!("[{ws_name}] failed to create .apiari/skills/: {e}");
+        return;
+    }
+
+    if !context_file.exists()
+        && let Err(e) = std::fs::write(&context_file, "# Workspace Context\n")
+    {
+        warn!("[{ws_name}] failed to create .apiari/context.md: {e}");
+    }
+}
+
 /// Build a fresh Coordinator for a workspace (used at startup and on respawn).
 fn build_coordinator(ws_name: &str, config: &WorkspaceConfig) -> Coordinator {
+    ensure_apiari_scaffold(&config.root, ws_name);
     let mut coordinator = Coordinator::new(&config.coordinator.model, config.coordinator.max_turns);
     coordinator.set_name(config.coordinator.name.clone());
     let skill_ctx = build_skill_context(ws_name, config);


### PR DESCRIPTION
## Summary
- **Write + Edit tools**: Added to coordinator's allowed tools in autonomous mode, removed from disallowed list. The coordinator can now use Claude Code's Write/Edit tools directly.
- **validate-bash exception**: The bash audit now allows output redirects, `tee`, `mkdir`, `touch`, `cp` targeting `.apiari/` paths (relative or absolute). Path traversal (`..`) is blocked.
- **Lazy scaffold**: On coordinator startup, `.apiari/context.md` and `.apiari/skills/` are created if missing, so the coordinator can always write immediately.
- **Prompt update**: Role boundaries now explicitly state the coordinator may write to `.apiari/context.md` and `.apiari/skills/*.md`, and must not write elsewhere.

## Test plan
- [x] All 58 audit tests pass, including 8 new tests for `.apiari/` write exceptions
- [x] `cargo clippy --workspace -- -D warnings` passes clean
- [ ] Manual: start a workspace, verify `.apiari/` scaffold is created
- [ ] Manual: coordinator can `Write` to `.apiari/context.md`
- [ ] Manual: coordinator bash `echo > .apiari/skills/test.md` is allowed
- [ ] Manual: coordinator bash `echo > src/main.rs` is still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)