### PR TITLE
feat: first-class coordinator config edit + validate

### DIFF
--- a/crates/apiari/src/buzz/coordinator/audit.rs
+++ b/crates/apiari/src/buzz/coordinator/audit.rs
@@ -986,6 +986,30 @@ if len(data) > 0:
     }
 
     #[test]
+    fn test_apiari_config_dir_tee_allowed() {
+        let result = classify_bash_command(
+            "echo '[watchers]' | tee ~/.config/apiari/workspaces/apiari.toml",
+        );
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "tee to ~/.config/apiari/workspaces/ should be ReadOnly"
+        );
+    }
+
+    #[test]
+    fn test_apiari_config_dir_append_redirect_allowed() {
+        let result = classify_bash_command(
+            "echo 'interval_secs = 120' >> ~/.config/apiari/workspaces/apiari.toml",
+        );
+        assert_eq!(
+            result,
+            BashClassification::ReadOnly,
+            "append redirect to ~/.config/apiari/workspaces/ should be ReadOnly"
+        );
+    }
+
+    #[test]
     fn test_non_apiari_config_dir_still_blocked() {
         let result = classify_bash_command("cp /tmp/evil.txt ~/.config/other/file.txt");
         assert!(

--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -32,6 +32,9 @@ pub fn default_preamble(name: &str) -> String {
            specifically `.apiari/context.md` and `.apiari/skills/*.md`. These are coordinator-owned \
            config files (project context and playbooks), NOT code. Do NOT write to any other \
            workspace paths — all code changes must go through swarm workers.\n\
+         - You MAY also read and edit `~/.config/apiari/workspaces/{{workspace}}.toml` (the workspace \
+           config file). After any edit, validate it with `apiari config validate --workspace <name>`. \
+           If validation fails, fix the TOML before finishing.\n\
          - `/devmode on` temporarily unlocks file creation, `gh repo create`, `git clone`, \
            `git init`, and general file writes for 30 minutes. Use it when the user asks to \
            create a new repo or needs to write files. Always turn it off when done: `/devmode off`. \

--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -27,13 +27,14 @@ pub fn default_preamble(name: &str) -> String {
          - You must NEVER use Bash to modify the workspace: no creating/editing/deleting files, \
            no git add/commit/push, no curl -o/wget into repos, no echo/cat/sed writing to files. \
            The ONLY Bash writes allowed are to /tmp/ (for swarm --prompt-file), your persistent \
-           memory file (see Persistent Memory section if present), and `.apiari/` (see below).\n\
+           memory file (see Persistent Memory section if present), `.apiari/` (see below), \
+           and `~/.config/apiari/workspaces/` (see below).\n\
          - You MAY use Write, Edit, or Bash to create and update files under `.apiari/`: \
            specifically `.apiari/context.md` and `.apiari/skills/*.md`. These are coordinator-owned \
            config files (project context and playbooks), NOT code. Do NOT write to any other \
            workspace paths — all code changes must go through swarm workers.\n\
          - You MAY also read and edit `~/.config/apiari/workspaces/{{workspace}}.toml` (the workspace \
-           config file). After any edit, validate it with `apiari config validate --workspace <name>`. \
+           config file). After any edit, validate it with `apiari config validate --workspace {{workspace}}`. \
            If validation fails, fix the TOML before finishing.\n\
          - `/devmode on` temporarily unlocks file creation, `gh repo create`, `git clone`, \
            `git init`, and general file writes for 30 minutes. Use it when the user asks to \

--- a/crates/apiari/src/config_validate.rs
+++ b/crates/apiari/src/config_validate.rs
@@ -1,0 +1,96 @@
+//! `apiari config validate` — validate workspace TOML config files.
+//!
+//! Parses each workspace config and checks it deserializes into `WorkspaceConfig`.
+//! Prints a summary line per workspace and exits non-zero if any fail.
+
+use color_eyre::eyre::Result;
+
+/// Run validation for one or all workspace configs.
+///
+/// Returns exit code: 0 if all valid, 1 if any fail.
+pub fn run(workspace: Option<&str>) -> Result<i32> {
+    let dir = crate::config::workspaces_dir();
+
+    if let Some(name) = workspace {
+        let path = dir.join(format!("{name}.toml"));
+        if !path.exists() {
+            eprintln!("\u{2717} {name}: file not found ({})", path.display());
+            return Ok(1);
+        }
+        match crate::config::load_workspace(&path) {
+            Ok(_) => {
+                println!("\u{2713} {name}: valid");
+                Ok(0)
+            }
+            Err(e) => {
+                println!("\u{2717} {name}: {e}");
+                Ok(1)
+            }
+        }
+    } else {
+        // Validate all workspace configs
+        if !dir.exists() {
+            println!("No workspaces directory found at {}", dir.display());
+            return Ok(0);
+        }
+
+        let mut entries: Vec<_> = std::fs::read_dir(&dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "toml"))
+            .collect();
+        entries.sort_by_key(|e| e.file_name());
+
+        if entries.is_empty() {
+            println!("No workspace configs found in {}", dir.display());
+            return Ok(0);
+        }
+
+        let mut any_failed = false;
+        for entry in entries {
+            let path = entry.path();
+            let name = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown");
+
+            match crate::config::load_workspace(&path) {
+                Ok(_) => println!("\u{2713} {name}: valid"),
+                Err(e) => {
+                    println!("\u{2717} {name}: {e}");
+                    any_failed = true;
+                }
+            }
+        }
+
+        Ok(if any_failed { 1 } else { 0 })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    #[test]
+    fn test_validate_valid_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "root = \"/tmp/test\"").unwrap();
+        drop(f);
+
+        let result = crate::config::load_workspace(&path);
+        assert!(result.is_ok(), "valid config should parse: {result:?}");
+    }
+
+    #[test]
+    fn test_validate_invalid_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "not_a_real_field = {{ broken").unwrap();
+        drop(f);
+
+        let result = crate::config::load_workspace(&path);
+        assert!(result.is_err(), "invalid TOML should fail to parse");
+    }
+}

