### PR TITLE
feat: load .apiari/soul.md as coordinator personality file

### DIFF
--- a/crates/apiari/src/buzz/coordinator/skills/apiari.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/apiari.rs
@@ -29,6 +29,10 @@ pub fn build_prompt(ctx: &SkillContext) -> String {
          merge_prs = false         # default false — must explicitly opt in\n\
          # merge_prs = [\"develop\", \"staging\"]   # scope to specific branches\n\
          ```\n\n\
+         ### Communication Style (Soul)\n\
+         `{root}/.apiari/soul.md` is automatically loaded into every coordinator session. \
+         Users should put communication style and behavioral guidelines here: tone, verbosity, \
+         what to lead with, personality traits. If the file does not exist, no soul is loaded.\n\n\
          ### Project Context\n\
          `{root}/.apiari/context.md` is automatically loaded into every coordinator session. \
          Users should put high-level project info here: what the project is, the tech stack, \
@@ -54,6 +58,7 @@ pub fn build_prompt(ctx: &SkillContext) -> String {
          declarative and playbooks reusable.\n\n\
          ### Scaffolding\n\
          `apiari init` creates the workspace config and scaffolds:\n\
+         - `.apiari/soul.md` — template for communication style\n\
          - `.apiari/context.md` — template for project context\n\
          - `.apiari/skills/` — empty directory for playbooks\n\n\
          Users can also create these manually.\n",

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -560,6 +560,32 @@ mod tests {
     }
 
     #[test]
+    fn test_build_skills_prompt_includes_soul_before_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let apiari_dir = dir.path().join(".apiari");
+        std::fs::create_dir_all(apiari_dir.join("skills")).unwrap();
+        std::fs::write(apiari_dir.join("soul.md"), "Be terse and opinionated.").unwrap();
+        std::fs::write(apiari_dir.join("context.md"), "# My Project\nA Rust CLI.").unwrap();
+
+        let ctx = SkillContext {
+            workspace_root: dir.path().to_path_buf(),
+            ..test_ctx()
+        };
+        let prompt = build_skills_prompt(&ctx);
+
+        assert!(prompt.contains("## Communication Style"));
+        assert!(prompt.contains("Be terse and opinionated."));
+
+        // Soul must appear before Project Context
+        let soul_pos = prompt.find("## Communication Style").unwrap();
+        let context_pos = prompt.find("## Project Context").unwrap();
+        assert!(
+            soul_pos < context_pos,
+            "Communication Style must appear before Project Context"
+        );
+    }
+
+    #[test]
     fn test_index_playbooks_reads_first_line() {
         let dir = tempfile::tempdir().unwrap();
         let skills_dir = dir.path().join(".apiari/skills");

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -7,6 +7,7 @@
 //! ## Skill Kinds
 //!
 //! - **Tool** — operational knowledge for external tools/CLIs (auto-detected from watcher config)
+//! - **Soul** — communication style and personality (auto-loaded from `.apiari/soul.md`)
 //! - **Context** — what this workspace/project is (auto-loaded from `.apiari/context.md`)
 //! - **Playbook** — how to handle a situation (indexed from `.apiari/skills/*.md`)
 
@@ -81,6 +82,12 @@ pub fn load_context_skill(workspace_root: &Path) -> Option<String> {
     std::fs::read_to_string(&path).ok()
 }
 
+/// Load the soul/personality from `.apiari/soul.md` if it exists.
+pub fn load_soul(workspace_root: &Path) -> Option<String> {
+    let path = workspace_root.join(".apiari/soul.md");
+    std::fs::read_to_string(&path).ok()
+}
+
 /// Index playbooks from `.apiari/skills/*.md`.
 ///
 /// Returns a list of (name, first-line description) entries.
@@ -144,9 +151,10 @@ pub fn load_playbook(workspace_root: &Path, name: &str) -> Option<String> {
 /// Prompt is assembled in this order:
 /// 1. Workspace info + repos
 /// 2. Tool skills (auto from watcher config)
-/// 3. Context skill (from `.apiari/context.md`)
-/// 4. Playbook index (names + descriptions from `.apiari/skills/*.md`)
-/// 5. Authority level statement
+/// 3. Soul / communication style (from `.apiari/soul.md`)
+/// 4. Context skill (from `.apiari/context.md`)
+/// 5. Playbook index (names + descriptions from `.apiari/skills/*.md`)
+/// 6. Authority level statement
 pub fn build_skills_prompt(ctx: &SkillContext) -> String {
     let mut prompt = format!(
         "## Workspace\n\
@@ -202,6 +210,15 @@ pub fn build_skills_prompt(ctx: &SkillContext) -> String {
 
     prompt.push_str("\n# Skills\nYou have the following tools and capabilities:\n\n");
     prompt.push_str(&tool_sections.join("\n"));
+
+    // Soul / communication style (from .apiari/soul.md)
+    if let Some(soul) = load_soul(&ctx.workspace_root) {
+        prompt.push_str("\n## Communication Style\n");
+        prompt.push_str(&soul);
+        if !soul.ends_with('\n') {
+            prompt.push('\n');
+        }
+    }
 
     // Context skill (from .apiari/context.md)
     if let Some(context) = load_context_skill(&ctx.workspace_root) {
@@ -523,6 +540,23 @@ mod tests {
     fn test_load_context_skill_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
         assert!(load_context_skill(dir.path()).is_none());
+    }
+
+    #[test]
+    fn test_load_soul_returns_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let apiari_dir = dir.path().join(".apiari");
+        std::fs::create_dir_all(&apiari_dir).unwrap();
+        std::fs::write(apiari_dir.join("soul.md"), "Be concise and direct.").unwrap();
+        let content = load_soul(dir.path());
+        assert!(content.is_some());
+        assert!(content.unwrap().contains("Be concise and direct."));
+    }
+
+    #[test]
+    fn test_load_soul_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_soul(dir.path()).is_none());
     }
 
     #[test]

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -83,7 +83,7 @@ pub fn load_context_skill(workspace_root: &Path) -> Option<String> {
 }
 
 /// Load the soul/personality from `.apiari/soul.md` if it exists.
-pub fn load_soul(workspace_root: &Path) -> Option<String> {
+pub fn load_soul_skill(workspace_root: &Path) -> Option<String> {
     let path = workspace_root.join(".apiari/soul.md");
     std::fs::read_to_string(&path).ok()
 }
@@ -212,7 +212,7 @@ pub fn build_skills_prompt(ctx: &SkillContext) -> String {
     prompt.push_str(&tool_sections.join("\n"));
 
     // Soul / communication style (from .apiari/soul.md)
-    if let Some(soul) = load_soul(&ctx.workspace_root) {
+    if let Some(soul) = load_soul_skill(&ctx.workspace_root) {
         prompt.push_str("\n## Communication Style\n");
         prompt.push_str(&soul);
         if !soul.ends_with('\n') {
@@ -543,20 +543,20 @@ mod tests {
     }
 
     #[test]
-    fn test_load_soul_returns_content() {
+    fn test_load_soul_skill_returns_content() {
         let dir = tempfile::tempdir().unwrap();
         let apiari_dir = dir.path().join(".apiari");
         std::fs::create_dir_all(&apiari_dir).unwrap();
         std::fs::write(apiari_dir.join("soul.md"), "Be concise and direct.").unwrap();
-        let content = load_soul(dir.path());
+        let content = load_soul_skill(dir.path());
         assert!(content.is_some());
         assert!(content.unwrap().contains("Be concise and direct."));
     }
 
     #[test]
-    fn test_load_soul_returns_none_when_missing() {
+    fn test_load_soul_skill_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(load_soul(dir.path()).is_none());
+        assert!(load_soul_skill(dir.path()).is_none());
     }
 
     #[test]

--- a/crates/apiari/src/init.rs
+++ b/crates/apiari/src/init.rs
@@ -96,6 +96,18 @@ pub fn run_init(name_override: Option<&str>) -> Result<()> {
     std::fs::create_dir_all(&skills_dir)
         .wrap_err_with(|| format!("failed to create {}", skills_dir.display()))?;
 
+    let soul_path = apiari_dir.join("soul.md");
+    if !soul_path.exists() {
+        let soul_template = "\
+# Soul
+
+Communication style and behavioral guidelines for the coordinator.
+";
+        std::fs::write(&soul_path, soul_template)
+            .wrap_err_with(|| format!("failed to write {}", soul_path.display()))?;
+        println!("  \u{2713} Created .apiari/soul.md \u{2014} define the coordinator's communication style\n");
+    }
+
     let context_path = apiari_dir.join("context.md");
     if !context_path.exists() {
         let context_template = "\

--- a/crates/apiari/src/init.rs
+++ b/crates/apiari/src/init.rs
@@ -90,7 +90,7 @@ pub fn run_init(name_override: Option<&str>) -> Result<()> {
 
     println!("\n  \u{2713} Created {config_display}\n");
 
-    // Scaffold .apiari/ directory with context.md and skills/
+    // Scaffold .apiari/ directory with soul.md, context.md, and skills/
     let apiari_dir = cwd.join(".apiari");
     let skills_dir = apiari_dir.join("skills");
     std::fs::create_dir_all(&skills_dir)
@@ -105,7 +105,7 @@ Communication style and behavioral guidelines for the coordinator.
 ";
         std::fs::write(&soul_path, soul_template)
             .wrap_err_with(|| format!("failed to write {}", soul_path.display()))?;
-        println!("  \u{2713} Created .apiari/soul.md \u{2014} define the coordinator's communication style\n");
+        println!("  \u{2713} Created .apiari/soul.md \u{2014} defines the coordinator's communication style\n");
     }
 
     let context_path = apiari_dir.join("context.md");


### PR DESCRIPTION
## Summary
- Adds support for `.apiari/soul.md` as a communication style / personality file loaded into every coordinator session
- `soul.md` = how the coordinator talks (tone, verbosity, style); `context.md` = what the project is (tech stack, conventions)
- Soul is loaded **before** context in the system prompt (personality comes before project knowledge)
- If `soul.md` doesn't exist, it's silently skipped (same as `context.md`)

## Changes
- **`skills/mod.rs`**: Added `load_soul()` function and inject soul content under `## Communication Style` heading before `## Project Context`
- **`skills/apiari.rs`**: Documented `soul.md` in the apiari system skill prompt (Communication Style section + scaffolding list)
- **`init.rs`**: Scaffold `.apiari/soul.md` with a brief template during `apiari init`
- **`audit.rs`**: Already covered — `.apiari/soul.md` falls under the existing `.apiari/` write exception

## Test plan
- [x] All existing tests pass (34 skills tests, 72 prompt/audit tests)
- [x] Two new tests: `test_load_soul_returns_content` and `test_load_soul_returns_none_when_missing`
- [ ] Manual: run `apiari init` in a fresh directory and verify `soul.md` is scaffolded
- [ ] Manual: add content to `soul.md` and verify it appears in coordinator system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)