### PR TITLE
feat: replace multi-panel dashboard with kanban strip

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -278,16 +278,21 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
             })
             .unwrap_or_default();
 
-        let entered = w
+        let created_utc = w
             .created_at
             .map(|t| t.with_timezone(&chrono::Utc))
             .unwrap_or(now);
 
+        let is_done_phase =
+            phase.eq_ignore_ascii_case("completed") || phase.eq_ignore_ascii_case("closed");
+
         if let Some(pr) = &w.pr {
             covered_prs.insert(pr.number);
+            let pr_done =
+                pr.state.eq_ignore_ascii_case("closed") || pr.state.eq_ignore_ascii_case("merged");
             let waiting =
                 phase == "waiting" || w.agent_session_status.as_deref() == Some("waiting");
-            if phase == "completed" || phase == "closed" || pr.state == "closed" {
+            if is_done_phase || pr_done {
                 cards.push(KanbanCard {
                     id: format!("worker:{}", w.id),
                     stage: KanbanStage::Done,
@@ -296,11 +301,12 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
                     subtitle: format!("PR #{} · completed", pr.number),
                     source: "worker".to_string(),
                     url: Some(pr.url.clone()),
-                    entered_stage_at: entered,
+                    // Use now() so long-running workers aren't filtered out
+                    // immediately on completion by the 30m cutoff.
+                    entered_stage_at: now,
                 });
             } else if waiting {
-                // Check if PR might need user attention (heuristic: waiting workers with PRs)
-                // We don't have CI/review data directly, so "waiting" with a PR → Needs Me
+                // Waiting worker with a PR → likely needs user attention
                 cards.push(KanbanCard {
                     id: format!("worker:{}", w.id),
                     stage: KanbanStage::NeedsMe,
@@ -309,7 +315,7 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
                     subtitle: format!("PR #{} · merge?", pr.number),
                     source: "worker".to_string(),
                     url: Some(pr.url.clone()),
-                    entered_stage_at: entered,
+                    entered_stage_at: created_utc,
                 });
             } else {
                 cards.push(KanbanCard {
@@ -320,10 +326,10 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
                     subtitle: format!("PR #{} · running", pr.number),
                     source: "worker".to_string(),
                     url: Some(pr.url.clone()),
-                    entered_stage_at: entered,
+                    entered_stage_at: created_utc,
                 });
             }
-        } else if phase == "completed" || phase == "closed" {
+        } else if is_done_phase {
             cards.push(KanbanCard {
                 id: format!("worker:{}", w.id),
                 stage: KanbanStage::Done,
@@ -332,7 +338,7 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
                 subtitle: "completed".to_string(),
                 source: "worker".to_string(),
                 url: None,
-                entered_stage_at: entered,
+                entered_stage_at: now,
             });
         } else {
             // Running, no PR yet
@@ -344,7 +350,7 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
                 subtitle: format!("running {elapsed}"),
                 source: "worker".to_string(),
                 url: None,
-                entered_stage_at: entered,
+                entered_stage_at: created_utc,
             });
         }
     }
@@ -510,9 +516,9 @@ struct SwarmPrInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OnboardingStage {
     Chat,      // only chat panel bright, Bee introduces herself
-    Workers,   // workers panel brightens
-    Heartbeat, // feed panel brightens
-    Reviews,   // reviews/signals panels brighten
+    Workers,   // kanban strip brightens (workers & signals)
+    Heartbeat, // remaining panels brighten
+    Reviews,   // signals/reviews panels brighten (zoom mode)
     Complete,  // all panels bright, onboarding done
 }
 
