### PR TITLE
Update CLAUDE.md: add --reviewer @copilot to PR creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Rules
 1. You are working in a git worktree on a `swarm/*` branch. Never commit to main.
 2. Only modify files within this repository.
-3. When done, create a PR with `gh pr create`.
+3. When done, create a PR with `gh pr create --reviewer @copilot`.
 4. Do not run `cargo install` or modify system state.
 5. Plan and execute in one go — do not pause for confirmation.
 


### PR DESCRIPTION
This update ensures that Copilot automatically reviews every PR opened by swarm workers.

**Changes:**
- Added `--reviewer @copilot` flag to the `gh pr create` command in CLAUDE.md

This brings consistency with the swarm repository's CLAUDE.md, which already includes this flag.