### PR TITLE
fix: increase signal follow-through session limits and re-enable Bash

### DIFF
--- a/crates/apiari/src/buzz/coordinator/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/mod.rs
@@ -63,6 +63,8 @@ pub struct Coordinator {
     working_dir: Option<PathBuf>,
     settings: Option<String>,
     safety_hooks: Option<Box<dyn SafetyHooks>>,
+    /// Number of turns used in the last completed session.
+    last_num_turns: u64,
 }
 
 impl Coordinator {
@@ -81,6 +83,7 @@ impl Coordinator {
             working_dir: None,
             settings: None,
             safety_hooks: None,
+            last_num_turns: 0,
         }
     }
 
@@ -168,6 +171,11 @@ impl Coordinator {
     /// Temporarily change max turns (e.g. for system notifications).
     pub fn set_max_turns(&mut self, turns: u32) {
         self.max_turns = turns;
+    }
+
+    /// Number of turns used in the last completed session.
+    pub fn last_num_turns(&self) -> u64 {
+        self.last_num_turns
     }
 
     /// Check if the Claude CLI is available.
@@ -282,6 +290,7 @@ impl Coordinator {
                     // Don't store the broken session — caller will reset.
                     return Err(error_detail.to_string());
                 }
+                self.last_num_turns = result.num_turns;
                 self.session_id = Some(result.session_id.clone());
                 self.session_token = Some(SessionToken {
                     provider: self.provider.clone(),

--- a/crates/apiari/src/buzz/coordinator/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/mod.rs
@@ -335,6 +335,7 @@ impl Coordinator {
     where
         F: FnMut(CoordinatorEvent),
     {
+        self.last_num_turns = 0;
         let client = ClaudeClient::new();
         let mut session = client.spawn(opts).await?;
         session.send_message(message).await?;

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -672,8 +672,8 @@ async fn run_coordinator_task(
                     }
                 };
 
-                // Run follow-throughs in a fresh session so tool restrictions
-                // stay isolated and don't poison the main coordinator session.
+                // Run follow-throughs in a fresh session so any per-session
+                // overrides stay isolated and don't poison the main session.
                 opts.resume = None;
 
                 // In observe mode, strip Bash from follow-throughs to enforce
@@ -771,6 +771,13 @@ async fn run_coordinator_task(
                                 "[{slot_name}] coordinator ack'd {source} events (no message sent)"
                             );
                         }
+                        // Check if the follow-through exhausted its turn budget.
+                        let used = coordinator.last_num_turns();
+                        if used >= max_turns as u64 {
+                            warn!(
+                                "signal follow-through exhausted max_turns ({max_turns}) for source={source}"
+                            );
+                        }
                     }
                     Err(e) => {
                         warn!(
@@ -778,14 +785,6 @@ async fn run_coordinator_task(
                             signals.len()
                         );
                     }
-                }
-
-                // Check if the follow-through exhausted its turn budget.
-                let used = coordinator.last_num_turns();
-                if used >= max_turns as u64 {
-                    warn!(
-                        "signal follow-through exhausted max_turns ({max_turns}) for source={source}"
-                    );
                 }
 
                 // Restore the user's session so subsequent messages resume

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -657,7 +657,8 @@ async fn run_coordinator_task(
                 };
 
                 let saved_turns = coordinator.max_turns();
-                coordinator.set_max_turns(3);
+                let max_turns = 15;
+                coordinator.set_max_turns(max_turns);
 
                 let mut opts = match coordinator
                     .build_options_with_playbooks(&store, playbook_content.as_deref())
@@ -674,19 +675,6 @@ async fn run_coordinator_task(
                 // (disallowed Bash) stay isolated and don't poison the main
                 // coordinator session.
                 opts.resume = None;
-
-                // Restrict to read-only for signal follow-throughs — no Bash allowed.
-                // Apply this restriction via opts so the coordinator's persistent
-                // configuration is not changed; other session-level side effects
-                // are handled via the save/restore logic below.
-                if !opts.disallowed_tools.iter().any(|t| t == "Bash") {
-                    opts.disallowed_tools.push("Bash".to_string());
-                }
-                // Also remove Bash from allowed_tools to avoid conflicting CLI
-                // flags (--allowedTools and --disallowedTools both containing Bash),
-                // which can cause Claude Code to persistently block Bash in the
-                // resumed session.
-                opts.allowed_tools.retain(|t| t != "Bash");
 
                 // Save the user's session token so we can restore it after the
                 // follow-through (handle_message_with_options overwrites session_id
@@ -780,6 +768,14 @@ async fn run_coordinator_task(
                             signals.len()
                         );
                     }
+                }
+
+                // Check if the follow-through exhausted its turn budget.
+                let used = coordinator.last_num_turns();
+                if used >= max_turns as u64 {
+                    warn!(
+                        "signal follow-through exhausted max_turns ({max_turns}) for source={source}"
+                    );
                 }
 
                 // Restore the user's session so subsequent messages resume

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -152,6 +152,7 @@ async fn run_coordinator_task(
     store: SignalStore,
     mut job_rx: mpsc::UnboundedReceiver<CoordinatorJob>,
     max_session_turns: u32,
+    authority: crate::config::WorkspaceAuthority,
 ) {
     let mut turn_count: u32 = 0;
 
@@ -672,9 +673,18 @@ async fn run_coordinator_task(
                 };
 
                 // Run follow-throughs in a fresh session so tool restrictions
-                // (disallowed Bash) stay isolated and don't poison the main
-                // coordinator session.
+                // stay isolated and don't poison the main coordinator session.
                 opts.resume = None;
+
+                // In observe mode, strip Bash from follow-throughs to enforce
+                // read-only. Autonomous mode keeps Bash — the validate-bash
+                // hook already audits commands.
+                if authority == crate::config::WorkspaceAuthority::Observe {
+                    if !opts.disallowed_tools.iter().any(|t| t == "Bash") {
+                        opts.disallowed_tools.push("Bash".to_string());
+                    }
+                    opts.allowed_tools.retain(|t| t != "Bash");
+                }
 
                 // Save the user's session token so we can restore it after the
                 // follow-through (handle_message_with_options overwrites session_id
@@ -1097,6 +1107,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             coord_store,
             coord_rx,
             max_session_turns,
+            ws.config.authority,
         ));
 
         // Morning brief scheduler
@@ -1336,6 +1347,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                         coord_store,
                         new_rx,
                         slot.max_session_turns,
+                        slot.config.authority,
                     )));
                     slot.coord_respawn_count += 1;
                     slot.coord_last_respawn = Some(std::time::Instant::now());


### PR DESCRIPTION
## Summary
- Increase follow-through `max_turns` from 3 to 15 so playbooks can execute multi-step workflows (gh pr view, gh api, swarm status, swarm send, etc.)
- Remove the code that strips Bash from `allowed_tools`/adds it to `disallowed_tools` — the coordinator's validate-bash hook already audits commands
- Add `tracing::warn!` when a follow-through session exhausts its turn budget, via new `Coordinator::last_num_turns()` tracking

## Test plan
- [ ] Verify follow-through sessions can now execute playbook steps requiring `gh` CLI commands
- [ ] Confirm multi-step playbooks (4-6+ tool calls) complete without hitting the turn limit
- [ ] Check logs for the new exhaustion warning when turns are intentionally maxed out
- [ ] Verify main interactive session max_turns is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)