@@ -561,31 +567,31 @@ impl OnboardingState {
             OnboardingStage::Chat => {
                 self.stage = OnboardingStage::Workers;
                 self.revealed_panels.insert(Panel::Workers);
+                self.revealed_panels.insert(Panel::Home);
                 Some(
-                    "On your left: Workers. When you dispatch a coding task, \
-                     an AI agent spins up in its own git worktree and gets to work. \
-                     Each worker shows its status, branch, and PR link.\n\n\
+                    "Above: the Kanban strip. Workers, signals, and PRs flow \
+                     through four stages \u{2014} Incoming, In Progress, Needs Me, Done. \
+                     Everything at a glance.\n\n\
                      Press enter to continue.",
                 )
             }
             OnboardingStage::Workers => {
                 self.stage = OnboardingStage::Heartbeat;
                 self.revealed_panels.insert(Panel::Feed);
-                self.revealed_panels.insert(Panel::Home);
+                self.revealed_panels.insert(Panel::Signals);
+                self.revealed_panels.insert(Panel::Reviews);
                 Some(
-                    "This is your Heartbeat \u{2014} a live feed of everything happening \
-                     in your workspace. Signals from GitHub (CI, PRs, releases), Sentry \
-                     errors, Linear issues \u{2014} it all flows here.\n\n\
+                    "Signals from GitHub (CI, PRs, releases), Sentry errors, \
+                     Linear issues \u{2014} they all appear as kanban cards. \
+                     The \u{201c}Needs Me\u{201d} column highlights what needs your attention.\n\n\
                      Press enter to continue.",
                 )
             }
             OnboardingStage::Heartbeat => {
                 self.stage = OnboardingStage::Reviews;
-                self.revealed_panels.insert(Panel::Signals);
-                self.revealed_panels.insert(Panel::Reviews);
                 Some(
-                    "Over here: your signal queue and reviews. Open PRs, review requests, \
-                     anything that needs your attention surfaces here automatically.\n\n\
+                    "Want more detail? Press 'w' for workers, 's' for signals, \
+                     'r' for reviews \u{2014} zoom hotkeys open full-screen panels.\n\n\
                      Press enter to continue.",
                 )
             }
@@ -595,6 +601,7 @@ impl OnboardingState {
                 // Reveal everything
                 self.revealed_panels.insert(Panel::Home);
                 self.revealed_panels.insert(Panel::Workers);
+                self.revealed_panels.insert(Panel::Shells);
                 self.revealed_panels.insert(Panel::Signals);
                 self.revealed_panels.insert(Panel::Reviews);
                 self.revealed_panels.insert(Panel::Feed);
@@ -690,7 +697,7 @@ pub struct WorkspaceState {
     pub shell_windows: Vec<crate::shells::ShellWindow>,
     /// Queued notifications waiting for streaming to finish.
     pub pending_notifications: Vec<String>,
-    /// Derived kanban cards (rebuilt on each tick).
+    /// Derived kanban cards (rebuilt on signal/worker refresh).
     pub kanban_cards: Vec<KanbanCard>,
 }
 
@@ -4275,5 +4282,220 @@ mod tests {
 
         let sentry_hb = hb.iter().find(|i| i.text == "sentry checked").unwrap();
         assert_eq!(sentry_hb.when, old, "sole sentry heartbeat should survive");
+    }
+
+    // ── build_kanban_cards tests ─────────────────────────────
+
+    fn make_worker(id: &str, phase: &str, pr: Option<PrInfo>) -> WorkerInfo {
+        WorkerInfo {
+            id: id.to_string(),
+            branch: format!("swarm/{id}"),
+            prompt: "test".to_string(),
+            agent_kind: "claude".to_string(),
+            phase: Some(phase.to_string()),
+            agent_session_status: None,
+            summary: None,
+            created_at: Some(chrono::Local::now()),
+            pr,
+            last_activity: None,
+            conversation: Vec::new(),
+            conv_scroll: apiari_tui::scroll::ScrollState::new(),
+            activity: Vec::new(),
+            activity_scroll: apiari_tui::scroll::ScrollState::new(),
+        }
+    }
+
+    fn make_pr(number: u64, state: &str) -> PrInfo {
+        PrInfo {
+            number,
+            title: format!("PR #{number}"),
+            state: state.to_string(),
+            url: format!("https://github.com/test/repo/pull/{number}"),
+        }
+    }
+
+    fn empty_ws() -> WorkspaceState {
+        let config: config::WorkspaceConfig = serde_json::from_str(r#"{"root":"/tmp"}"#).unwrap();
+        WorkspaceState {
+            name: "test".into(),
+            config,
+            signals: Vec::new(),
+            workers: Vec::new(),
+            chat_history: Vec::new(),
+            input: String::new(),
+            cursor_pos: 0,
+            chat_scroll: apiari_tui::scroll::ScrollState::new(),
+            streaming: false,
+            coordinator_preview: None,
+            has_unread_response: false,
+            coordinator_turns: 0,
+            usage_input_tokens: 0,
+            usage_output_tokens: 0,
+            usage_cache_read_tokens: 0,
+            usage_cost_usd: None,
+            usage_context_window: 0,
+            prev_worker_phases: Default::default(),
+            prev_signal_ids: Default::default(),
+            prev_pr_workers: Default::default(),
+            sparkline_data: vec![0; 24],
+            watcher_health: Vec::new(),
+            feed: Vec::new(),
+            feed_scroll: apiari_tui::scroll::ScrollState::new(),
+            thoughts: Vec::new(),
+            is_setup_placeholder: false,
+            tmux: None,
+            shell_windows: Vec::new(),
+            pending_notifications: Vec::new(),
+            kanban_cards: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_kanban_running_worker_maps_to_in_progress() {
+        let mut ws = empty_ws();
+        ws.workers = vec![make_worker("abc-1234", "running", None)];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].stage, KanbanStage::InProgress);
+        assert!(cards[0].subtitle.contains("running"));
+    }
+
+    #[test]
+    fn test_kanban_worker_with_pr_running_maps_to_in_progress() {
+        let mut ws = empty_ws();
+        ws.workers = vec![make_worker(
+            "abc-1234",
+            "running",
+            Some(make_pr(42, "open")),
+        )];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].stage, KanbanStage::InProgress);
+        assert!(cards[0].subtitle.contains("PR #42"));
+    }
+
+    #[test]
+    fn test_kanban_waiting_worker_with_pr_maps_to_needs_me() {
+        let mut ws = empty_ws();
+        ws.workers = vec![make_worker(
+            "abc-1234",
+            "waiting",
+            Some(make_pr(42, "open")),
+        )];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].stage, KanbanStage::NeedsMe);
+        assert!(cards[0].subtitle.contains("merge?"));
+    }
+
+    #[test]
+    fn test_kanban_pr_state_case_insensitive() {
+        let mut ws = empty_ws();
+        // Test uppercase "CLOSED"
+        ws.workers = vec![make_worker(
+            "abc-1234",
+            "running",
+            Some(make_pr(42, "CLOSED")),
+        )];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].stage, KanbanStage::Done);
+
+        // Test "MERGED"
+        ws.workers = vec![make_worker(
+            "abc-5678",
+            "running",
+            Some(make_pr(43, "MERGED")),
+        )];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].stage, KanbanStage::Done);
+
+        // Test mixed case "Closed"
+        ws.workers = vec![make_worker(
+            "abc-9999",
+            "running",
+            Some(make_pr(44, "Closed")),
+        )];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].stage, KanbanStage::Done);
+    }
+
+    #[test]
+    fn test_kanban_done_cards_not_immediately_filtered() {
+        // Done cards use now() for entered_stage_at, so they should survive the 30m cutoff
+        let mut ws = empty_ws();
+        ws.workers = vec![make_worker("abc-1234", "completed", None)];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].stage, KanbanStage::Done);
+    }
+
+    #[test]
+    fn test_kanban_old_done_signal_filtered() {
+        let mut ws = empty_ws();
+        let mut sig = make_signal("github_merged_pr", "merge-123", None);
+        sig.created_at = Utc::now() - chrono::Duration::hours(1);
+        ws.signals = vec![sig];
+        let cards = build_kanban_cards(&ws);
+        assert!(
+            cards.is_empty(),
+            "Done signals older than 30m should be filtered"
+        );
+    }
+
+    #[test]
+    fn test_kanban_noise_signals_excluded() {
+        let mut ws = empty_ws();
+        ws.signals = vec![
+            make_signal("github_ci_pass", "ci-123", None),
+            make_signal("github_bot_review", "bot-456", None),
+        ];
+        let cards = build_kanban_cards(&ws);
+        assert!(cards.is_empty(), "Noise signals should not create cards");
+    }
+
+    #[test]
+    fn test_kanban_signal_dedup_with_worker_pr() {
+        let mut ws = empty_ws();
+        ws.workers = vec![make_worker(
+            "abc-1234",
+            "running",
+            Some(make_pr(42, "open")),
+        )];
+        // CI failure for the same PR — should be deduped
+        let mut sig = make_signal("github_ci_failure", "ci-org/repo-42", None);
+        sig.metadata = Some(r#"{"pr_number":42}"#.to_string());
+        ws.signals = vec![sig];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(
+            cards.len(),
+            1,
+            "Signal should be deduped with worker PR card"
+        );
+        assert_eq!(cards[0].id, "worker:abc-1234");
+    }
+
+    #[test]
+    fn test_kanban_sentry_signal_maps_to_incoming() {
+        let mut ws = empty_ws();
+        ws.signals = vec![make_signal("sentry", "sentry-err-1", None)];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].stage, KanbanStage::Incoming);
+    }
+
+    #[test]
+    fn test_kanban_review_requested_maps_to_needs_me() {
+        let mut ws = empty_ws();
+        ws.signals = vec![make_signal(
+            "github_review_queue",
+            "rq-org/repo-10",
+            Some(r#"{"query_name":"Review Requested","repo":"org/repo","pr_number":10}"#),
+        )];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].stage, KanbanStage::NeedsMe);
     }
 }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -231,6 +231,242 @@ pub enum WorkerEventKind {
     StatusChange,
 }
 
