### PR TITLE
chore: bump apiari to 0.2.2, swarm dep to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apiari"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "apiari-claude-sdk",
  "apiari-codex-sdk",
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "apiari-swarm"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd63abb9a0030bfed4cc064e8b7e1aae4cc7f16fd702dda75413c6b6d601ff3"
+checksum = "38c198715656ed61adf8c207673ebc0ffe48a8461a7311a4d27e83fe215b2925"
 dependencies = [
  "apiari-claude-sdk",
  "apiari-codex-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ apiari-claude-sdk = "0.1.0"
 apiari-codex-sdk = "0.1.0"
 apiari-gemini-sdk = "0.1.0"
 chrono-tz = "0.9"
-apiari-swarm = { version = "0.1.4", default-features = false, features = ["client"] }
+apiari-swarm = { version = "0.1.5", default-features = false, features = ["client"] }

--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/ApiariTools/apiari"

--- a/crates/apiari/src/buzz/watcher/swarm.rs
+++ b/crates/apiari/src/buzz/watcher/swarm.rs
@@ -6,10 +6,10 @@
 //!
 //! Replaces the previous approach of polling `.swarm/state.json` on disk.
 
-use apiari_swarm::core::ipc::{global_socket_path, socket_path};
-use apiari_swarm::core::state::WorkerPhase;
-use apiari_swarm::daemon::ipc_client::send_daemon_request;
-use apiari_swarm::daemon::protocol::{DaemonRequest, DaemonResponse, WorkerInfo};
+use apiari_swarm::WorkerPhase;
+use apiari_swarm::client::{
+    DaemonRequest, DaemonResponse, WorkerInfo, global_socket_path, send_daemon_request, socket_path,
+};
 use async_trait::async_trait;
 use color_eyre::Result;
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary
- Bumps `apiari` crate version from 0.2.1 to 0.2.2
- Updates `apiari-swarm` workspace dependency from 0.1.4 to 0.1.5

**Note:** `apiari-swarm` 0.1.5 is not yet published on crates.io. `cargo check` will fail until it is available. Cargo.lock will update once the dependency is resolvable.

## Test plan
- [ ] Verify `cargo check` passes once `apiari-swarm` 0.1.5 is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)