### PR TITLE
feat: polish kanban strip with dividers, badges, and richer styling

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -4507,26 +4507,31 @@ mod tests {
         let mut ws = empty_ws();
         ws.signals = vec![make_signal("github_release", "rel-v1.0", None)];
         let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].icon, "🚀");
 
         // Email → 📧
         ws.signals = vec![make_signal("email", "email-1", None)];
         let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].icon, "📧");
 
         // Notion → 📓
         ws.signals = vec![make_signal("notion", "notion-1", None)];
         let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].icon, "📓");
 
         // Linear → 📋
         ws.signals = vec![make_signal("linear", "lin-1", None)];
         let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].icon, "📋");
 
         // Unknown → ⚡
         ws.signals = vec![make_signal("unknown_source", "unk-1", None)];
         let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].icon, "⚡");
     }
 }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -4484,6 +4484,7 @@ mod tests {
         let cards = build_kanban_cards(&ws);
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].stage, KanbanStage::Incoming);
+        assert_eq!(cards[0].icon, "⚡");
     }
 
     #[test]
@@ -4497,5 +4498,35 @@ mod tests {
         let cards = build_kanban_cards(&ws);
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].stage, KanbanStage::NeedsMe);
+        assert_eq!(cards[0].icon, "🔍");
+    }
+
+    #[test]
+    fn test_kanban_signal_icon_mappings() {
+        // Release → 🚀
+        let mut ws = empty_ws();
+        ws.signals = vec![make_signal("github_release", "rel-v1.0", None)];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards[0].icon, "🚀");
+
+        // Email → 📧
+        ws.signals = vec![make_signal("email", "email-1", None)];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards[0].icon, "📧");
+
+        // Notion → 📓
+        ws.signals = vec![make_signal("notion", "notion-1", None)];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards[0].icon, "📓");
+
+        // Linear → 📋
+        ws.signals = vec![make_signal("linear", "lin-1", None)];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards[0].icon, "📋");
+
+        // Unknown → ⚡
+        ws.signals = vec![make_signal("unknown_source", "unk-1", None)];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards[0].icon, "⚡");
     }
 }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -392,11 +392,11 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
             }
             "github_ci_pass" | "github_bot_review" => continue,
             "github_merged_pr" => (KanbanStage::Done, "📋"),
-            "github_release" => (KanbanStage::Done, "📋"),
-            "sentry" => (KanbanStage::Incoming, "🐛"),
+            "github_release" => (KanbanStage::Done, "🚀"),
+            "sentry" => (KanbanStage::Incoming, "⚡"),
             "linear" => (KanbanStage::Incoming, "📋"),
-            "email" => (KanbanStage::Incoming, "📋"),
-            "notion" => (KanbanStage::Incoming, "📋"),
+            "email" => (KanbanStage::Incoming, "📧"),
+            "notion" => (KanbanStage::Incoming, "📓"),
             _ => (KanbanStage::Incoming, "⚡"),
         };
 

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -498,9 +498,9 @@ fn draw_kanban_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, ar
     } else {
         "\u{26a0}\u{fe0f}"
     };
-    let today_signals = ws.signals.len();
+    let open_signals = ws.signals.len();
     let title = format!(
-        " Kanban \u{00b7} Watchers: {healthy}/{total} {health_icon} \u{00b7} Last poll: {last_poll} \u{00b7} Today: {today_signals} signals "
+        " Kanban \u{00b7} Watchers: {healthy}/{total} {health_icon} \u{00b7} Last poll: {last_poll} \u{00b7} Open: {open_signals} signals "
     );
 
     let block = Block::default()
@@ -611,7 +611,7 @@ fn draw_kanban_column(
             "DONE",
             Style::default()
                 .fg(theme::STEEL)
-                .add_modifier(Modifier::DIM | Modifier::UNDERLINED),
+                .add_modifier(Modifier::BOLD | Modifier::DIM | Modifier::UNDERLINED),
         ),
     };
 
@@ -652,7 +652,7 @@ fn draw_kanban_column(
     for card in cards.iter().take(show_count) {
         // Line 1: icon + title + action hint for NeedsMe
         let mut title_spans = vec![
-            Span::raw(&card.icon),
+            Span::styled(&card.icon, card_style),
             Span::raw(" "),
             Span::styled(&card.title, card_style),
         ];

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -498,7 +498,7 @@ fn draw_kanban_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, ar
     } else {
         "\u{26a0}\u{fe0f}"
     };
-    let open_signals = ws.signals.len();
+    let open_signals = ws.kanban_cards.len();
     let title = format!(
         " Kanban \u{00b7} Watchers: {healthy}/{total} {health_icon} \u{00b7} Last poll: {last_poll} \u{00b7} Open: {open_signals} signals "
     );

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -498,8 +498,9 @@ fn draw_kanban_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, ar
     } else {
         "\u{26a0}\u{fe0f}"
     };
+    let today_signals = ws.signals.len();
     let title = format!(
-        " Kanban \u{00b7} Watchers: {healthy}/{total} {health_icon} \u{00b7} Last poll: {last_poll} "
+        " Kanban \u{00b7} Watchers: {healthy}/{total} {health_icon} \u{00b7} Last poll: {last_poll} \u{00b7} Today: {today_signals} signals "
     );
 
     let block = Block::default()