--- a/crates/apiari/src/config_validate.rs
+++ b/crates/apiari/src/config_validate.rs
@@ -3,8 +3,8 @@
 //! Parses each workspace config and checks it deserializes into `WorkspaceConfig`.
 //! Prints a summary line per workspace and exits non-zero if any fail.
 
-use color_eyre::eyre::Result;
-use std::path::Path;
+use color_eyre::eyre::{Result, WrapErr};
+use std::path::{Component, Path};
 
 /// Run validation for one or all workspace configs.
 ///
@@ -14,14 +14,19 @@ pub fn run(workspace: Option<&str>) -> Result<i32> {
     run_with_dir(workspace, &dir)
 }
 
-/// Sanitize a workspace name — reject path separators and traversal.
+/// Sanitize a workspace name — reject path separators and `.`/`..` components.
+///
+/// Uses `Path::components()` so that names like `.hidden` or `foo..bar` are
+/// allowed (they are single `Normal` components), while `..`, `.`, and anything
+/// containing path separators is rejected.
 fn sanitize_workspace_name(name: &str) -> Result<()> {
-    if name.is_empty()
-        || name.contains('/')
-        || name.contains('\\')
-        || name.contains("..")
-        || name.starts_with('.')
-    {
+    if name.is_empty() {
+        color_eyre::eyre::bail!("invalid workspace name: {name:?}");
+    }
+    let path = Path::new(name);
+    let components: Vec<_> = path.components().collect();
+    // Must be exactly one Normal component (no separators, no . or ..)
+    if components.len() != 1 || !matches!(components[0], Component::Normal(_)) {
         color_eyre::eyre::bail!("invalid workspace name: {name:?}");
     }
     Ok(())
@@ -53,7 +58,8 @@ fn run_with_dir(workspace: Option<&str>, dir: &Path) -> Result<i32> {
             return Ok(0);
         }
 
-        let mut entries: Vec<_> = std::fs::read_dir(dir)?
+        let mut entries: Vec<_> = std::fs::read_dir(dir)
+            .wrap_err_with(|| format!("failed to read {}", dir.display()))?
             .filter_map(|e| e.ok())
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "toml"))
             .collect();
