### PR TITLE
feat: add built-in /reload command to restart daemon

### DIFF
--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -2423,18 +2423,20 @@ fn remove_pid() {
 
 /// Build the `/help` text, appending any custom commands from the workspace config.
 fn build_help_text(config: &WorkspaceConfig) -> String {
-    let mut text = "Built-in commands:\n\
-        /status — show open signals\n\
-        /config — show workspace configuration summary\n\
-        /brief — generate morning brief on demand\n\
-        /reset — reset coordinator session\n\
-        /clear — clear session (hard reset, no context carried forward)\n\
-        /compact — compact session (summarize key context to memory, then reset)\n\
-        /devmode — toggle dev mode (on/off/status)\n\
-        /update — install latest apiari + swarm from crates.io\n\
-        /reload — restart daemon to pick up config changes\n\
-        /help — this message"
-        .to_string();
+    let mut text = concat!(
+        "Built-in commands:\n",
+        "/status — show open signals\n",
+        "/config — show workspace configuration summary\n",
+        "/brief — generate morning brief on demand\n",
+        "/reset — reset coordinator session\n",
+        "/clear — clear session (hard reset, no context carried forward)\n",
+        "/compact — compact session (summarize key context to memory, then reset)\n",
+        "/devmode — toggle dev mode (on/off/status)\n",
+        "/update — install latest apiari + swarm from crates.io\n",
+        "/reload — restart daemon to pick up config changes\n",
+        "/help — this message",
+    )
+    .to_string();
     if !config.commands.is_empty() {
         text.push_str("\n\nCustom commands:");
         for cmd in &config.commands {

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1896,11 +1896,11 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                     "reload" => {
                                         info!("[{}] running /reload", slot.name);
                                         if let Some(ref server) = socket_server {
-                                            server.broadcast_activity("telegram", &slot.name, "assistant_message", "Daemon reloaded.");
+                                            server.broadcast_activity("telegram", &slot.name, "assistant_message", "Restarting daemon...");
                                         }
                                         let _ = channel.send_message(&OutboundMessage {
                                             chat_id,
-                                            text: "Daemon reloaded.".to_string(),
+                                            text: "Restarting daemon...".to_string(),
                                             buttons: vec![],
                                             topic_id,
                                         }).await;
@@ -1938,14 +1938,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                         let _ = channel.send_message(&OutboundMessage { chat_id, text, buttons: vec![], topic_id }).await;
                                     }
                                     "help" => {
-                                        let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/devmode — toggle dev mode (on/off/status)\n/update — install latest apiari + swarm from crates.io\n/reload — restart daemon to pick up config changes\n/help — this message".to_string();
-                                        if !slot.config.commands.is_empty() {
-                                            text.push_str("\n\nCustom commands:");
-                                            for cmd in &slot.config.commands {
-                                                let desc = cmd.description.as_deref().unwrap_or("(no description)");
-                                                text.push_str(&format!("\n/{} — {}", cmd.name, desc));
-                                            }
-                                        }
+                                        let text = build_help_text(&slot.config);
                                         if let Some(ref server) = socket_server {
                                             server.broadcast_activity("telegram", &slot.name, "assistant_message", &text);
                                         }
@@ -2428,7 +2421,32 @@ fn remove_pid() {
     let _ = std::fs::remove_file(pid_path());
 }
 
-/// Handle a TUI slash command. Returns `true` if the command was handled.
+/// Build the `/help` text, appending any custom commands from the workspace config.
+fn build_help_text(config: &WorkspaceConfig) -> String {
+    let mut text = "Built-in commands:\n\
+        /status — show open signals\n\
+        /config — show workspace configuration summary\n\
+        /brief — generate morning brief on demand\n\
+        /reset — reset coordinator session\n\
+        /clear — clear session (hard reset, no context carried forward)\n\
+        /compact — compact session (summarize key context to memory, then reset)\n\
+        /devmode — toggle dev mode (on/off/status)\n\
+        /update — install latest apiari + swarm from crates.io\n\
+        /reload — restart daemon to pick up config changes\n\
+        /help — this message"
+        .to_string();
+    if !config.commands.is_empty() {
+        text.push_str("\n\nCustom commands:");
+        for cmd in &config.commands {
+            let desc = cmd.description.as_deref().unwrap_or("(no description)");
+            text.push_str(&format!("\n/{} — {}", cmd.name, desc));
+        }
+    }
+    text
+}
+
+/// Handle a TUI slash command. Returns a [`TuiCommandResult`] indicating
+/// whether the command was handled, unrecognized, or requests a daemon restart.
 async fn handle_tui_command(
     command: &str,
     args: &str,
@@ -2567,21 +2585,13 @@ async fn handle_tui_command(
             TuiCommandResult::Handled
         }
         "help" => {
-            let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/devmode — toggle dev mode (on/off/status)\n/update — install latest apiari + swarm from crates.io\n/reload — restart daemon to pick up config changes\n/help — this message"
-                .to_string();
-            if !slot.config.commands.is_empty() {
-                text.push_str("\n\nCustom commands:");
-                for cmd in &slot.config.commands {
-                    let desc = cmd.description.as_deref().unwrap_or("(no description)");
-                    text.push_str(&format!("\n/{} — {}", cmd.name, desc));
-                }
-            }
+            let text = build_help_text(&slot.config);
             reply(responder, socket_server, &slot.name, &text);
             TuiCommandResult::Handled
         }
         "reload" => {
             info!("[{}] running /reload", slot.name);
-            reply(responder, socket_server, &slot.name, "Daemon reloaded.");
+            reply(responder, socket_server, &slot.name, "Restarting daemon...");
             TuiCommandResult::Restart
         }
         "update" => {

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -53,6 +53,16 @@ enum ExitReason {
     Restart,
 }
 
+/// Result of handling a TUI built-in command.
+enum TuiCommandResult {
+    /// Command was not recognized — fall through to coordinator.
+    NotHandled,
+    /// Command was handled.
+    Handled,
+    /// Command requests a daemon restart.
+    Restart,
+}
+
 /// A workspace slot in the daemon — holds per-workspace state.
 struct WorkspaceSlot {
     name: String,
@@ -1672,16 +1682,17 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                     Some((cmd, args)) => (cmd, args.trim()),
                                     None => (rest, ""),
                                 };
-                                let handled = handle_tui_command(
+                                match handle_tui_command(
                                     command,
                                     args,
                                     slot,
                                     &client_req.responder,
                                     &socket_server,
                                     &telegram_channels,
-                                ).await;
-                                if handled {
-                                    continue;
+                                ).await {
+                                    TuiCommandResult::Handled => continue,
+                                    TuiCommandResult::Restart => return ExitReason::Restart,
+                                    TuiCommandResult::NotHandled => {}
                                 }
                                 // Not a built-in command — fall through to coordinator
                             }
@@ -1882,6 +1893,19 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                             }
                                         }
                                     }
+                                    "reload" => {
+                                        info!("[{}] running /reload", slot.name);
+                                        if let Some(ref server) = socket_server {
+                                            server.broadcast_activity("telegram", &slot.name, "assistant_message", "Daemon reloaded.");
+                                        }
+                                        let _ = channel.send_message(&OutboundMessage {
+                                            chat_id,
+                                            text: "Daemon reloaded.".to_string(),
+                                            buttons: vec![],
+                                            topic_id,
+                                        }).await;
+                                        return ExitReason::Restart;
+                                    }
                                     "brief" => {
                                         channel.send_typing(chat_id, topic_id).await;
 
@@ -1914,7 +1938,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                         let _ = channel.send_message(&OutboundMessage { chat_id, text, buttons: vec![], topic_id }).await;
                                     }
                                     "help" => {
-                                        let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/devmode — toggle dev mode (on/off/status)\n/update — install latest apiari + swarm from crates.io\n/help — this message".to_string();
+                                        let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/devmode — toggle dev mode (on/off/status)\n/update — install latest apiari + swarm from crates.io\n/reload — restart daemon to pick up config changes\n/help — this message".to_string();
                                         if !slot.config.commands.is_empty() {
                                             text.push_str("\n\nCustom commands:");
                                             for cmd in &slot.config.commands {
@@ -2412,7 +2436,7 @@ async fn handle_tui_command(
     responder: &mpsc::UnboundedSender<socket::DaemonResponse>,
     socket_server: &Option<Arc<socket::DaemonSocketServer>>,
     telegram_channels: &HashMap<String, TelegramChannel>,
-) -> bool {
+) -> TuiCommandResult {
     /// Send a text response back to the TUI client.
     fn reply(
         responder: &mpsc::UnboundedSender<socket::DaemonResponse>,
@@ -2436,12 +2460,12 @@ async fn handle_tui_command(
         "status" => {
             let summary = build_full_status(slot).await;
             reply(responder, socket_server, &slot.name, &summary);
-            true
+            TuiCommandResult::Handled
         }
         "reset" => {
             let _ = slot.coord_tx.send(CoordinatorJob::ResetSession);
             reply(responder, socket_server, &slot.name, "Session reset.");
-            true
+            TuiCommandResult::Handled
         }
         "clear" => {
             if slot
@@ -2461,7 +2485,7 @@ async fn handle_tui_command(
                     "Error: coordinator task shut down",
                 );
             }
-            true
+            TuiCommandResult::Handled
         }
         "compact" => {
             if slot
@@ -2481,7 +2505,7 @@ async fn handle_tui_command(
                     "Error: coordinator task shut down",
                 );
             }
-            true
+            TuiCommandResult::Handled
         }
         "brief" => {
             let channel = slot
@@ -2529,21 +2553,21 @@ async fn handle_tui_command(
                     "No Telegram channel configured for briefs.",
                 );
             }
-            true
+            TuiCommandResult::Handled
         }
         "config" => {
             let skill_ctx = build_skill_context(&slot.name, &slot.config);
             let text = crate::buzz::coordinator::skills::config::build_config_summary(&skill_ctx);
             reply(responder, socket_server, &slot.name, &text);
-            true
+            TuiCommandResult::Handled
         }
         "devmode" => {
             let text = crate::buzz::coordinator::devmode::handle_command(args);
             reply(responder, socket_server, &slot.name, &text);
-            true
+            TuiCommandResult::Handled
         }
         "help" => {
-            let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/devmode — toggle dev mode (on/off/status)\n/update — install latest apiari + swarm from crates.io\n/help — this message"
+            let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/devmode — toggle dev mode (on/off/status)\n/update — install latest apiari + swarm from crates.io\n/reload — restart daemon to pick up config changes\n/help — this message"
                 .to_string();
             if !slot.config.commands.is_empty() {
                 text.push_str("\n\nCustom commands:");
@@ -2553,7 +2577,12 @@ async fn handle_tui_command(
                 }
             }
             reply(responder, socket_server, &slot.name, &text);
-            true
+            TuiCommandResult::Handled
+        }
+        "reload" => {
+            info!("[{}] running /reload", slot.name);
+            reply(responder, socket_server, &slot.name, "Daemon reloaded.");
+            TuiCommandResult::Restart
         }
         "update" => {
             // Send initial status as a streaming token (Done sent after completion)
@@ -2616,7 +2645,7 @@ async fn handle_tui_command(
                     }
                 }
             }
-            true
+            TuiCommandResult::Handled
         }
         _ => {
             // Check custom commands
@@ -2658,10 +2687,10 @@ async fn handle_tui_command(
                         );
                     }
                 }
-                true
+                TuiCommandResult::Handled
             } else {
                 // Not a known command — let the coordinator handle it
-                false
+                TuiCommandResult::NotHandled
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds a `/reload` built-in command that restarts the daemon process so config/soul/context/playbook changes take effect without leaving the session
- Works from both TUI and Telegram, using the same exec-replace restart mechanism as `/update` (without the cargo install step)
- Added to `/help` output in both TUI and Telegram handlers
- Introduced `TuiCommandResult` enum to allow TUI commands to signal restart (previously `handle_tui_command` returned `bool`)

## Test plan
- [ ] Run `apiari daemon start --foreground`, send `/reload` from TUI — confirm "Daemon reloaded." message and daemon restarts
- [ ] Send `/reload` from Telegram — confirm message and restart
- [ ] Send `/help` — confirm `/reload` appears in the command list
- [ ] Verify other commands (`/status`, `/update`, `/reset`, etc.) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)