### PR TITLE
fix: render signal follow-through responses as assistant messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "apiari-tui"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612f2e215d90aaaa077b5101f0c953e45527e5ae2298f9d099c1964e7a3d41d6"
+checksum = "d52a56bc2c3cfc69b55b5652040f9c789a03946e942ccc6670794fe436e7de53"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ reqwest = { version = "0.12", features = ["json"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 libc = "0.2"
 apiari-common = "0.1.0"
-apiari-tui = "0.1.0"
+apiari-tui = "0.2.0"
 apiari-claude-sdk = "0.1.0"
 apiari-codex-sdk = "0.1.0"
 apiari-gemini-sdk = "0.1.0"

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -785,12 +785,14 @@ async fn run_coordinator_task(
                                 "[signal: {source}] {response}"
                             );
 
-                            // Broadcast to TUI clients as a notification.
+                            // Broadcast to TUI clients as an assistant message so
+                            // the response renders as a normal assistant chat bubble
+                            // rather than a dim system status line.
                             if let Some(ref server) = socket_server {
                                 server.broadcast_activity(
                                     "signal",
                                     &slot_name,
-                                    "notification",
+                                    "assistant_message",
                                     &notification_text,
                                 );
                             }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1988,7 +1988,8 @@ impl App {
                     ws.has_unread_response = true;
                 }
                 "notification" => {
-                    // Signal follow-through results: queue if streaming, else show immediately.
+                    // Signal arrival notifications (e.g. "! 3 new signals: github (2)").
+                    // Follow-through *responses* are now broadcast as "assistant_message".
                     if ws.streaming {
                         ws.pending_notifications.push(text.to_string());
                     } else {

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -979,6 +979,8 @@ fn draw_chat_panel(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area:
                     }
                 }
                 ChatLine::Assistant(text, ts, _source) => {
+                    // TODO: map to ConversationEntry::Question when assistant message ends with "?"
+                    // and contains actionable content (merge, close, dispatch, etc.)
                     conversation::ConversationEntry::AssistantText {
                         text: text.clone(),
                         timestamp: ts.clone(),


### PR DESCRIPTION
## Summary
- Signal follow-through responses from the coordinator were broadcast as `"notification"` activity type, causing the TUI to render them as dim gray `ConversationEntry::Status` lines instead of normal assistant chat bubbles
- Changed daemon to broadcast follow-through responses as `"assistant_message"` so they map to `ChatLine::Assistant` → `ConversationEntry::AssistantText`
- Signal arrival notifications (e.g. "! 3 new signals: github (2)") remain as `"notification"` → `ChatLine::System` (dim gray is correct for those)

## Details
**Root cause**: In `daemon/mod.rs`, the follow-through completion handler at line ~790 was calling `broadcast_activity("signal", ..., "notification", ...)`. The TUI's `push_activity` handler in `app.rs` maps `"notification"` to `ChatLine::System`, which renders as `ConversationEntry::Status` (dim gray).

**Fix**: Changed the broadcast to use `"assistant_message"` activity type, which the TUI already correctly maps to `ChatLine::Assistant` → `ConversationEntry::AssistantText`.

**Verified**: `/doctor` context injection (`InjectContext`) only stores context on the coordinator via `set_pending_context` — it never broadcasts to the TUI or creates a visible chat message.

**TODO added**: Comment in `render.rs` for future mapping to `ConversationEntry::Question` when assistant messages end with "?" and contain actionable content.

## Test plan
- [x] `cargo fmt -p apiari` — clean
- [x] `cargo clippy -p apiari -- -D warnings` — clean
- [x] Existing notification queuing tests pass (they test signal arrival notifications, not follow-through responses)
- [ ] Manual: trigger a signal follow-through and verify the response renders as a normal assistant message bubble, not dim gray status text

🤖 Generated with [Claude Code](https://claude.com/claude-code)