### PR TITLE
feat: add /doctor command and config_version field

### DIFF
--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -1189,6 +1189,7 @@ max_session_turns = 0
     #[test]
     fn test_resolve_repos_explicit_override() {
         let config = WorkspaceConfig {
+            config_version: None,
             root: "/tmp/nonexistent".into(),
             repos: vec!["Org/Repo".to_string()],
             authority: WorkspaceAuthority::default(),
@@ -1214,6 +1215,7 @@ max_session_turns = 0
     fn test_resolve_repos_empty_discovers() {
         // With a non-existent root, discover_repos returns empty
         let config = WorkspaceConfig {
+            config_version: None,
             root: "/tmp/nonexistent-dir-12345".into(),
             repos: vec![],
             authority: WorkspaceAuthority::default(),
@@ -1238,6 +1240,7 @@ max_session_turns = 0
     #[test]
     fn test_to_buzz_config() {
         let ws = WorkspaceConfig {
+            config_version: None,
             root: "/tmp".into(),
             repos: vec![],
             authority: WorkspaceAuthority::default(),
@@ -1490,6 +1493,7 @@ max_session_turns = 0
     /// Helper to build a minimal WorkspaceConfig with a GitHub watcher for repo resolution tests.
     fn ws_with_github(ws_repos: Vec<String>, gh_repos: Vec<String>) -> WorkspaceConfig {
         WorkspaceConfig {
+            config_version: None,
             root: "/nonexistent".into(),
             repos: ws_repos,
             authority: WorkspaceAuthority::default(),

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -1101,6 +1101,10 @@ interval_secs = 15
         let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.root, PathBuf::from("/Users/josh/Developer/apiari"));
         assert_eq!(config.repos, vec!["ApiariTools/swarm"]);
+        assert!(
+            config.config_version.is_none(),
+            "missing config_version should default to None"
+        );
         assert!(config.telegram.is_some());
         assert!(config.watchers.github.is_some());
         assert!(config.watchers.swarm.is_some());
@@ -1114,6 +1118,10 @@ root = "/tmp/test"
 "#;
         let config: WorkspaceConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.root, PathBuf::from("/tmp/test"));
+        assert!(
+            config.config_version.is_none(),
+            "missing config_version should default to None"
+        );
         assert!(config.repos.is_empty());
         assert!(config.telegram.is_none());
         assert_eq!(config.coordinator.model, "sonnet");

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -121,9 +121,17 @@ impl MergePrsCapability {
     }
 }
 
+/// Current workspace config version. Bump when adding new fields or changing semantics.
+pub const CURRENT_CONFIG_VERSION: u32 = 1;
+
 /// A fully self-contained workspace configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
+    /// Schema version for forward-compatible config evolution.
+    /// `None` means pre-versioning (version 0).
+    #[serde(default)]
+    pub config_version: Option<u32>,
+
     /// Absolute path to the workspace root.
     pub root: PathBuf,
 

--- a/crates/apiari/src/daemon/doctor.rs
+++ b/crates/apiari/src/daemon/doctor.rs
@@ -1,0 +1,192 @@
+//! `/doctor` — workspace health checker.
+//!
+//! Inspects the workspace config and `.apiari/` scaffold, reports issues,
+//! and optionally fixes them with `--fix`.
+
+use std::path::Path;
+
+use crate::config::{CURRENT_CONFIG_VERSION, WorkspaceConfig};
+
+/// Run the doctor check for a workspace. Returns the report text.
+///
+/// If `fix` is true, missing `.apiari/` files are scaffolded (never overwrites).
+pub fn run(workspace_name: &str, config: &WorkspaceConfig, fix: bool) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    let mut issues = 0u32;
+
+    lines.push(format!(
+        "apiari doctor \u{2014} workspace: {workspace_name}\n"
+    ));
+
+    // ── config_version ───────────────────────────────────────
+    match config.config_version {
+        Some(v) if v >= CURRENT_CONFIG_VERSION => {
+            lines.push(format!("\u{2705} config_version: {v} (current)"));
+        }
+        Some(v) => {
+            lines.push(format!(
+                "\u{26a0}\u{fe0f}  config_version: {v} \u{2014} current is {CURRENT_CONFIG_VERSION}. \
+                 Review the changelog for what\u{2019}s new."
+            ));
+            issues += 1;
+        }
+        None => {
+            lines.push(format!(
+                "\u{26a0}\u{fe0f}  config_version missing \u{2014} add `config_version = {CURRENT_CONFIG_VERSION}` \
+                 to your workspace TOML"
+            ));
+            issues += 1;
+        }
+    }
+
+    // ── .apiari/ files ───────────────────────────────────────
+    let root = &config.root;
+    let apiari_dir = root.join(".apiari");
+
+    // soul.md
+    let soul_path = apiari_dir.join("soul.md");
+    if soul_path.exists() {
+        lines.push("\u{2705} .apiari/soul.md exists".to_string());
+    } else {
+        lines.push(
+            "\u{26a0}\u{fe0f}  .apiari/soul.md not found \u{2014} create one to customize coordinator personality"
+                .to_string(),
+        );
+        issues += 1;
+        if fix {
+            scaffold_soul(&soul_path);
+        }
+    }
+
+    // context.md
+    let context_path = apiari_dir.join("context.md");
+    if context_path.exists() {
+        lines.push("\u{2705} .apiari/context.md exists".to_string());
+    } else {
+        lines.push(
+            "\u{26a0}\u{fe0f}  .apiari/context.md not found \u{2014} create one to give the coordinator project context"
+                .to_string(),
+        );
+        issues += 1;
+        if fix {
+            scaffold_context(&context_path);
+        }
+    }
+
+    // skills/
+    let skills_dir = apiari_dir.join("skills");
+    if skills_dir.is_dir() {
+        let count = std::fs::read_dir(&skills_dir)
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+                    .count()
+            })
+            .unwrap_or(0);
+        lines.push(format!(
+            "\u{2705} .apiari/skills/ exists ({count} playbook{})",
+            if count == 1 { "" } else { "s" }
+        ));
+    } else {
+        lines.push(
+            "\u{26a0}\u{fe0f}  .apiari/skills/ not found \u{2014} create it to add coordinator playbooks"
+                .to_string(),
+        );
+        issues += 1;
+        if fix {
+            let _ = std::fs::create_dir_all(&skills_dir);
+        }
+    }
+
+    // ── binary version ───────────────────────────────────────
+    let current_version = env!("CARGO_PKG_VERSION");
+    let latest = check_latest_release();
+    match latest {
+        Some(ref tag) => {
+            let tag_version = tag.strip_prefix('v').unwrap_or(tag);
+            if tag_version == current_version {
+                lines.push(format!("\u{2705} apiari v{current_version} (latest)"));
+            } else {
+                lines.push(format!(
+                    "\u{26a0}\u{fe0f}  apiari v{current_version} \u{2014} latest is {tag}. \
+                     Run /update to upgrade."
+                ));
+                issues += 1;
+            }
+        }
+        None => {
+            lines.push(format!(
+                "\u{2705} apiari v{current_version} (could not check latest)"
+            ));
+        }
+    }
+
+    // ── summary ──────────────────────────────────────────────
+    if issues > 0 && !fix {
+        lines.push(format!(
+            "\n{issues} issue{} found. Run `/doctor --fix` to scaffold missing files.",
+            if issues == 1 { "" } else { "s" }
+        ));
+    } else if issues > 0 && fix {
+        lines.push("\n\u{2705} Scaffolded missing files.".to_string());
+    }
+
+    lines.join("\n")
+}
+
+/// Check the latest GitHub release tag. Returns `None` on any error.
+fn check_latest_release() -> Option<String> {
+    let output = std::process::Command::new("gh")
+        .args([
+            "release",
+            "view",
+            "--repo",
+            "ApiariTools/apiari",
+            "--json",
+            "tagName",
+            "-q",
+            ".tagName",
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let tag = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if tag.is_empty() { None } else { Some(tag) }
+}
+
+fn scaffold_soul(path: &Path) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let template = "\
+# Soul
+
+Communication style and behavioral guidelines for the coordinator.
+";
+    let _ = std::fs::write(path, template);
+}
+
+fn scaffold_context(path: &Path) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let template = "\
+# Project Name
+
+What is this project? (1-2 sentences)
+
+## Stack
+
+## Team / ownership
+
+## Key conventions
+
+## Anything the coordinator should always know
+";
+    let _ = std::fs::write(path, template);
+}

--- a/crates/apiari/src/daemon/doctor.rs
+++ b/crates/apiari/src/daemon/doctor.rs
@@ -3,6 +3,8 @@
 //! Inspects the workspace config and `.apiari/` scaffold, reports issues,
 //! and optionally fixes them with `--fix`.
 
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::Path;
 
 use crate::config::{CURRENT_CONFIG_VERSION, WorkspaceConfig};
@@ -13,6 +15,7 @@ use crate::config::{CURRENT_CONFIG_VERSION, WorkspaceConfig};
 pub fn run(workspace_name: &str, config: &WorkspaceConfig, fix: bool) -> String {
     let mut lines: Vec<String> = Vec::new();
     let mut issues = 0u32;
+    let mut scaffolded = 0u32;
 
     lines.push(format!(
         "apiari doctor \u{2014} workspace: {workspace_name}\n"
@@ -20,8 +23,15 @@ pub fn run(workspace_name: &str, config: &WorkspaceConfig, fix: bool) -> String 
 
     // ── config_version ───────────────────────────────────────
     match config.config_version {
-        Some(v) if v >= CURRENT_CONFIG_VERSION => {
+        Some(v) if v == CURRENT_CONFIG_VERSION => {
             lines.push(format!("\u{2705} config_version: {v} (current)"));
+        }
+        Some(v) if v > CURRENT_CONFIG_VERSION => {
+            lines.push(format!(
+                "\u{26a0}\u{fe0f}  config_version: {v} \u{2014} this binary only knows up to \
+                 {CURRENT_CONFIG_VERSION}. You may need to update apiari."
+            ));
+            issues += 1;
         }
         Some(v) => {
             lines.push(format!(
@@ -53,8 +63,8 @@ pub fn run(workspace_name: &str, config: &WorkspaceConfig, fix: bool) -> String 
                 .to_string(),
         );
         issues += 1;
-        if fix {
-            scaffold_soul(&soul_path);
+        if fix && scaffold_soul(&soul_path) {
+            scaffolded += 1;
         }
     }
 
@@ -68,8 +78,8 @@ pub fn run(workspace_name: &str, config: &WorkspaceConfig, fix: bool) -> String 
                 .to_string(),
         );
         issues += 1;
-        if fix {
-            scaffold_context(&context_path);
+        if fix && scaffold_context(&context_path) {
+            scaffolded += 1;
         }
     }
 
@@ -94,8 +104,8 @@ pub fn run(workspace_name: &str, config: &WorkspaceConfig, fix: bool) -> String 
                 .to_string(),
         );
         issues += 1;
-        if fix {
-            let _ = std::fs::create_dir_all(&skills_dir);
+        if fix && std::fs::create_dir_all(&skills_dir).is_ok() {
+            scaffolded += 1;
         }
     }
 
@@ -123,13 +133,24 @@ pub fn run(workspace_name: &str, config: &WorkspaceConfig, fix: bool) -> String 
     }
 
     // ── summary ──────────────────────────────────────────────
-    if issues > 0 && !fix {
+    if fix && scaffolded > 0 {
+        lines.push(format!(
+            "\n\u{2705} Scaffolded {scaffolded} missing file{}.",
+            if scaffolded == 1 { "" } else { "s" }
+        ));
+    }
+    let unfixable = issues - scaffolded;
+    if unfixable > 0 {
+        lines.push(format!(
+            "\n{unfixable} issue{} remaining that {} manual attention.",
+            if unfixable == 1 { "" } else { "s" },
+            if unfixable == 1 { "needs" } else { "need" }
+        ));
+    } else if !fix && issues > 0 {
         lines.push(format!(
             "\n{issues} issue{} found. Run `/doctor --fix` to scaffold missing files.",
             if issues == 1 { "" } else { "s" }
         ));
-    } else if issues > 0 && fix {
-        lines.push("\n\u{2705} Scaffolded missing files.".to_string());
     }
 
     lines.join("\n")
@@ -159,7 +180,8 @@ fn check_latest_release() -> Option<String> {
     if tag.is_empty() { None } else { Some(tag) }
 }
 
-fn scaffold_soul(path: &Path) {
+/// Atomically create soul.md only if it doesn't exist. Returns true on success.
+fn scaffold_soul(path: &Path) -> bool {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -168,10 +190,11 @@ fn scaffold_soul(path: &Path) {
 
 Communication style and behavioral guidelines for the coordinator.
 ";
-    let _ = std::fs::write(path, template);
+    write_new_file(path, template)
 }
 
-fn scaffold_context(path: &Path) {
+/// Atomically create context.md only if it doesn't exist. Returns true on success.
+fn scaffold_context(path: &Path) -> bool {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -188,5 +211,140 @@ What is this project? (1-2 sentences)
 
 ## Anything the coordinator should always know
 ";
-    let _ = std::fs::write(path, template);
+    write_new_file(path, template)
+}
+
+/// Write `contents` to `path` only if the file does not already exist (atomic create).
+fn write_new_file(path: &Path, contents: &str) -> bool {
+    match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(mut f) => f.write_all(contents.as_bytes()).is_ok(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::*;
+
+    /// Build a minimal WorkspaceConfig pointing at `root`.
+    fn test_config(root: std::path::PathBuf, config_version: Option<u32>) -> WorkspaceConfig {
+        WorkspaceConfig {
+            config_version,
+            root,
+            repos: vec![],
+            authority: WorkspaceAuthority::default(),
+            capabilities: WorkspaceCapabilities::default(),
+            telegram: None,
+            coordinator: CoordinatorConfig::default(),
+            watchers: WatchersConfig::default(),
+            swarm: SwarmConfig::default(),
+            pipeline: PipelineConfig::default(),
+            commands: vec![],
+            morning_brief: None,
+            daemon_tcp_port: None,
+            daemon_tcp_bind: None,
+            daemon_host: None,
+            daemon_port: None,
+            daemon_endpoints: vec![],
+            shells: ShellsConfig::default(),
+        }
+    }
+
+    #[test]
+    fn test_config_version_none_warns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path().to_path_buf(), None);
+        let text = run("test", &config, false);
+        assert!(text.contains("config_version missing"), "{text}");
+        assert!(text.contains("issue"), "{text}");
+    }
+
+    #[test]
+    fn test_config_version_current_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Create .apiari scaffold so those don't count as issues
+        let apiari = tmp.path().join(".apiari");
+        std::fs::create_dir_all(apiari.join("skills")).unwrap();
+        std::fs::write(apiari.join("soul.md"), "x").unwrap();
+        std::fs::write(apiari.join("context.md"), "x").unwrap();
+
+        let config = test_config(tmp.path().to_path_buf(), Some(CURRENT_CONFIG_VERSION));
+        let text = run("test", &config, false);
+        assert!(
+            text.contains(&format!(
+                "config_version: {CURRENT_CONFIG_VERSION} (current)"
+            )),
+            "{text}"
+        );
+        // No issues (besides possibly version check)
+        assert!(!text.contains("config_version missing"), "{text}");
+    }
+
+    #[test]
+    fn test_config_version_older_warns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path().to_path_buf(), Some(0));
+        let text = run("test", &config, false);
+        assert!(text.contains("config_version: 0"), "{text}");
+        assert!(text.contains("current is"), "{text}");
+    }
+
+    #[test]
+    fn test_config_version_newer_warns_incompatible() {
+        let tmp = tempfile::tempdir().unwrap();
+        let future_version = CURRENT_CONFIG_VERSION + 1;
+        let config = test_config(tmp.path().to_path_buf(), Some(future_version));
+        let text = run("test", &config, false);
+        assert!(
+            text.contains("this binary only knows up to"),
+            "should warn about newer version: {text}"
+        );
+    }
+
+    #[test]
+    fn test_fix_creates_missing_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path().to_path_buf(), Some(CURRENT_CONFIG_VERSION));
+
+        let text = run("test", &config, true);
+        assert!(text.contains("Scaffolded"), "{text}");
+
+        // Files should now exist
+        assert!(tmp.path().join(".apiari/soul.md").exists());
+        assert!(tmp.path().join(".apiari/context.md").exists());
+        assert!(tmp.path().join(".apiari/skills").is_dir());
+    }
+
+    #[test]
+    fn test_fix_does_not_overwrite_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let apiari = tmp.path().join(".apiari");
+        std::fs::create_dir_all(apiari.join("skills")).unwrap();
+        std::fs::write(apiari.join("soul.md"), "custom soul").unwrap();
+        std::fs::write(apiari.join("context.md"), "custom context").unwrap();
+
+        let config = test_config(tmp.path().to_path_buf(), Some(CURRENT_CONFIG_VERSION));
+        let _ = run("test", &config, true);
+
+        // Originals should be untouched
+        assert_eq!(
+            std::fs::read_to_string(apiari.join("soul.md")).unwrap(),
+            "custom soul"
+        );
+        assert_eq!(
+            std::fs::read_to_string(apiari.join("context.md")).unwrap(),
+            "custom context"
+        );
+    }
+
+    #[test]
+    fn test_fix_summary_distinguishes_fixable_from_unfixable() {
+        let tmp = tempfile::tempdir().unwrap();
+        // config_version None = unfixable, missing files = fixable
+        let config = test_config(tmp.path().to_path_buf(), None);
+        let text = run("test", &config, true);
+        assert!(text.contains("Scaffolded"), "{text}");
+        assert!(text.contains("manual attention"), "{text}");
+    }
 }

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -3,6 +3,7 @@
 //! Discovers workspace configs, builds per-workspace watcher registries,
 //! shares Telegram connections by bot_token, and routes messages by (chat_id, topic_id).
 
+pub mod doctor;
 pub mod morning_brief;
 pub mod socket;
 
@@ -50,16 +51,6 @@ enum ExitReason {
     /// Error — daemon should restart.
     Error(color_eyre::eyre::Error),
     /// Self-update — exec the new binary.
-    Restart,
-}
-
-/// Result of handling a TUI built-in command.
-enum TuiCommandResult {
-    /// Command was not recognized — fall through to coordinator.
-    NotHandled,
-    /// Command was handled.
-    Handled,
-    /// Command requests a daemon restart.
     Restart,
 }
 
@@ -1682,17 +1673,16 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                     Some((cmd, args)) => (cmd, args.trim()),
                                     None => (rest, ""),
                                 };
-                                match handle_tui_command(
+                                let handled = handle_tui_command(
                                     command,
                                     args,
                                     slot,
                                     &client_req.responder,
                                     &socket_server,
                                     &telegram_channels,
-                                ).await {
-                                    TuiCommandResult::Handled => continue,
-                                    TuiCommandResult::Restart => return ExitReason::Restart,
-                                    TuiCommandResult::NotHandled => {}
+                                ).await;
+                                if handled {
+                                    continue;
                                 }
                                 // Not a built-in command — fall through to coordinator
                             }
@@ -1893,19 +1883,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                             }
                                         }
                                     }
