### PR TITLE
fix: inject /doctor output into coordinator context

### DIFF
--- a/crates/apiari/src/buzz/coordinator/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/mod.rs
@@ -97,6 +97,9 @@ pub struct Coordinator {
     safety_hooks: Option<Box<dyn SafetyHooks>>,
     /// Number of turns used in the last completed session.
     last_num_turns: u64,
+    /// Context to prepend to the next user message (e.g. /doctor output).
+    /// Consumed on the next `take_pending_context()` call.
+    pending_context: Option<String>,
 }
 
 impl Coordinator {
@@ -116,6 +119,7 @@ impl Coordinator {
             settings: None,
             safety_hooks: None,
             last_num_turns: 0,
+            pending_context: None,
         }
     }
 
@@ -127,6 +131,18 @@ impl Coordinator {
     /// Set extra context to include in the system prompt (e.g. skills prompt).
     pub fn set_extra_context(&mut self, context: String) {
         self.extra_context = Some(context);
+    }
+
+    /// Queue context to be prepended to the next user message dispatched to
+    /// the coordinator. Used for built-in command output (e.g. /doctor) that
+    /// the coordinator should see without triggering a separate LLM turn.
+    pub fn set_pending_context(&mut self, context: String) {
+        self.pending_context = Some(context);
+    }
+
+    /// Take (and clear) any pending context queued via `set_pending_context`.
+    pub fn take_pending_context(&mut self) -> Option<String> {
+        self.pending_context.take()
     }
 
     /// Set a custom prompt preamble (replaces default identity/role sections).

--- a/crates/apiari/src/buzz/coordinator/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/mod.rs
@@ -755,6 +755,7 @@ impl Coordinator {
         info!("coordinator session reset");
         self.session_id = None;
         self.session_token = None;
+        self.pending_context = None;
     }
 }
 

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -118,11 +118,10 @@ enum CoordinatorJob {
         socket_server: Option<Arc<socket::DaemonSocketServer>>,
         slot_name: String,
     },
-    /// Inject context into the coordinator session without streaming tokens
-    /// to the user or incrementing the turn count. Used for built-in command
-    /// output (e.g. /doctor) that the coordinator should see but the user
-    /// has already received directly.
-    InjectContext { text: String, ws_name: String },
+    /// Queue context to be prepended to the next user message. Used for
+    /// built-in command output (e.g. /doctor) that the coordinator should
+    /// see without triggering a separate LLM turn.
+    InjectContext { text: String },
     /// Coordinator follow-through triggered by a signal hook.
     SignalFollowThrough {
         signals: Vec<String>,
@@ -357,12 +356,20 @@ async fn run_coordinator_task(
                     }
                 };
 
+                // Prepend any pending context (e.g. /doctor output) to
+                // the user message so the coordinator sees it inline.
+                let dispatch_text = if let Some(ctx) = coordinator.take_pending_context() {
+                    format!("{ctx}\n\n---\n\nUser message: {text}")
+                } else {
+                    text.clone()
+                };
+
                 let name_for_cb = ws_name.clone();
                 let model_for_cb = coordinator.model().to_string();
                 let responder_for_cb = responder.clone();
 
                 let result = coordinator
