### PR TITLE
chore: bump apiari to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apiari"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "apiari-claude-sdk",
  "apiari-codex-sdk",

--- a/crates/apiari/Cargo.toml
+++ b/crates/apiari/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari"
-version = "0.2.2"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/ApiariTools/apiari"


### PR DESCRIPTION
## Summary
- Bump apiari crate version from 0.2.2 to 0.3.0

## Test plan
- [x] `cargo check -p apiari` passes
- [x] `cargo fmt` and `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)