-                                    "reload" => {
-                                        info!("[{}] running /reload", slot.name);
-                                        if let Some(ref server) = socket_server {
-                                            server.broadcast_activity("telegram", &slot.name, "assistant_message", "Restarting daemon...");
-                                        }
-                                        let _ = channel.send_message(&OutboundMessage {
-                                            chat_id,
-                                            text: "Restarting daemon...".to_string(),
-                                            buttons: vec![],
-                                            topic_id,
-                                        }).await;
-                                        return ExitReason::Restart;
-                                    }
                                     "brief" => {
                                         channel.send_typing(chat_id, topic_id).await;
 
@@ -1937,8 +1914,27 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                         }
                                         let _ = channel.send_message(&OutboundMessage { chat_id, text, buttons: vec![], topic_id }).await;
                                     }
+                                    "doctor" => {
+                                        let fix = args.trim() == "--fix";
+                                        let ws_name = slot.name.clone();
+                                        let ws_config = slot.config.clone();
+                                        let text = tokio::task::spawn_blocking(move || {
+                                            doctor::run(&ws_name, &ws_config, fix)
+                                        }).await.unwrap_or_else(|e| format!("doctor failed: {e}"));
+                                        if let Some(ref server) = socket_server {
+                                            server.broadcast_activity("telegram", &slot.name, "assistant_message", &text);
+                                        }
+                                        let _ = channel.send_message(&OutboundMessage { chat_id, text, buttons: vec![], topic_id }).await;
+                                    }
                                     "help" => {
-                                        let text = build_help_text(&slot.config);
+                                        let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/doctor — check workspace health (--fix to scaffold missing files)\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/devmode — toggle dev mode (on/off/status)\n/update — install latest apiari + swarm from crates.io\n/help — this message".to_string();
+                                        if !slot.config.commands.is_empty() {
+                                            text.push_str("\n\nCustom commands:");
+                                            for cmd in &slot.config.commands {
+                                                let desc = cmd.description.as_deref().unwrap_or("(no description)");
+                                                text.push_str(&format!("\n/{} — {}", cmd.name, desc));
+                                            }
+                                        }
                                         if let Some(ref server) = socket_server {
                                             server.broadcast_activity("telegram", &slot.name, "assistant_message", &text);
                                         }
@@ -2421,34 +2417,7 @@ fn remove_pid() {
     let _ = std::fs::remove_file(pid_path());
 }
 
-/// Build the `/help` text, appending any custom commands from the workspace config.
-fn build_help_text(config: &WorkspaceConfig) -> String {
-    let mut text = concat!(
-        "Built-in commands:\n",
-        "/status — show open signals\n",
-        "/config — show workspace configuration summary\n",
-        "/brief — generate morning brief on demand\n",
-        "/reset — reset coordinator session\n",
-        "/clear — clear session (hard reset, no context carried forward)\n",
-        "/compact — compact session (summarize key context to memory, then reset)\n",
-        "/devmode — toggle dev mode (on/off/status)\n",
-        "/update — install latest apiari + swarm from crates.io\n",
-        "/reload — restart daemon to pick up config changes\n",
-        "/help — this message",
-    )
-    .to_string();
-    if !config.commands.is_empty() {
-        text.push_str("\n\nCustom commands:");
-        for cmd in &config.commands {
-            let desc = cmd.description.as_deref().unwrap_or("(no description)");
-            text.push_str(&format!("\n/{} — {}", cmd.name, desc));
-        }
-    }
-    text
-}
-
-/// Handle a TUI slash command. Returns a [`TuiCommandResult`] indicating
-/// whether the command was handled, unrecognized, or requests a daemon restart.
+/// Handle a TUI slash command. Returns `true` if the command was handled.
 async fn handle_tui_command(
     command: &str,
     args: &str,
@@ -2456,7 +2425,7 @@ async fn handle_tui_command(
     responder: &mpsc::UnboundedSender<socket::DaemonResponse>,
     socket_server: &Option<Arc<socket::DaemonSocketServer>>,
     telegram_channels: &HashMap<String, TelegramChannel>,
-) -> TuiCommandResult {
+) -> bool {
     /// Send a text response back to the TUI client.
     fn reply(
         responder: &mpsc::UnboundedSender<socket::DaemonResponse>,
@@ -2480,12 +2449,12 @@ async fn handle_tui_command(
         "status" => {
             let summary = build_full_status(slot).await;
             reply(responder, socket_server, &slot.name, &summary);
-            TuiCommandResult::Handled
+            true
         }
         "reset" => {
             let _ = slot.coord_tx.send(CoordinatorJob::ResetSession);
             reply(responder, socket_server, &slot.name, "Session reset.");
-            TuiCommandResult::Handled
+            true
         }
         "clear" => {
             if slot
@@ -2505,7 +2474,7 @@ async fn handle_tui_command(
                     "Error: coordinator task shut down",
                 );
             }
-            TuiCommandResult::Handled
+            true
         }
         "compact" => {
             if slot
@@ -2525,7 +2494,7 @@ async fn handle_tui_command(
                     "Error: coordinator task shut down",
                 );
             }
-            TuiCommandResult::Handled
+            true
         }
         "brief" => {
             let channel = slot
@@ -2573,28 +2542,41 @@ async fn handle_tui_command(
                     "No Telegram channel configured for briefs.",
                 );
             }
-            TuiCommandResult::Handled
+            true
         }
         "config" => {
             let skill_ctx = build_skill_context(&slot.name, &slot.config);
             let text = crate::buzz::coordinator::skills::config::build_config_summary(&skill_ctx);
             reply(responder, socket_server, &slot.name, &text);
-            TuiCommandResult::Handled
+            true
         }
         "devmode" => {
             let text = crate::buzz::coordinator::devmode::handle_command(args);
             reply(responder, socket_server, &slot.name, &text);
-            TuiCommandResult::Handled
+            true
+        }
+        "doctor" => {
+            let fix = args.trim() == "--fix";
+            let ws_name = slot.name.clone();
+            let ws_config = slot.config.clone();
+            let text = tokio::task::spawn_blocking(move || doctor::run(&ws_name, &ws_config, fix))
+                .await
+                .unwrap_or_else(|e| format!("doctor failed: {e}"));
+            reply(responder, socket_server, &slot.name, &text);
+            true
         }
         "help" => {
-            let text = build_help_text(&slot.config);
+            let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/doctor — check workspace health (--fix to scaffold missing files)\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/devmode — toggle dev mode (on/off/status)\n/update — install latest apiari + swarm from crates.io\n/help — this message"
+                .to_string();
+            if !slot.config.commands.is_empty() {
+                text.push_str("\n\nCustom commands:");
+                for cmd in &slot.config.commands {
+                    let desc = cmd.description.as_deref().unwrap_or("(no description)");
+                    text.push_str(&format!("\n/{} — {}", cmd.name, desc));
+                }
+            }
             reply(responder, socket_server, &slot.name, &text);
-            TuiCommandResult::Handled
-        }
-        "reload" => {
-            info!("[{}] running /reload", slot.name);
-            reply(responder, socket_server, &slot.name, "Restarting daemon...");
-            TuiCommandResult::Restart
+            true
         }
         "update" => {
             // Send initial status as a streaming token (Done sent after completion)
@@ -2657,7 +2639,7 @@ async fn handle_tui_command(
                     }
                 }
             }
-            TuiCommandResult::Handled
+            true
         }
         _ => {
             // Check custom commands
@@ -2699,10 +2681,10 @@ async fn handle_tui_command(
                         );
                     }
                 }