+// ── Kanban board ─────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KanbanStage {
+    Incoming,
+    InProgress,
+    NeedsMe,
+    Done,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct KanbanCard {
+    pub id: String,
+    pub stage: KanbanStage,
+    pub icon: String,
+    pub title: String,
+    pub subtitle: String,
+    pub source: String,
+    pub url: Option<String>,
+    pub entered_stage_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Build kanban cards by deriving them from worker and signal state.
+pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
+    let now = chrono::Utc::now();
+    let mut cards: Vec<KanbanCard> = Vec::new();
+    // Track PR numbers covered by worker cards so we can dedup signals.
+    let mut covered_prs: std::collections::HashSet<u64> = std::collections::HashSet::new();
+
+    // ── Workers → cards ──
+    for w in &ws.workers {
+        let phase = w.phase.as_deref().unwrap_or("");
+        let elapsed = w
+            .created_at
+            .map(|t| {
+                let mins = chrono::Utc::now()
+                    .signed_duration_since(t.with_timezone(&chrono::Utc))
+                    .num_minutes();
+                if mins >= 60 {
+                    format!("{}h{}m", mins / 60, mins % 60)
+                } else {
+                    format!("{mins}m")
+                }
+            })
+            .unwrap_or_default();
+
+        let entered = w
+            .created_at
+            .map(|t| t.with_timezone(&chrono::Utc))
+            .unwrap_or(now);
+
+        if let Some(pr) = &w.pr {
+            covered_prs.insert(pr.number);
+            let waiting =
+                phase == "waiting" || w.agent_session_status.as_deref() == Some("waiting");
+            if phase == "completed" || phase == "closed" || pr.state == "closed" {
+                cards.push(KanbanCard {
+                    id: format!("worker:{}", w.id),
+                    stage: KanbanStage::Done,
+                    icon: "👷".to_string(),
+                    title: short_id(&w.id),
+                    subtitle: format!("PR #{} · completed", pr.number),
+                    source: "worker".to_string(),
+                    url: Some(pr.url.clone()),
+                    entered_stage_at: entered,
+                });
+            } else if waiting {
+                // Check if PR might need user attention (heuristic: waiting workers with PRs)
+                // We don't have CI/review data directly, so "waiting" with a PR → Needs Me
+                cards.push(KanbanCard {
+                    id: format!("worker:{}", w.id),
+                    stage: KanbanStage::NeedsMe,
+                    icon: "👷".to_string(),
+                    title: short_id(&w.id),
+                    subtitle: format!("PR #{} · merge?", pr.number),
+                    source: "worker".to_string(),
+                    url: Some(pr.url.clone()),
+                    entered_stage_at: entered,
+                });
+            } else {
+                cards.push(KanbanCard {
+                    id: format!("worker:{}", w.id),
+                    stage: KanbanStage::InProgress,
+                    icon: "👷".to_string(),
+                    title: short_id(&w.id),
+                    subtitle: format!("PR #{} · running", pr.number),
+                    source: "worker".to_string(),
+                    url: Some(pr.url.clone()),
+                    entered_stage_at: entered,
+                });
+            }
+        } else if phase == "completed" || phase == "closed" {
+            cards.push(KanbanCard {
+                id: format!("worker:{}", w.id),
+                stage: KanbanStage::Done,
+                icon: "👷".to_string(),
+                title: short_id(&w.id),
+                subtitle: "completed".to_string(),
+                source: "worker".to_string(),
+                url: None,
+                entered_stage_at: entered,
+            });
+        } else {
+            // Running, no PR yet
+            cards.push(KanbanCard {
+                id: format!("worker:{}", w.id),
+                stage: KanbanStage::InProgress,
+                icon: "👷".to_string(),
+                title: short_id(&w.id),
+                subtitle: format!("running {elapsed}"),
+                source: "worker".to_string(),
+                url: None,
+                entered_stage_at: entered,
+            });
+        }
+    }
+
+    // ── Signals → cards ──
+    for sig in &ws.signals {
+        // Skip noise signals
+        if is_noise_signal(sig) {
+            continue;
+        }
+        // Skip signals that are covered by worker PR cards
+        if signal_covered_by_worker(sig, &covered_prs) {
+            continue;
+        }
+
+        let src = sig.source.as_str();
+        let (stage, icon) = match src {
+            "github_review_queue" => {
+                let query = sig
+                    .metadata
+                    .as_deref()
+                    .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+                    .and_then(|v| {
+                        v.get("query_name")
+                            .and_then(|q| q.as_str())
+                            .map(String::from)
+                    })
+                    .unwrap_or_default();
+                if query.contains("Review Requested") {
+                    (KanbanStage::NeedsMe, "🔍")
+                } else {
+                    (KanbanStage::Incoming, "🔍")
+                }
+            }
+            "github_ci_failure" => {
+                // If there's a matching worker, it's in progress via the worker card already.
+                // Otherwise incoming.
+                (KanbanStage::Incoming, "🐛")
+            }
+            "github_ci_pass" | "github_bot_review" => continue,
+            "github_merged_pr" => (KanbanStage::Done, "📋"),
+            "github_release" => (KanbanStage::Done, "📋"),
+            "sentry" => (KanbanStage::Incoming, "🐛"),
+            "linear" => (KanbanStage::Incoming, "📋"),
+            "email" => (KanbanStage::Incoming, "📋"),
+            "notion" => (KanbanStage::Incoming, "📋"),
+            _ => (KanbanStage::Incoming, "⚡"),
+        };
+
+        cards.push(KanbanCard {
+            id: format!("signal:{}", sig.id),
+            stage,
+            icon: icon.to_string(),
+            title: truncate_title(&sig.title, 40),
+            subtitle: src.to_string(),
+            source: src.to_string(),
+            url: sig.url.clone(),
+            entered_stage_at: sig.created_at,
+        });
+    }
+
+    // Filter out Done cards older than 30 minutes
+    let cutoff = now - chrono::Duration::minutes(30);
+    cards.retain(|c| c.stage != KanbanStage::Done || c.entered_stage_at > cutoff);
+
+    cards
+}
+
+/// Check if a signal is already represented by a worker's PR card.
+fn signal_covered_by_worker(
+    sig: &SignalRecord,
+    covered_prs: &std::collections::HashSet<u64>,
+) -> bool {
+    if covered_prs.is_empty() {
+        return false;
+    }
+    let src = sig.source.as_str();
+    // These signal types are PR-specific and get folded into worker cards
+    if matches!(
+        src,
+        "github_ci_pass" | "github_ci_failure" | "github_bot_review"
+    ) {
+        // Try to extract PR number from external_id
+        if let Some(pr_num) = extract_pr_number_from_signal(sig) {
+            return covered_prs.contains(&pr_num);
+        }
+    }
+    false
+}
+
+/// Try to extract a PR number from a signal's external_id or metadata.
+fn extract_pr_number_from_signal(sig: &SignalRecord) -> Option<u64> {
+    // Try metadata first
+    if let Some(meta) = &sig.metadata
+        && let Ok(v) = serde_json::from_str::<serde_json::Value>(meta)
+        && let Some(n) = v.get("pr_number").and_then(|n| n.as_u64())
+    {
+        return Some(n);
+    }
+    // Try parsing from external_id (format: "ci-{repo}-{number}" or "rq-{repo}-{number}")
+    let eid = &sig.external_id;
+    let last_dash = eid.rfind('-')?;
+    eid[last_dash + 1..].parse().ok()
+}
+
+fn short_id(id: &str) -> String {
+    if id.len() > 12 {
+        format!("{}…", &id[..12])
+    } else {
+        id.to_string()
+    }
+}
+
+fn truncate_title(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{truncated}…")
+    }
+}
+
 /// Deserialization types for .swarm/state.json.
 #[derive(Debug, Deserialize)]
 struct SwarmStateFile {
@@ -454,6 +690,8 @@ pub struct WorkspaceState {
     pub shell_windows: Vec<crate::shells::ShellWindow>,
     /// Queued notifications waiting for streaming to finish.
     pub pending_notifications: Vec<String>,
+    /// Derived kanban cards (rebuilt on each tick).
+    pub kanban_cards: Vec<KanbanCard>,
 }
 
 // ── App ───────────────────────────────────────────────────
@@ -572,6 +810,7 @@ impl App {
                     tmux,
                     shell_windows: Vec::new(),
                     pending_notifications: Vec::new(),
+                    kanban_cards: Vec::new(),
                 }
             })
             .collect();