-                    .dispatch_message(&text, bundle, |event| match event {
+                    .dispatch_message(&dispatch_text, bundle, |event| match event {
                         CoordinatorEvent::Token(t) => {
                             let _ = responder_for_cb.send(socket::DaemonResponse::Token {
                                 workspace: name_for_cb.clone(),
@@ -470,40 +477,12 @@ async fn run_coordinator_task(
                 }
             }
 
-            CoordinatorJob::InjectContext { text, ws_name } => {
-                let bundle = match coordinator.prepare_dispatch(&store) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        warn!("[{ws_name}] failed to inject context: {e}");
-                        continue;
-                    }
-                };
-
-                // Dispatch to the coordinator so the context enters the
-                // session, but silently discard response tokens — the user
-                // already saw the command output directly.
-                let result = coordinator
-                    .dispatch_message(&text, bundle, |_event| {})
-                    .await;
-
-                // Persist as a system-sourced context message (not a user
-                // chat message) so it shows up in conversation history.
-                {
-                    let conv = ConversationStore::new(store.conn(), store.workspace());
-                    if let Err(e) = conv.save_message("user", &text, Some("system"), None, None) {
-                        warn!("[{ws_name}] failed to save injected context: {e}");
-                    }
-                }
-
-                if let Err(e) = result {
-                    warn!("[{ws_name}] context injection dispatch failed: {e}");
-                    if coordinator.has_session() {
-                        coordinator.reset_session();
-                        turn_count = 0;
-                    }
-                }
-                // Deliberately do NOT increment turn_count — injected
-                // context should not push the session toward auto-compact.
+            CoordinatorJob::InjectContext { text } => {
+                // Store context on the coordinator so it is prepended to the
+                // next real user message. No LLM turn is triggered here —
+                // the coordinator will see the context when the user sends
+                // their next message.
+                coordinator.set_pending_context(text);
             }
 
             CoordinatorJob::ResetSession => {
@@ -1729,7 +1708,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                     if let Some(context) = inject_context {
                                         let job = CoordinatorJob::InjectContext {
                                             text: context,
-                                            ws_name: ws_name.clone(),
                                         };
                                         if slot.coord_tx.send(job).is_err() {
                                             warn!("[{ws_name}] failed to inject command context: coordinator task shut down");

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -118,6 +118,11 @@ enum CoordinatorJob {
         socket_server: Option<Arc<socket::DaemonSocketServer>>,
         slot_name: String,
     },
+    /// Inject context into the coordinator session without streaming tokens
+    /// to the user or incrementing the turn count. Used for built-in command
+    /// output (e.g. /doctor) that the coordinator should see but the user
+    /// has already received directly.
+    InjectContext { text: String, ws_name: String },
     /// Coordinator follow-through triggered by a signal hook.
     SignalFollowThrough {
         signals: Vec<String>,
@@ -463,6 +468,42 @@ async fn run_coordinator_task(
                         });
                     }
                 }
+            }
+
+            CoordinatorJob::InjectContext { text, ws_name } => {
+                let bundle = match coordinator.prepare_dispatch(&store) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        warn!("[{ws_name}] failed to inject context: {e}");
+                        continue;
+                    }
+                };
+
+                // Dispatch to the coordinator so the context enters the
+                // session, but silently discard response tokens — the user
+                // already saw the command output directly.
+                let result = coordinator
+                    .dispatch_message(&text, bundle, |_event| {})
+                    .await;
+
+                // Persist as a system-sourced context message (not a user
+                // chat message) so it shows up in conversation history.
+                {
+                    let conv = ConversationStore::new(store.conn(), store.workspace());
+                    if let Err(e) = conv.save_message("user", &text, Some("system"), None, None) {
+                        warn!("[{ws_name}] failed to save injected context: {e}");
+                    }
+                }
+
+                if let Err(e) = result {
+                    warn!("[{ws_name}] context injection dispatch failed: {e}");
+                    if coordinator.has_session() {
+                        coordinator.reset_session();
+                        turn_count = 0;
+                    }
+                }
+                // Deliberately do NOT increment turn_count — injected
+                // context should not push the session toward auto-compact.
             }
 
             CoordinatorJob::ResetSession => {
@@ -1686,13 +1727,13 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                     // (e.g. /doctor output), inject it so the coordinator
                                     // can reference the results in future turns.
                                     if let Some(context) = inject_context {
-                                        let job = CoordinatorJob::TuiChat {
+                                        let job = CoordinatorJob::InjectContext {
                                             text: context,
-                                            responder: client_req.responder.clone(),
-                                            socket_server: socket_server.clone(),
-                                            ws_name,
+                                            ws_name: ws_name.clone(),
                                         };
-                                        let _ = slot.coord_tx.send(job);
+                                        if slot.coord_tx.send(job).is_err() {
+                                            warn!("[{ws_name}] failed to inject command context: coordinator task shut down");
+                                        }
                                     }
                                     continue;
                                 }
@@ -2429,7 +2470,10 @@ fn remove_pid() {
     let _ = std::fs::remove_file(pid_path());
 }
 
-/// Handle a TUI slash command. Returns `true` if the command was handled.
+/// Handle a TUI slash command. Returns `(handled, inject_context)` where
+/// `handled` is `true` if the command was recognized and processed, and
+/// `inject_context` is an optional string to forward into the coordinator
+/// session so it can reference the output in future turns (e.g. /doctor).
 async fn handle_tui_command(
     command: &str,
     args: &str,

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1673,7 +1673,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                     Some((cmd, args)) => (cmd, args.trim()),
                                     None => (rest, ""),
                                 };
-                                let handled = handle_tui_command(
+                                let (handled, inject_context) = handle_tui_command(
                                     command,
                                     args,
                                     slot,
@@ -1682,6 +1682,18 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                     &telegram_channels,
                                 ).await;
                                 if handled {
+                                    // If the command produced context for the coordinator
+                                    // (e.g. /doctor output), inject it so the coordinator
+                                    // can reference the results in future turns.
+                                    if let Some(context) = inject_context {
+                                        let job = CoordinatorJob::TuiChat {
+                                            text: context,
+                                            responder: client_req.responder.clone(),
+                                            socket_server: socket_server.clone(),
+                                            ws_name,
+                                        };
+                                        let _ = slot.coord_tx.send(job);
+                                    }
                                     continue;
                                 }
                                 // Not a built-in command — fall through to coordinator
@@ -2425,7 +2437,7 @@ async fn handle_tui_command(
     responder: &mpsc::UnboundedSender<socket::DaemonResponse>,
     socket_server: &Option<Arc<socket::DaemonSocketServer>>,
     telegram_channels: &HashMap<String, TelegramChannel>,
-) -> bool {
+) -> (bool, Option<String>) {
     /// Send a text response back to the TUI client.
     fn reply(
         responder: &mpsc::UnboundedSender<socket::DaemonResponse>,
@@ -2449,12 +2461,12 @@ async fn handle_tui_command(
         "status" => {
             let summary = build_full_status(slot).await;
             reply(responder, socket_server, &slot.name, &summary);
-            true
+            (true, None)
         }
         "reset" => {
             let _ = slot.coord_tx.send(CoordinatorJob::ResetSession);
             reply(responder, socket_server, &slot.name, "Session reset.");
-            true
+            (true, None)
         }
         "clear" => {
             if slot
@@ -2474,7 +2486,7 @@ async fn handle_tui_command(
                     "Error: coordinator task shut down",
                 );
             }
-            true
+            (true, None)
         }
         "compact" => {
             if slot
@@ -2494,7 +2506,7 @@ async fn handle_tui_command(
                     "Error: coordinator task shut down",
                 );
             }
-            true
+            (true, None)
         }
         "brief" => {
             let channel = slot
@@ -2542,18 +2554,18 @@ async fn handle_tui_command(
                     "No Telegram channel configured for briefs.",
                 );
             }
-            true
+            (true, None)
         }
         "config" => {
             let skill_ctx = build_skill_context(&slot.name, &slot.config);
             let text = crate::buzz::coordinator::skills::config::build_config_summary(&skill_ctx);
             reply(responder, socket_server, &slot.name, &text);
-            true
+            (true, None)
         }
         "devmode" => {
             let text = crate::buzz::coordinator::devmode::handle_command(args);
             reply(responder, socket_server, &slot.name, &text);
-            true
+            (true, None)
         }
         "doctor" => {
             let fix = args.trim() == "--fix";
@@ -2563,7 +2575,8 @@ async fn handle_tui_command(
                 .await
                 .unwrap_or_else(|e| format!("doctor failed: {e}"));
             reply(responder, socket_server, &slot.name, &text);
-            true
+            let context = format!("The user ran /doctor and got the following output:\n\n{text}");
+            (true, Some(context))
         }
         "help" => {
             let mut text = "Built-in commands:\n/status — show open signals\n/config — show workspace configuration summary\n/brief — generate morning brief on demand\n/doctor — check workspace health (--fix to scaffold missing files)\n/reset — reset coordinator session\n/clear — clear session (hard reset, no context carried forward)\n/compact — compact session (summarize key context to memory, then reset)\n/devmode — toggle dev mode (on/off/status)\n/update — install latest apiari + swarm from crates.io\n/help — this message"
@@ -2576,7 +2589,7 @@ async fn handle_tui_command(
                 }
             }
             reply(responder, socket_server, &slot.name, &text);
-            true
+            (true, None)
         }
         "update" => {
             // Send initial status as a streaming token (Done sent after completion)
@@ -2639,7 +2652,7 @@ async fn handle_tui_command(
                     }
                 }
             }
-            true
+            (true, None)
         }
         _ => {
             // Check custom commands
@@ -2681,10 +2694,10 @@ async fn handle_tui_command(
                         );
                     }
                 }
-                true
+                (true, None)
             } else {
                 // Not a known command — let the coordinator handle it
-                false
+                (false, None)
             }
         }
     }

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -118,9 +118,10 @@ enum CoordinatorJob {
         socket_server: Option<Arc<socket::DaemonSocketServer>>,
         slot_name: String,
     },