@@ -184,8 +190,8 @@ mod tests {
     fn test_sanitize_rejects_path_traversal() {
         assert!(sanitize_workspace_name("../etc/passwd").is_err());
         assert!(sanitize_workspace_name("foo/bar").is_err());
-        assert!(sanitize_workspace_name("foo\\bar").is_err());
-        assert!(sanitize_workspace_name(".hidden").is_err());
+        assert!(sanitize_workspace_name("..").is_err());
+        assert!(sanitize_workspace_name(".").is_err());
         assert!(sanitize_workspace_name("").is_err());
     }
 
@@ -194,6 +200,8 @@ mod tests {
         assert!(sanitize_workspace_name("myworkspace").is_ok());
         assert!(sanitize_workspace_name("my-workspace").is_ok());
         assert!(sanitize_workspace_name("my_workspace").is_ok());
+        assert!(sanitize_workspace_name(".hidden").is_ok());
+        assert!(sanitize_workspace_name("foo..bar").is_ok());
     }
 
     #[test]

--- a/crates/apiari/src/config_validate.rs
+++ b/crates/apiari/src/config_validate.rs
@@ -4,14 +4,33 @@
 //! Prints a summary line per workspace and exits non-zero if any fail.
 
 use color_eyre::eyre::Result;
+use std::path::Path;
 
 /// Run validation for one or all workspace configs.
 ///
 /// Returns exit code: 0 if all valid, 1 if any fail.
 pub fn run(workspace: Option<&str>) -> Result<i32> {
     let dir = crate::config::workspaces_dir();
+    run_with_dir(workspace, &dir)
+}
 
+/// Sanitize a workspace name — reject path separators and traversal.
+fn sanitize_workspace_name(name: &str) -> Result<()> {
+    if name.is_empty()
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains("..")
+        || name.starts_with('.')
+    {
+        color_eyre::eyre::bail!("invalid workspace name: {name:?}");
+    }
+    Ok(())
+}
+
+/// Inner implementation that accepts a directory, for testability.
+fn run_with_dir(workspace: Option<&str>, dir: &Path) -> Result<i32> {
     if let Some(name) = workspace {
+        sanitize_workspace_name(name)?;
         let path = dir.join(format!("{name}.toml"));
         if !path.exists() {
             eprintln!("\u{2717} {name}: file not found ({})", path.display());
@@ -23,7 +42,7 @@ pub fn run(workspace: Option<&str>) -> Result<i32> {
                 Ok(0)
             }
             Err(e) => {
-                println!("\u{2717} {name}: {e}");
+                eprintln!("\u{2717} {name}: {e}");
                 Ok(1)
             }
         }
@@ -34,7 +53,7 @@ pub fn run(workspace: Option<&str>) -> Result<i32> {
             return Ok(0);
         }
 
-        let mut entries: Vec<_> = std::fs::read_dir(&dir)?
+        let mut entries: Vec<_> = std::fs::read_dir(dir)?
             .filter_map(|e| e.ok())
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "toml"))
             .collect();
@@ -56,7 +75,7 @@ pub fn run(workspace: Option<&str>) -> Result<i32> {
             match crate::config::load_workspace(&path) {
                 Ok(_) => println!("\u{2713} {name}: valid"),
                 Err(e) => {
-                    println!("\u{2717} {name}: {e}");
+                    eprintln!("\u{2717} {name}: {e}");
                     any_failed = true;
                 }
             }
@@ -68,6 +87,7 @@ pub fn run(workspace: Option<&str>) -> Result<i32> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::io::Write;
 
     #[test]
@@ -92,5 +112,94 @@ mod tests {
 
         let result = crate::config::load_workspace(&path);
         assert!(result.is_err(), "invalid TOML should fail to parse");
+    }
+
+    #[test]
+    fn test_run_single_valid_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(dir.path().join("myws.toml")).unwrap();
+        writeln!(f, "root = \"/tmp/myws\"").unwrap();
+        drop(f);
+
+        let code = run_with_dir(Some("myws"), dir.path()).unwrap();
+        assert_eq!(code, 0, "valid workspace should return 0");
+    }
+
+    #[test]
+    fn test_run_single_invalid_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(dir.path().join("bad.toml")).unwrap();
+        writeln!(f, "not_valid {{{{ toml").unwrap();
+        drop(f);
+
+        let code = run_with_dir(Some("bad"), dir.path()).unwrap();
+        assert_eq!(code, 1, "invalid workspace should return 1");
+    }
+
+    #[test]
+    fn test_run_single_missing_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let code = run_with_dir(Some("nonexistent"), dir.path()).unwrap();
+        assert_eq!(code, 1, "missing workspace should return 1");
+    }
+
+    #[test]
+    fn test_run_all_workspaces_mixed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(dir.path().join("good.toml")).unwrap();
+        writeln!(f, "root = \"/tmp/good\"").unwrap();
+        drop(f);
+
+        let mut f = std::fs::File::create(dir.path().join("bad.toml")).unwrap();
+        writeln!(f, "broken {{{{ toml").unwrap();
+        drop(f);
+
+        let code = run_with_dir(None, dir.path()).unwrap();
+        assert_eq!(code, 1, "mixed valid/invalid should return 1");
+    }
+
+    #[test]
+    fn test_run_all_workspaces_all_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(dir.path().join("a.toml")).unwrap();
+        writeln!(f, "root = \"/tmp/a\"").unwrap();
+        drop(f);
+
+        let mut f = std::fs::File::create(dir.path().join("b.toml")).unwrap();
+        writeln!(f, "root = \"/tmp/b\"").unwrap();
+        drop(f);
+
+        let code = run_with_dir(None, dir.path()).unwrap();
+        assert_eq!(code, 0, "all valid should return 0");
+    }
+
+    #[test]
+    fn test_run_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let code = run_with_dir(None, dir.path()).unwrap();
+        assert_eq!(code, 0, "empty dir should return 0");
+    }
+
+    #[test]
+    fn test_sanitize_rejects_path_traversal() {
+        assert!(sanitize_workspace_name("../etc/passwd").is_err());
+        assert!(sanitize_workspace_name("foo/bar").is_err());
+        assert!(sanitize_workspace_name("foo\\bar").is_err());
+        assert!(sanitize_workspace_name(".hidden").is_err());
+        assert!(sanitize_workspace_name("").is_err());
+    }
+
+    #[test]
+    fn test_sanitize_accepts_valid_names() {
+        assert!(sanitize_workspace_name("myworkspace").is_ok());
+        assert!(sanitize_workspace_name("my-workspace").is_ok());
+        assert!(sanitize_workspace_name("my_workspace").is_ok());
+    }
+
+    #[test]
+    fn test_run_rejects_traversal_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = run_with_dir(Some("../evil"), dir.path());
+        assert!(result.is_err(), "path traversal name should be rejected");
     }
 }