@@ -713,6 +952,7 @@ impl App {
             tmux: None,
             shell_windows: Vec::new(),
             pending_notifications: Vec::new(),
+            kanban_cards: Vec::new(),
         };
 
         let setup = SetupState {
@@ -841,6 +1081,7 @@ impl App {
             tmux: None,
             shell_windows: Vec::new(),
             pending_notifications: Vec::new(),
+            kanban_cards: Vec::new(),
         };
 
         ws_state.chat_history.push(ChatLine::Assistant(
@@ -1037,6 +1278,7 @@ impl App {
             tmux,
             shell_windows: Vec::new(),
             pending_notifications: Vec::new(),
+            kanban_cards: Vec::new(),
         };
 
         if is_add {
@@ -2241,6 +2483,8 @@ impl App {
             }
 
             ws.prev_signal_ids = current_ids;
+            // Rebuild kanban cards from updated state
+            ws.kanban_cards = build_kanban_cards(ws);
         }
         self.last_signal_refresh = Instant::now();
         self.clamp_selections();
@@ -2352,6 +2596,8 @@ impl App {
                     .collect();
 
                 ws.workers = new_workers;
+                // Rebuild kanban cards from updated state
+                ws.kanban_cards = build_kanban_cards(ws);
             }
         }
         self.last_worker_refresh = Instant::now();
@@ -2399,6 +2645,8 @@ impl App {
 
                 ws.prev_signal_ids = current_ids;
                 ws.signals = new_signals;
+                // Rebuild kanban cards from updated state
+                ws.kanban_cards = build_kanban_cards(ws);
             }
         }
         self.last_signal_refresh = Instant::now();
@@ -3840,6 +4088,7 @@ mod tests {
             tmux: None,
             shell_windows: Vec::new(),
             pending_notifications: Vec::new(),
+            kanban_cards: Vec::new(),
         };
         app.workspaces = vec![ws];
         app.setup = None;

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -2550,6 +2550,7 @@ mod tests {
             tmux: None,
             shell_windows: Vec::new(),
             pending_notifications: Vec::new(),
+            kanban_cards: Vec::new(),
         };
         let ws_name = ws.name.clone();
         App {

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -477,16 +477,20 @@ fn draw_kanban_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, ar
     // Build status line for the header
     let healthy = ws.watcher_health.iter().filter(|w| w.healthy).count();
     let total = ws.watcher_health.len();
-    let last_poll = if let Some(w) = ws.watcher_health.first() {
-        if w.last_check_secs < 0 {
-            "never".to_string()
-        } else if w.last_check_secs < 60 {
-            format!("{}s ago", w.last_check_secs)
-        } else {
-            format!("{}m ago", w.last_check_secs / 60)
+    // Most recent poll across all watchers (min non-negative last_check_secs)
+    let last_poll = {
+        let most_recent = ws
+            .watcher_health
+            .iter()
+            .filter(|w| w.last_check_secs >= 0)
+            .map(|w| w.last_check_secs)
+            .min();
+        match most_recent {
+            Some(secs) if secs < 60 => format!("{secs}s ago"),
+            Some(secs) => format!("{}m ago", secs / 60),
+            None if ws.watcher_health.is_empty() => "n/a".to_string(),
+            None => "never".to_string(), // all watchers have -1
         }
-    } else {
-        "n/a".to_string()
     };
 
     let health_icon = if total == 0 || healthy == total {

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -195,158 +195,23 @@ fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
         return;
     }
 
-    let has_thoughts = !ws.thoughts.is_empty();
-    let thoughts_h: u16 = if has_thoughts { 1 } else { 0 };
-
-    // Build action summary to decide if we need the banner
-    let actions = build_action_summary(app, ws);
-    let action_h: u16 = if actions.is_empty() { 0 } else { 1 };
-
-    // KPI height: enough for watchers (1 per line) + borders
-    let kpi_h = (ws.watcher_health.len() as u16 + 2).clamp(4, 7);
+    // Kanban strip + Chat layout
+    let kanban_h = compute_kanban_height(ws);
 
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(kpi_h),      // KPI cards (Watchers + Today)
-            Constraint::Length(action_h),   // Action banner
-            Constraint::Percentage(55),     // Workers + Signals/Feed
-            Constraint::Length(thoughts_h), // Thoughts strip
-            Constraint::Min(5),             // Chat
+            Constraint::Length(kanban_h), // Kanban strip
+            Constraint::Min(5),           // Chat (gets everything else)
         ])
         .split(area);
 
-    // Track areas for onboarding dimming
-    let mut dim_areas: Vec<(Panel, Rect)> = Vec::new();
+    draw_kanban_strip(frame, app, ws, rows[0]);
+    draw_chat_panel(frame, app, ws, rows[1]);
 
-    draw_kpi_strip(frame, app, ws, rows[0]);
-    dim_areas.push((Panel::Home, rows[0]));
-
-    if !actions.is_empty() {
-        draw_action_banner(frame, &actions, rows[1]);
-        dim_areas.push((Panel::Home, rows[1]));
-    }
-
-    // Workers + right column side by side
-    let items = rows[2];
-    let wide = items.width >= 80;
-    let medium = items.width >= 60;
-    let has_reviews = app.has_review_queue();
-    let has_shells = app.current_ws_has_shells();
-
-    if medium {
-        let cols = Layout::default()
-            .direction(Direction::Horizontal)
-            .spacing(1)
-            .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
-            .split(items);
-
-        // Left column: Workers, and optionally Shells below
-        if has_shells {
-            let left_rows = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
-                .split(cols[0]);
-            draw_workers_panel(frame, app, ws, left_rows[0]);
-            dim_areas.push((Panel::Workers, left_rows[0]));
-            draw_shells_panel(frame, app, ws, left_rows[1]);
-            dim_areas.push((Panel::Shells, left_rows[1]));
-        } else {
-            draw_workers_panel(frame, app, ws, cols[0]);
-            dim_areas.push((Panel::Workers, cols[0]));
-        }
-
-        if wide {
-            if has_reviews {
-                // Wide + reviews: Reviews (35%) + Signals (30%) + Feed (35%)
-                let right_rows = Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([
-                        Constraint::Percentage(35),
-                        Constraint::Percentage(30),
-                        Constraint::Percentage(35),
-                    ])
-                    .split(cols[1]);
-                draw_reviews_pane(frame, app, ws, right_rows[0]);
-                dim_areas.push((Panel::Reviews, right_rows[0]));
-                draw_signals_card(frame, app, ws, right_rows[1]);
-                dim_areas.push((Panel::Signals, right_rows[1]));
-                draw_feed_panel(frame, app, ws, right_rows[2]);
-                dim_areas.push((Panel::Feed, right_rows[2]));
-            } else {
-                // Wide: Signals (top) + Feed (bottom)
-                let right_rows = Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
-                    .split(cols[1]);
-                draw_signals_card(frame, app, ws, right_rows[0]);
-                dim_areas.push((Panel::Signals, right_rows[0]));
-                draw_feed_panel(frame, app, ws, right_rows[1]);
-                dim_areas.push((Panel::Feed, right_rows[1]));
-            }
-        } else if has_reviews {
-            // Medium + reviews: Reviews (50%) + Signals (50%)
-            let right_rows = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                .split(cols[1]);
-            draw_reviews_pane(frame, app, ws, right_rows[0]);
-            dim_areas.push((Panel::Reviews, right_rows[0]));
-            draw_signals_card(frame, app, ws, right_rows[1]);
-            dim_areas.push((Panel::Signals, right_rows[1]));
-        } else {
-            // Medium: just signals, no feed
-            draw_signals_card(frame, app, ws, cols[1]);
-            dim_areas.push((Panel::Signals, cols[1]));
-        }
-    } else {
-        // Narrow: stack vertically
-        if has_reviews {
-            let third = items.height / 3;
-            let wk_area = Rect::new(items.x, items.y, items.width, third);
-            draw_workers_panel(frame, app, ws, wk_area);
-            dim_areas.push((Panel::Workers, wk_area));
-            let rev_y = items.y + third;
-            let rev_area = Rect::new(items.x, rev_y, items.width, third);
-            draw_reviews_pane(frame, app, ws, rev_area);
-            dim_areas.push((Panel::Reviews, rev_area));
-            let sig_y = rev_y + third;
-            let sig_rem = items.height.saturating_sub(third * 2);
-            if sig_rem > 0 {
-                let sig_area = Rect::new(items.x, sig_y, items.width, sig_rem);
-                draw_signals_card(frame, app, ws, sig_area);
-                dim_areas.push((Panel::Signals, sig_area));
-            }
-        } else {
-            let half = items.height / 2;
-            let wk_area = Rect::new(items.x, items.y, items.width, half);
-            draw_workers_panel(frame, app, ws, wk_area);
-            dim_areas.push((Panel::Workers, wk_area));
-            let sig_y = items.y + half;
-            let sig_rem = items.height.saturating_sub(half);
-            if sig_rem > 0 {
-                let sig_area = Rect::new(items.x, sig_y, items.width, sig_rem);
-                draw_signals_card(frame, app, ws, sig_area);
-                dim_areas.push((Panel::Signals, sig_area));
-            }
-        }
-    }
-
-    // Thoughts strip
-    if has_thoughts {
-        draw_thoughts_strip(frame, app, ws, rows[3]);
-        dim_areas.push((Panel::Home, rows[3]));
-    }
-
-    draw_chat_panel(frame, app, ws, rows[4]);
-
-    // Onboarding: dim unrevealed panels
-    if app.onboarding.active {
-        for (panel, rect) in &dim_areas {
-            if !app.onboarding.is_revealed(*panel) {
-                onboarding_dim_area(frame, *rect);
-            }
-        }
+    // Onboarding: dim kanban area if Home panel not revealed
+    if app.onboarding.active && !app.onboarding.is_revealed(Panel::Home) {
+        onboarding_dim_area(frame, rows[0]);
     }
 }
 
@@ -579,6 +444,201 @@ fn draw_kpi_strip(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area: 
 
         frame.render_widget(Paragraph::new(lines), inner);
     }
+}
+
+// ── Kanban strip ─────────────────────────────────────────
+
+/// Compute the height of the kanban strip based on card count.
+fn compute_kanban_height(ws: &app::WorkspaceState) -> u16 {
+    if ws.kanban_cards.is_empty() {
+        return 3; // header + "all clear" + border
+    }
+
+    // Count cards per visible column
+    let mut counts = [0u16; 4]; // Incoming, InProgress, NeedsMe, Done
+    for card in &ws.kanban_cards {
+        let idx = match card.stage {
+            app::KanbanStage::Incoming => 0,
+            app::KanbanStage::InProgress => 1,
+            app::KanbanStage::NeedsMe => 2,
+            app::KanbanStage::Done => 3,
+        };
+        counts[idx] += 1;
+    }
+
+    // Tallest column determines height: each card = 2 lines, + 1 header line + 2 border
+    let max_cards = counts.iter().copied().max().unwrap_or(0);
+    let content_h = max_cards * 2 + 1; // header line + cards
+    (content_h + 2).clamp(3, 8) // +2 for borders, clamp to reasonable range
+}
+
+/// Draw the kanban strip with columns for each stage.
+fn draw_kanban_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, area: Rect) {
+    // Build status line for the header
+    let healthy = ws.watcher_health.iter().filter(|w| w.healthy).count();
+    let total = ws.watcher_health.len();
+    let last_poll = if let Some(w) = ws.watcher_health.first() {
+        if w.last_check_secs < 0 {
+            "never".to_string()
+        } else if w.last_check_secs < 60 {
+            format!("{}s ago", w.last_check_secs)
+        } else {
+            format!("{}m ago", w.last_check_secs / 60)
+        }
+    } else {
+        "n/a".to_string()
+    };
+
+    let health_icon = if total == 0 || healthy == total {
+        "\u{2705}"
+    } else {
+        "\u{26a0}\u{fe0f}"
+    };
+    let title = format!(
+        " Kanban \u{00b7} Watchers: {healthy}/{total} {health_icon} \u{00b7} Last poll: {last_poll} "
+    );
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_set(border::ROUNDED)
+        .border_style(Style::default().fg(theme::STEEL))
+        .style(Style::default().bg(theme::COMB))
+        .title(Span::styled(title, Style::default().fg(theme::POLLEN)));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if ws.kanban_cards.is_empty() {
+        let line = Line::from(vec![
+            Span::styled(" \u{1f41d} ", Style::default().fg(theme::HONEY)),
+            Span::styled(
+                "All clear \u{2014} nothing in flight",
+                Style::default().fg(theme::SMOKE),
+            ),
+        ]);
+        frame.render_widget(Paragraph::new(vec![line]), inner);
+        return;
+    }
+
+    // Group cards by stage
+    let stages = [
+        app::KanbanStage::Incoming,
+        app::KanbanStage::InProgress,
+        app::KanbanStage::NeedsMe,
+        app::KanbanStage::Done,
+    ];
+
+    let mut columns: Vec<(app::KanbanStage, Vec<&app::KanbanCard>)> = Vec::new();
+    for stage in &stages {
+        let cards: Vec<&app::KanbanCard> = ws
+            .kanban_cards
+            .iter()
+            .filter(|c| c.stage == *stage)
+            .collect();
+        if !cards.is_empty() {
+            columns.push((*stage, cards));
+        }
+    }
+
+    if columns.is_empty() {
+        return;
+    }
+
+    // Split inner area into equal columns
+    let constraints: Vec<Constraint> = columns
+        .iter()
+        .map(|_| Constraint::Ratio(1, columns.len() as u32))
+        .collect();
+    let col_areas = Layout::default()
+        .direction(Direction::Horizontal)
+        .spacing(1)
+        .constraints(constraints)
+        .split(inner);
+
+    for (i, (stage, cards)) in columns.iter().enumerate() {
+        let col_area = col_areas[i];
+        draw_kanban_column(frame, *stage, cards, col_area);
+    }
+}
+
+fn draw_kanban_column(
+    frame: &mut Frame,
+    stage: app::KanbanStage,
+    cards: &[&app::KanbanCard],
+    area: Rect,
+) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+
+    let (header_text, header_style) = match stage {
+        app::KanbanStage::Incoming => ("INCOMING", Style::default().fg(theme::FROST)),
+        app::KanbanStage::InProgress => ("IN PROGRESS", Style::default().fg(theme::MINT)),
+        app::KanbanStage::NeedsMe => (
+            "NEEDS ME",
+            Style::default()
+                .fg(theme::HONEY)
+                .add_modifier(Modifier::BOLD),
+        ),
+        app::KanbanStage::Done => (
+            "DONE",
+            Style::default()
+                .fg(theme::STEEL)
+                .add_modifier(Modifier::DIM),
+        ),
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Header line
+    lines.push(Line::from(Span::styled(header_text, header_style)));
+
+    // How many cards can we fit? Each card = 2 lines, reserve 1 for header
+    let available = area.height.saturating_sub(1) as usize;
+    let cards_fit = available / 2;
+    let show_count = cards_fit.min(cards.len());
+    let overflow = cards.len().saturating_sub(show_count);
+
+    let is_needs_me = stage == app::KanbanStage::NeedsMe;
+    let card_style = if is_needs_me {
+        Style::default()
+            .fg(theme::HONEY)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::FROST)
+    };
+    let subtitle_style = if is_needs_me {
+        Style::default().fg(theme::HONEY)
+    } else {
+        Style::default().fg(theme::SMOKE)
+    };
+
+    for card in cards.iter().take(show_count) {
+        // Line 1: icon + title
+        let title_line = Line::from(vec![
+            Span::raw(&card.icon),
+            Span::raw(" "),
+            Span::styled(&card.title, card_style),
+        ]);
+        lines.push(title_line);
+
+        // Line 2: subtitle (indented)
+        let sub_line = Line::from(vec![
+            Span::raw("  "),
+            Span::styled(&card.subtitle, subtitle_style),
+        ]);
+        lines.push(sub_line);
+    }
+
+    if overflow > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("  +{overflow} more"),
+            Style::default()
+                .fg(theme::SMOKE)
+                .add_modifier(Modifier::DIM),
+        )));
+    }
+
+    frame.render_widget(Paragraph::new(lines), area);
 }
 
 // ── Action banner ────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replace Workers, Signals, Reviews, and Feed panels in the default dashboard layout with a horizontal kanban strip showing cards in four attention stages: **INCOMING**, **IN PROGRESS**, **NEEDS ME**, **DONE**
- Cards are derived from existing worker and signal data (workers map to In Progress/Needs Me/Done based on phase and PR status; signals map to Incoming/Needs Me/Done based on source type)
- Chat panel now gets ~80% of screen space; kanban strip auto-sizes (3-8 lines) based on card count
- Existing zoom hotkeys (w/s/r/f) and panel draw functions preserved for backward compatibility

## Test plan
- [ ] Verify kanban strip renders with worker cards in correct stages
- [ ] Verify signal cards appear in correct kanban columns
- [ ] Verify empty state shows "All clear — nothing in flight" message
- [ ] Verify zoom hotkeys still work (w for workers, s for signals, etc.)
- [ ] Verify chat panel gets majority of screen space
- [ ] Verify Done cards older than 30 minutes are filtered out
- [ ] `cargo fmt` and `cargo clippy` pass cleanly

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)