@@ -547,20 +548,33 @@ fn draw_kanban_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, ar
         return;
     }
 
-    // Split inner area into equal columns
-    let constraints: Vec<Constraint> = columns
-        .iter()
-        .map(|_| Constraint::Ratio(1, columns.len() as u32))
-        .collect();
+    // Build constraints with 1-char gaps for dividers between columns
+    let num_cols = columns.len() as u32;
+    let mut constraints: Vec<Constraint> = Vec::new();
+    for (i, _) in columns.iter().enumerate() {
+        if i > 0 {
+            constraints.push(Constraint::Length(1)); // divider
+        }
+        constraints.push(Constraint::Ratio(1, num_cols));
+    }
     let col_areas = Layout::default()
         .direction(Direction::Horizontal)
-        .spacing(1)
         .constraints(constraints)
         .split(inner);
 
     for (i, (stage, cards)) in columns.iter().enumerate() {
-        let col_area = col_areas[i];
+        let area_idx = i * 2; // skip divider slots
+        let col_area = col_areas[area_idx];
         draw_kanban_column(frame, *stage, cards, col_area);
+
+        // Draw divider after this column (before the next)
+        if i + 1 < columns.len() {
+            let div_area = col_areas[area_idx + 1];
+            let divider_lines: Vec<Line> = (0..div_area.height)
+                .map(|_| Line::from(Span::styled("│", Style::default().fg(theme::STEEL))))
+                .collect();
+            frame.render_widget(Paragraph::new(divider_lines), div_area);
+        }
     }
 }
 
@@ -575,19 +589,29 @@ fn draw_kanban_column(
     }
 
     let (header_text, header_style) = match stage {
-        app::KanbanStage::Incoming => ("INCOMING", Style::default().fg(theme::FROST)),
-        app::KanbanStage::InProgress => ("IN PROGRESS", Style::default().fg(theme::MINT)),
+        app::KanbanStage::Incoming => (
+            "INCOMING",
+            Style::default()
+                .fg(theme::FROST)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        ),
+        app::KanbanStage::InProgress => (
+            "IN PROGRESS",
+            Style::default()
+                .fg(theme::MINT)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        ),
         app::KanbanStage::NeedsMe => (
             "NEEDS ME",
             Style::default()
                 .fg(theme::HONEY)
-                .add_modifier(Modifier::BOLD),
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
         ),
         app::KanbanStage::Done => (
             "DONE",
             Style::default()
                 .fg(theme::STEEL)
-                .add_modifier(Modifier::DIM),
+                .add_modifier(Modifier::DIM | Modifier::UNDERLINED),
         ),
     };
 
@@ -603,27 +627,44 @@ fn draw_kanban_column(
     let overflow = cards.len().saturating_sub(show_count);
 
     let is_needs_me = stage == app::KanbanStage::NeedsMe;
+    let is_done = stage == app::KanbanStage::Done;
     let card_style = if is_needs_me {
         Style::default()
             .fg(theme::HONEY)
             .add_modifier(Modifier::BOLD)
+    } else if is_done {
+        Style::default()
+            .fg(theme::STEEL)
+            .add_modifier(Modifier::DIM)
     } else {
         Style::default().fg(theme::FROST)
     };
     let subtitle_style = if is_needs_me {
         Style::default().fg(theme::HONEY)
+    } else if is_done {
+        Style::default()
+            .fg(theme::STEEL)
+            .add_modifier(Modifier::DIM)
     } else {
         Style::default().fg(theme::SMOKE)
     };
 
     for card in cards.iter().take(show_count) {
-        // Line 1: icon + title
-        let title_line = Line::from(vec![
+        // Line 1: icon + title + action hint for NeedsMe
+        let mut title_spans = vec![
             Span::raw(&card.icon),
             Span::raw(" "),
             Span::styled(&card.title, card_style),
-        ]);
-        lines.push(title_line);
+        ];
+        if is_needs_me {
+            title_spans.push(Span::styled(
+                " \u{2192}",
+                Style::default()
+                    .fg(theme::HONEY)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
+        lines.push(Line::from(title_spans));
 
         // Line 2: subtitle (indented)
         let sub_line = Line::from(vec![


### PR DESCRIPTION
## Summary
- Add vertical `│` column dividers between kanban stages for visual separation
- Add bold + underline to all column headers (INCOMING, IN PROGRESS, NEEDS ME, DONE)
- Update source-type icons: ⚡ for sentry/generic signals, 🚀 for releases, 📧 for email, 📓 for notion
- Dim Done cards (STEEL color + DIM modifier) so resolved items fade visually
- Add `→` action hint suffix on NeedsMe cards to highlight actionable items
- Add "Today: N signals" count to watcher health header line

## Test plan
- [x] `cargo fmt -p apiari` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] Visual inspection: column dividers render between stages
- [ ] Visual inspection: NeedsMe column stands out in amber/bold
- [ ] Visual inspection: Done cards appear dimmed
- [ ] Visual inspection: watcher health line shows signal count

🤖 Generated with [Claude Code](https://claude.com/claude-code)