### PR TITLE
fix: reply with error for unrecognized TUI slash commands

### DIFF
--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1684,7 +1684,19 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                 if handled {
                                     continue;
                                 }
-                                // Not a built-in command — fall through to coordinator
+                                // Unknown slash command — reply with error
+                                let err_text = format!("Unknown command: /{}. Run /help for available commands.", command);
+                                let _ = client_req.responder.send(socket::DaemonResponse::Token {
+                                    workspace: ws_name.clone(),
+                                    text: err_text.clone(),
+                                });
+                                let _ = client_req.responder.send(socket::DaemonResponse::Done {
+                                    workspace: ws_name.clone(),
+                                });
+                                if let Some(server) = &socket_server {
+                                    server.broadcast_activity("tui", &ws_name, "assistant_message", &err_text);
+                                }
+                                continue;
                             }
 
                             let ws_name_for_err = ws_name.clone();


### PR DESCRIPTION
## Summary
- When a user types an unknown `/command` in the TUI chat, the daemon now replies with `"Unknown command: /{command}. Run /help for available commands."` instead of silently passing it to the coordinator LLM.
- Only changes the TUI command handler path in the caller (~line 1684 of `daemon/mod.rs`). The Telegram handler already handles this correctly and is untouched.

## Test plan
- [ ] Type an unknown command like `/foobar` in the TUI chat and verify the error message appears
- [ ] Verify known commands like `/status` and `/help` still work normally
- [ ] Verify Telegram unknown command handling is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)