-    /// Queue context to be prepended to the next user message. Used for
-    /// built-in command output (e.g. /doctor) that the coordinator should
-    /// see without triggering a separate LLM turn.
+    /// Queue context to be prepended to the next TUI user message. Used for
+    /// built-in TUI command output (e.g. /doctor) that the coordinator should
+    /// see without triggering a separate LLM turn. Only consumed by the
+    /// `TuiChat` path; Telegram dispatches are unaffected.
     InjectContext { text: String },
     /// Coordinator follow-through triggered by a signal hook.
     SignalFollowThrough {
@@ -358,7 +359,8 @@ async fn run_coordinator_task(
 
                 // Prepend any pending context (e.g. /doctor output) to
                 // the user message so the coordinator sees it inline.
-                let dispatch_text = if let Some(ctx) = coordinator.take_pending_context() {
+                let pending_ctx = coordinator.take_pending_context();
+                let dispatch_text = if let Some(ref ctx) = pending_ctx {
                     format!("{ctx}\n\n---\n\nUser message: {text}")
                 } else {
                     text.clone()
@@ -461,6 +463,11 @@ async fn run_coordinator_task(
                         }
                     }
                     Err(e) => {
+                        // Restore pending context so it's available on the
+                        // next attempt — the coordinator never ingested it.
+                        if let Some(ctx) = pending_ctx {
+                            coordinator.set_pending_context(ctx);
+                        }
                         // If session resume failed, reset and try fresh next time
                         if coordinator.has_session() {
                             warn!(


### PR DESCRIPTION
## Summary
- After `/doctor` runs in the TUI, its output is queued as pending context on the coordinator via a lightweight `CoordinatorJob::InjectContext` message
- On the next TUI user message, the pending context is prepended to the dispatch text so the coordinator sees it inline — no separate LLM turn is triggered
- Added `pending_context` field to `Coordinator` with `set_pending_context()` / `take_pending_context()` methods
- Context is restored if dispatch fails, and cleared on session reset/clear/compact
- No changes to Telegram handler or doctor.rs logic

## Problem
When `/doctor` ran via `handle_tui_command`, it replied to the user and returned `true`, causing the main loop to `continue` — the coordinator LLM never saw the output. When the user then said "fix it", the coordinator had no idea what `/doctor` reported.

## Approach
`handle_tui_command` now returns `(bool, Option<String>)` where the optional string is context to inject. For `/doctor`, the output is returned as context, sent to the coordinator task via `CoordinatorJob::InjectContext`, and stored as `pending_context`. The next `TuiChat` dispatch prepends it to the user message. This avoids a separate LLM turn (no hidden tool use, no extra cost) while ensuring the coordinator can reference the results.

## Test plan
- [ ] Run `/doctor` in the TUI, then ask "fix the issues" — coordinator should reference the doctor output
- [ ] Run `/doctor` then `/reset` then ask a question — doctor context should NOT leak into the fresh session
- [ ] Trigger a dispatch failure (e.g. invalid API key) after `/doctor` — context should be available on retry
- [ ] Run other built-in commands (`/status`, `/help`, etc.) — should work as before with no coordinator injection
- [ ] Verify Telegram `/doctor` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)