-                TuiCommandResult::Handled
+                true
             } else {
                 // Not a known command — let the coordinator handle it
-                TuiCommandResult::NotHandled
+                false
             }
         }
     }

--- a/crates/apiari/src/init.rs
+++ b/crates/apiari/src/init.rs
@@ -4,7 +4,7 @@ use color_eyre::eyre::{Result, WrapErr};
 use std::io::{IsTerminal, Read, Write};
 use std::path::Path;
 
-use crate::config::workspaces_dir;
+use crate::config::{CURRENT_CONFIG_VERSION, workspaces_dir};
 
 /// Generate a template workspace TOML.
 fn workspace_template(root: &Path, coordinator_name: &str) -> String {
@@ -25,7 +25,7 @@ fn workspace_template(root: &Path, coordinator_name: &str) -> String {
         .join("\n");
 
     format!(
-        r#"config_version = 1
+        r#"config_version = {CURRENT_CONFIG_VERSION}
 root = "{root_str}"
 repos = []  # empty = auto-discover from workspace root
 

--- a/crates/apiari/src/init.rs
+++ b/crates/apiari/src/init.rs
@@ -25,7 +25,8 @@ fn workspace_template(root: &Path, coordinator_name: &str) -> String {
         .join("\n");
 
     format!(
-        r#"root = "{root_str}"
+        r#"config_version = 1
+root = "{root_str}"
 repos = []  # empty = auto-discover from workspace root
 
 # [telegram]


### PR DESCRIPTION
## Summary
- Adds `config_version: Option<u32>` to `WorkspaceConfig` with `CURRENT_CONFIG_VERSION = 1`. `apiari init` sets it on new configs; existing configs without it default to `None` (pre-versioning).
- Adds `/doctor` built-in command (works from both TUI and Telegram) that checks config version, `.apiari/` scaffold files (soul.md, context.md, skills/), and binary version against the latest GitHub release.
- Supports `--fix` flag to scaffold missing `.apiari/` files using the same templates as `apiari init`, never overwriting existing files.

## Test plan
- [ ] Run `apiari init` on a fresh directory and verify `config_version = 1` appears in the generated TOML
- [ ] Load an existing config without `config_version` and verify it deserializes correctly (defaults to `None`)
- [ ] Run `/doctor` from TUI — verify it reports config version, .apiari/ file status, and binary version
- [ ] Run `/doctor` from Telegram — verify same output
- [ ] Run `/doctor --fix` with missing `.apiari/soul.md` and verify it gets created
- [ ] Run `/doctor --fix` with existing files and verify nothing is overwritten
- [ ] Run `/help` and verify `/doctor` appears in the command list

🤖 Generated with [Claude Code](https://claude.com/claude-code)