--- a/crates/apiari/src/main.rs
+++ b/crates/apiari/src/main.rs
@@ -1,6 +1,7 @@
 mod buzz;
 mod config;
 mod config_set;
+mod config_validate;
 mod daemon;
 mod git_safety;
 pub mod shells;
@@ -101,6 +102,12 @@ enum ConfigCommand {
         value: String,
 
         /// Workspace name (default: auto-detect from current directory)
+        #[arg(long)]
+        workspace: Option<String>,
+    },
+    /// Validate workspace config files
+    Validate {
+        /// Workspace name (default: validate all)
         #[arg(long)]
         workspace: Option<String>,
     },
@@ -210,6 +217,12 @@ async fn main() -> Result<()> {
                 workspace,
             } => {
                 config_set::run(workspace.as_deref(), &key, &value)?;
+            }
+            ConfigCommand::Validate { workspace } => {
+                let code = config_validate::run(workspace.as_deref())?;
+                if code != 0 {
+                    std::process::exit(code);
+                }
             }
         },
         Some(Command::ValidateBash) => {


### PR DESCRIPTION
## Summary
- Adds `apiari config validate [--workspace <name>]` CLI subcommand that parses workspace TOML files and checks they deserialize into `WorkspaceConfig`, printing ✓/✗ per workspace and exiting non-zero on failure
- Updates the coordinator system prompt to document that it may read/edit `~/.config/apiari/workspaces/{workspace}.toml` and must validate after edits
- Adds audit tests confirming `tee` and `>>` append redirects to workspace config paths are allowed

## Test plan
- [x] All 534 existing tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] New audit tests verify tee and append redirect to `~/.config/apiari/workspaces/` are ReadOnly
- [x] New config_validate module has unit tests for valid and invalid TOML parsing
- [ ] Manual: `apiari config validate` prints status for all workspace configs
- [ ] Manual: `apiari config validate --workspace <name>` validates a single workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)