### PR TITLE
fix: allow gh pr merge when merge_prs capability is enabled

### DIFF
--- a/crates/apiari/src/buzz/coordinator/audit.rs
+++ b/crates/apiari/src/buzz/coordinator/audit.rs
@@ -283,7 +283,7 @@ fn is_shell_passthrough(command: &str) -> bool {
 /// stays intact. This prevents patterns inside string literals (e.g. date
 /// comparisons in `python3 -c` or `jq` filters) from triggering false
 /// positives in WRITE_PATTERNS or redirect detection.
-fn strip_quoted_strings(command: &str) -> String {
+pub(crate) fn strip_quoted_strings(command: &str) -> String {
     let mut result = String::with_capacity(command.len());
     let mut chars = command.chars().peekable();
 

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -616,6 +616,21 @@ pub fn discover_workspaces() -> Result<Vec<Workspace>> {
     Ok(workspaces)
 }
 
+/// Find the workspace whose root most specifically (longest prefix) contains
+/// `cwd`. Returns `None` if no workspace root is a prefix of `cwd`.
+///
+/// Using longest-prefix matching ensures nested workspace roots resolve to the
+/// most specific workspace, which is the correct and consistent behavior.
+pub fn workspace_for_cwd<'a>(
+    workspaces: &'a [Workspace],
+    cwd: &std::path::Path,
+) -> Option<&'a Workspace> {
+    workspaces
+        .iter()
+        .filter(|ws| cwd.starts_with(&ws.config.root))
+        .max_by_key(|ws| ws.config.root.as_os_str().len())
+}
+
 /// Maximum directory depth for recursive repo discovery.
 const MAX_DISCOVER_DEPTH: u32 = 4;
 

--- a/crates/apiari/src/config_set.rs
+++ b/crates/apiari/src/config_set.rs
@@ -21,13 +21,12 @@ fn find_workspace_config(workspace: Option<&str>) -> Result<(String, PathBuf)> {
         return Ok((name.to_string(), path));
     }
 
-    // Auto-detect: find workspace whose root contains cwd
+    // Auto-detect: find workspace whose root most specifically contains cwd.
     let cwd = std::env::current_dir().wrap_err("failed to get current directory")?;
-    for ws in crate::config::discover_workspaces()? {
-        if cwd.starts_with(&ws.config.root) {
-            let path = dir.join(format!("{}.toml", ws.name));
-            return Ok((ws.name, path));
-        }
+    let workspaces = crate::config::discover_workspaces()?;
+    if let Some(ws) = crate::config::workspace_for_cwd(&workspaces, &cwd) {
+        let path = dir.join(format!("{}.toml", ws.name));
+        return Ok((ws.name.clone(), path));
     }
 
     bail!(

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -102,11 +102,16 @@ fn is_merge_allowed() -> bool {
         Err(_) => return false,
     };
 
-    for ws in &workspaces {
-        if cwd.starts_with(&ws.config.root) {
-            let caps = ws.config.capabilities.resolved(ws.config.authority);
-            return caps.merge_prs.is_allowed(None);
-        }
+    // Find the most specific (longest root) matching workspace to handle
+    // nested workspace roots correctly.
+    let best = workspaces
+        .iter()
+        .filter(|ws| cwd.starts_with(&ws.config.root))
+        .max_by_key(|ws| ws.config.root.as_os_str().len());
+
+    if let Some(ws) = best {
+        let caps = ws.config.capabilities.resolved(ws.config.authority);
+        return caps.merge_prs.is_allowed(None);
     }
 
     false
@@ -128,6 +133,31 @@ mod tests {
 
     /// Tests that mutate HOME must hold this lock to avoid interfering with each other.
     static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard that sets HOME on creation and restores (or removes) it on drop.
+    /// Holds the HOME_LOCK for the duration, and handles panics via Drop.
+    struct HomeGuard {
+        orig: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl HomeGuard {
+        fn new(new_home: &std::path::Path) -> Self {
+            let lock = HOME_LOCK.lock().unwrap();
+            let orig = std::env::var("HOME").ok();
+            unsafe { std::env::set_var("HOME", new_home) };
+            Self { orig, _lock: lock }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.orig {
+                Some(h) => unsafe { std::env::set_var("HOME", h) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
 
     #[test]
     fn test_extract_command_valid() {
@@ -246,21 +276,15 @@ mod tests {
 
     #[test]
     fn test_verdict_deny_for_gh_pr_merge_squash() {
-        let _guard = HOME_LOCK.lock().unwrap();
         // gh pr merge is mutating — denied when no workspace config matches
         // (is_merge_allowed fails closed). The reason should reference
         // "gh pr merge", NOT "shell passthrough".
         // Use an empty temp HOME so no real workspace config interferes.
         let tmp = tempfile::tempdir().unwrap();
-        let orig_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _guard = HomeGuard::new(tmp.path());
 
         let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --repo Org/repo --squash --delete-branch"}}"#;
         let verdict = evaluate(input);
-
-        if let Some(h) = orig_home {
-            unsafe { std::env::set_var("HOME", h) };
-        }
 
         match verdict {
             Verdict::Deny { reason } => {
@@ -275,7 +299,6 @@ mod tests {
 
     #[test]
     fn test_verdict_allow_gh_pr_merge_when_capability_enabled() {
-        let _guard = HOME_LOCK.lock().unwrap();
         // When a workspace config with merge_prs=true exists and its root
         // matches the current directory, gh pr merge should be allowed.
         let tmp = tempfile::tempdir().unwrap();
@@ -286,17 +309,10 @@ mod tests {
         let config_content = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = true\n",);
         std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
 
-        // Point config dir to our temp dir
-        let orig_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _guard = HomeGuard::new(tmp.path());
 
         let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --squash"}}"#;
         let verdict = evaluate(input);
-
-        // Restore HOME
-        if let Some(h) = orig_home {
-            unsafe { std::env::set_var("HOME", h) };
-        }
 
         assert_eq!(
             verdict,
@@ -307,7 +323,6 @@ mod tests {
 
     #[test]
     fn test_verdict_deny_gh_pr_merge_when_capability_disabled() {
-        let _guard = HOME_LOCK.lock().unwrap();
         // When merge_prs is explicitly false, gh pr merge should be denied.
         let tmp = tempfile::tempdir().unwrap();
         let ws_dir = tmp.path().join(".config/apiari/workspaces");
@@ -317,15 +332,10 @@ mod tests {
         let config_content = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = false\n",);
         std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
 
-        let orig_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _guard = HomeGuard::new(tmp.path());
 
         let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --squash"}}"#;
         let verdict = evaluate(input);
-
-        if let Some(h) = orig_home {
-            unsafe { std::env::set_var("HOME", h) };
-        }
 
         match verdict {
             Verdict::Deny { reason } => {

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -123,14 +123,7 @@ fn is_merge_allowed() -> bool {
 /// Separated from `is_merge_allowed()` so tests can inject workspaces directly
 /// without mutating environment variables.
 fn check_merge_allowed(cwd: &std::path::Path, workspaces: &[config::Workspace]) -> bool {
-    // Find the most specific (longest root) matching workspace to handle
-    // nested workspace roots correctly.
-    let best = workspaces
-        .iter()
-        .filter(|ws| cwd.starts_with(&ws.config.root))
-        .max_by_key(|ws| ws.config.root.as_os_str().len());
-
-    if let Some(ws) = best {
+    if let Some(ws) = config::workspace_for_cwd(workspaces, cwd) {
         let caps = ws.config.capabilities.resolved(ws.config.authority);
         return match caps.merge_prs {
             config::MergePrsCapability::Bool(allowed) => allowed,

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -125,10 +125,13 @@ fn check_merge_allowed(cwd: &std::path::Path, workspaces: &[config::Workspace]) 
 
     if let Some(ws) = best {
         let caps = ws.config.capabilities.resolved(ws.config.authority);
-        // Match directly: Bool(true) allows, everything else denies.
-        // Branch-scoped configs fail closed because validate-bash doesn't
-        // know the target branch from the command line.
-        return matches!(caps.merge_prs, config::MergePrsCapability::Bool(true));
+        return match caps.merge_prs {
+            config::MergePrsCapability::Bool(allowed) => allowed,
+            // validate-bash can't determine the target branch from the command
+            // line, so branch-scoped configs are treated as "enabled" here.
+            // The coordinator enforces the per-branch restriction later.
+            config::MergePrsCapability::Branches(_) => true,
+        };
     }
 
     false
@@ -296,13 +299,14 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_denied_when_branch_scoped() {
-        // Branch-scoped configs fail closed — validate-bash can't determine
-        // the target branch from the command line.
+    fn test_merge_allowed_when_branch_scoped() {
+        // validate-bash can't determine the target branch, so branch-scoped
+        // configs are treated as "enabled" — the coordinator enforces the
+        // per-branch restriction later.
         let cwd = std::env::current_dir().unwrap();
         let toml = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = [\"main\"]\n");
         let ws = test_workspace(&toml);
-        assert!(!check_merge_allowed(&cwd, &[ws]));
+        assert!(check_merge_allowed(&cwd, &[ws]));
     }
 
     #[test]

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -73,7 +73,11 @@ fn evaluate(input: &str) -> Verdict {
         BashClassification::ReadOnly => Verdict::Allow,
         BashClassification::PotentiallyMutating { matched_pattern } => {
             // Allow gh pr merge if the workspace has merge_prs capability enabled
-            if matched_pattern == "gh pr merge" && is_merge_allowed() {
+            // AND the command is a single invocation (no chaining).
+            if matched_pattern == "gh pr merge"
+                && !contains_command_chaining(&command)
+                && is_merge_allowed()
+            {
                 return Verdict::Allow;
             }
             Verdict::Deny {
@@ -128,13 +132,26 @@ fn check_merge_allowed(cwd: &std::path::Path, workspaces: &[config::Workspace]) 
         return match caps.merge_prs {
             config::MergePrsCapability::Bool(allowed) => allowed,
             // validate-bash can't determine the target branch from the command
-            // line, so branch-scoped configs are treated as "enabled" here.
-            // The coordinator enforces the per-branch restriction later.
-            config::MergePrsCapability::Branches(_) => true,
+            // line, so branch-scoped configs fail closed here. The coordinator
+            // has full context and enforces branch-scoped merges itself.
+            config::MergePrsCapability::Branches(_) => false,
         };
     }
 
     false
+}
+
+/// Check if a command contains shell chaining operators that could bypass
+/// the allowlist (e.g. `gh pr merge 123 && git push`).
+fn contains_command_chaining(command: &str) -> bool {
+    // Check for shell operators that chain or compose commands.
+    // This is intentionally conservative — reject anything suspicious.
+    command.contains("&&")
+        || command.contains("||")
+        || command.contains('|')
+        || command.contains(';')
+        || command.contains('`')
+        || command.contains("$(")
 }
 
 /// Extract the command string from the hook JSON input.
@@ -149,6 +166,38 @@ fn extract_command(input: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Tests that mutate HOME must hold this lock to avoid interfering with each other.
+    static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard that sets HOME on creation and restores (or removes) it on drop.
+    /// Holds the HOME_LOCK for the duration, and handles panics via Drop.
+    struct HomeGuard {
+        orig: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl HomeGuard {
+        fn new(new_home: &std::path::Path) -> Self {
+            let lock = HOME_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let orig = std::env::var("HOME").ok();
+            // Safety: HOME_LOCK serializes all HOME-mutating tests in this module.
+            unsafe { std::env::set_var("HOME", new_home) };
+            Self { orig, _lock: lock }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.orig {
+                Some(h) => unsafe { std::env::set_var("HOME", h) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
 
     /// Build a test workspace by parsing a TOML config string.
     fn test_workspace(toml_content: &str) -> config::Workspace {
@@ -274,6 +323,78 @@ mod tests {
         );
     }
 
+    // -- evaluate() end-to-end tests for gh pr merge --
+
+    #[test]
+    fn test_evaluate_denies_gh_pr_merge_without_config() {
+        // evaluate() should deny gh pr merge when no workspace config matches
+        // (is_merge_allowed fails closed). Use empty temp HOME.
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = HomeGuard::new(tmp.path());
+
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --repo Org/repo --squash --delete-branch"}}"#;
+        match evaluate(input) {
+            Verdict::Deny { reason } => {
+                assert!(
+                    reason.contains("gh pr merge"),
+                    "reason should reference gh pr merge: {reason}"
+                );
+            }
+            Verdict::Allow => panic!("expected Deny for gh pr merge without config"),
+        }
+    }
+
+    #[test]
+    fn test_evaluate_allows_gh_pr_merge_with_config() {
+        // evaluate() should allow gh pr merge when workspace has merge_prs=true.
+        let tmp = tempfile::tempdir().unwrap();
+        let ws_dir = tmp.path().join(".config/apiari/workspaces");
+        std::fs::create_dir_all(&ws_dir).unwrap();
+
+        let cwd = std::env::current_dir().unwrap();
+        let config_content = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = true\n");
+        std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
+
+        let _guard = HomeGuard::new(tmp.path());
+
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --squash"}}"#;
+        assert_eq!(
+            evaluate(input),
+            Verdict::Allow,
+            "evaluate() should allow gh pr merge when merge_prs=true"
+        );
+    }
+
+    #[test]
+    fn test_evaluate_denies_gh_pr_merge_with_chaining() {
+        // Command chaining must always be denied, even with merge_prs enabled.
+        let tmp = tempfile::tempdir().unwrap();
+        let ws_dir = tmp.path().join(".config/apiari/workspaces");
+        std::fs::create_dir_all(&ws_dir).unwrap();
+
+        let cwd = std::env::current_dir().unwrap();
+        let config_content = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = true\n");
+        std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
+
+        let _guard = HomeGuard::new(tmp.path());
+
+        let cases = &[
+            r#"gh pr merge 123 --squash && git push"#,
+            r#"gh pr merge 123 --squash; rm -rf /"#,
+            r#"gh pr merge 123 --squash || echo fail"#,
+            r#"gh pr merge 123 --squash | tee log"#,
+            r#"gh pr merge `echo 123` --squash"#,
+            r#"gh pr merge $(echo 123) --squash"#,
+        ];
+        for cmd in cases {
+            let input = format!(r#"{{"tool_name":"Bash","tool_input":{{"command":"{cmd}"}}}}"#,);
+            match evaluate(&input) {
+                Verdict::Deny { .. } => {} // expected
+                Verdict::Allow => panic!("expected Deny for chained command: {cmd}"),
+            }
+        }
+    }
+
     // -- check_merge_allowed tests: use injected workspaces, no env var mutation --
 
     #[test]
@@ -299,14 +420,13 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_allowed_when_branch_scoped() {
+    fn test_merge_denied_when_branch_scoped() {
         // validate-bash can't determine the target branch, so branch-scoped
-        // configs are treated as "enabled" — the coordinator enforces the
-        // per-branch restriction later.
+        // configs fail closed. The coordinator enforces branch-scoped merges.
         let cwd = std::env::current_dir().unwrap();
         let toml = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = [\"main\"]\n");
         let ws = test_workspace(&toml);
-        assert!(check_merge_allowed(&cwd, &[ws]));
+        assert!(!check_merge_allowed(&cwd, &[ws]));
     }
 
     #[test]

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -11,6 +11,7 @@
 //! (which can deregister the tool for the session).
 
 use crate::buzz::coordinator::audit::{self, BashClassification};
+use crate::config;
 use std::io::Read;
 
 /// The hook's verdict: either allow (no stdout) or deny (JSON on stdout).
@@ -70,12 +71,45 @@ fn evaluate(input: &str) -> Verdict {
 
     match audit::classify_bash_command_with_devmode(&command) {
         BashClassification::ReadOnly => Verdict::Allow,
-        BashClassification::PotentiallyMutating { matched_pattern } => Verdict::Deny {
-            reason: format!(
-                "BLOCKED: coordinator attempted mutating Bash command (matched: {matched_pattern})"
-            ),
-        },
+        BashClassification::PotentiallyMutating { matched_pattern } => {
+            // Allow gh pr merge if the workspace has merge_prs capability enabled
+            if matched_pattern == "gh pr merge" && is_merge_allowed() {
+                return Verdict::Allow;
+            }
+            Verdict::Deny {
+                reason: format!(
+                    "BLOCKED: coordinator attempted mutating Bash command (matched: {matched_pattern})"
+                ),
+            }
+        }
     }
+}
+
+/// Check if the current workspace allows PR merging.
+///
+/// Scans `~/.config/apiari/workspaces/*.toml` for a workspace whose `root`
+/// matches the current working directory (or is a parent of it). If found,
+/// checks the `merge_prs` capability. Fails closed (returns false) if the
+/// config can't be loaded or no matching workspace is found.
+fn is_merge_allowed() -> bool {
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+
+    let workspaces = match config::discover_workspaces() {
+        Ok(ws) => ws,
+        Err(_) => return false,
+    };
+
+    for ws in &workspaces {
+        if cwd.starts_with(&ws.config.root) {
+            let caps = ws.config.capabilities.resolved(ws.config.authority);
+            return caps.merge_prs.is_allowed(None);
+        }
+    }
+
+    false
 }
 
 /// Extract the command string from the hook JSON input.
@@ -90,6 +124,10 @@ fn extract_command(input: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Tests that mutate HOME must hold this lock to avoid interfering with each other.
+    static HOME_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_extract_command_valid() {
@@ -208,10 +246,22 @@ mod tests {
 
     #[test]
     fn test_verdict_deny_for_gh_pr_merge_squash() {
-        // gh pr merge is mutating — must be denied, and the reason should
-        // reference "gh pr merge", NOT "shell passthrough".
+        let _guard = HOME_LOCK.lock().unwrap();
+        // gh pr merge is mutating — denied when no workspace config matches
+        // (is_merge_allowed fails closed). The reason should reference
+        // "gh pr merge", NOT "shell passthrough".
+        // Use an empty temp HOME so no real workspace config interferes.
+        let tmp = tempfile::tempdir().unwrap();
+        let orig_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+
         let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --repo Org/repo --squash --delete-branch"}}"#;
         let verdict = evaluate(input);
+
+        if let Some(h) = orig_home {
+            unsafe { std::env::set_var("HOME", h) };
+        }
+
         match verdict {
             Verdict::Deny { reason } => {
                 assert!(
@@ -220,6 +270,68 @@ mod tests {
                 );
             }
             Verdict::Allow => panic!("expected Deny for gh pr merge"),
+        }
+    }
+
+    #[test]
+    fn test_verdict_allow_gh_pr_merge_when_capability_enabled() {
+        let _guard = HOME_LOCK.lock().unwrap();
+        // When a workspace config with merge_prs=true exists and its root
+        // matches the current directory, gh pr merge should be allowed.
+        let tmp = tempfile::tempdir().unwrap();
+        let ws_dir = tmp.path().join(".config/apiari/workspaces");
+        std::fs::create_dir_all(&ws_dir).unwrap();
+
+        let cwd = std::env::current_dir().unwrap();
+        let config_content = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = true\n",);
+        std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
+
+        // Point config dir to our temp dir
+        let orig_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --squash"}}"#;
+        let verdict = evaluate(input);
+
+        // Restore HOME
+        if let Some(h) = orig_home {
+            unsafe { std::env::set_var("HOME", h) };
+        }
+
+        assert_eq!(
+            verdict,
+            Verdict::Allow,
+            "gh pr merge should be allowed when merge_prs capability is enabled"
+        );
+    }
+
+    #[test]
+    fn test_verdict_deny_gh_pr_merge_when_capability_disabled() {
+        let _guard = HOME_LOCK.lock().unwrap();
+        // When merge_prs is explicitly false, gh pr merge should be denied.
+        let tmp = tempfile::tempdir().unwrap();
+        let ws_dir = tmp.path().join(".config/apiari/workspaces");
+        std::fs::create_dir_all(&ws_dir).unwrap();
+
+        let cwd = std::env::current_dir().unwrap();
+        let config_content = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = false\n",);
+        std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
+
+        let orig_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --squash"}}"#;
+        let verdict = evaluate(input);
+
+        if let Some(h) = orig_home {
+            unsafe { std::env::set_var("HOME", h) };
+        }
+
+        match verdict {
+            Verdict::Deny { reason } => {
+                assert!(reason.contains("gh pr merge"));
+            }
+            Verdict::Allow => panic!("expected Deny when merge_prs is false"),
         }
     }
 

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -143,20 +143,24 @@ fn check_merge_allowed(cwd: &std::path::Path, workspaces: &[config::Workspace]) 
 
 /// Check if a command contains shell chaining operators that could bypass
 /// the allowlist (e.g. `gh pr merge 123 && git push`).
+///
+/// Strips quoted strings first so that metacharacters inside arguments
+/// (e.g. `--body "a | b"`) don't trigger false positives.
 fn contains_command_chaining(command: &str) -> bool {
+    let stripped = audit::strip_quoted_strings(command);
     // Check for shell operators that chain or compose commands.
     // This is intentionally conservative — reject anything suspicious.
-    command.contains("&&")
-        || command.contains("||")
-        || command.contains('|')
-        || command.contains(';')
-        || command.contains('`')
-        || command.contains("$(")
-        || command.contains('&')
-        || command.contains('\n')
-        || command.contains('\r')
-        || command.contains(">(")
-        || command.contains("<(")
+    stripped.contains("&&")
+        || stripped.contains("||")
+        || stripped.contains('|')
+        || stripped.contains(';')
+        || stripped.contains('`')
+        || stripped.contains("$(")
+        || stripped.contains('&')
+        || stripped.contains('\n')
+        || stripped.contains('\r')
+        || stripped.contains(">(")
+        || stripped.contains("<(")
 }
 
 /// Extract the command string from the hook JSON input.
@@ -410,6 +414,21 @@ mod tests {
                 Verdict::Allow => panic!("expected Deny for chained command: {cmd}"),
             }
         }
+    }
+
+    #[test]
+    fn test_chaining_check_ignores_quoted_metacharacters() {
+        // Metacharacters inside quoted strings are arguments, not operators.
+        assert!(!contains_command_chaining(
+            r#"gh pr merge 123 --body "fix: a | b && c""#
+        ));
+        assert!(!contains_command_chaining(
+            "gh pr merge 123 --body 'use foo; bar'"
+        ));
+        // But unquoted metacharacters still trigger.
+        assert!(contains_command_chaining(
+            r#"gh pr merge 123 --body "safe" && git push"#
+        ));
     }
 
     // -- check_merge_allowed tests: use injected workspaces, no env var mutation --

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -152,6 +152,11 @@ fn contains_command_chaining(command: &str) -> bool {
         || command.contains(';')
         || command.contains('`')
         || command.contains("$(")
+        || command.contains('&')
+        || command.contains('\n')
+        || command.contains('\r')
+        || command.contains(">(")
+        || command.contains("<(")
 }
 
 /// Extract the command string from the hook JSON input.
@@ -169,6 +174,10 @@ mod tests {
     use std::sync::Mutex;
 
     /// Tests that mutate HOME must hold this lock to avoid interfering with each other.
+    /// Note: this only serializes tests within this module. Tests in other modules that
+    /// read HOME could observe the temporary value. This is an accepted tradeoff — the
+    /// pure-logic check_merge_allowed() tests cover most cases without env mutation;
+    /// only the evaluate() end-to-end tests need HOME isolation.
     static HOME_LOCK: Mutex<()> = Mutex::new(());
 
     /// RAII guard that sets HOME on creation and restores (or removes) it on drop.
@@ -385,7 +394,15 @@ mod tests {
             r#"gh pr merge 123 --squash | tee log"#,
             r#"gh pr merge `echo 123` --squash"#,
             r#"gh pr merge $(echo 123) --squash"#,
+            "gh pr merge 123 --squash & rm -rf /",
+            "gh pr merge 123 >(tee log) --squash",
+            "gh pr merge 123 <(cat prs) --squash",
         ];
+
+        // Newlines/carriage returns can't be embedded in JSON test strings,
+        // so test contains_command_chaining directly for those.
+        assert!(contains_command_chaining("gh pr merge 123\nrm -rf /"));
+        assert!(contains_command_chaining("gh pr merge 123\rrm -rf /"));
         for cmd in cases {
             let input = format!(r#"{{"tool_name":"Bash","tool_input":{{"command":"{cmd}"}}}}"#,);
             match evaluate(&input) {

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -111,7 +111,9 @@ fn is_merge_allowed() -> bool {
 
     if let Some(ws) = best {
         let caps = ws.config.capabilities.resolved(ws.config.authority);
-        return caps.merge_prs.is_allowed(None);
+        // Pass Some("") so branch-scoped configs (e.g. ["main"]) fail closed
+        // when the target branch is unknown from the command line.
+        return caps.merge_prs.is_allowed(Some(""));
     }
 
     false
@@ -143,7 +145,9 @@ mod tests {
 
     impl HomeGuard {
         fn new(new_home: &std::path::Path) -> Self {
-            let lock = HOME_LOCK.lock().unwrap();
+            let lock = HOME_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             let orig = std::env::var("HOME").ok();
             unsafe { std::env::set_var("HOME", new_home) };
             Self { orig, _lock: lock }
@@ -319,6 +323,33 @@ mod tests {
             Verdict::Allow,
             "gh pr merge should be allowed when merge_prs capability is enabled"
         );
+    }
+
+    #[test]
+    fn test_verdict_deny_gh_pr_merge_when_branch_scoped() {
+        // merge_prs = ["main"] should deny because we can't determine the
+        // target branch from the command — fails closed with Some("").
+        let tmp = tempfile::tempdir().unwrap();
+        let ws_dir = tmp.path().join(".config/apiari/workspaces");
+        std::fs::create_dir_all(&ws_dir).unwrap();
+
+        let cwd = std::env::current_dir().unwrap();
+        let config_content = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = [\"main\"]\n",);
+        std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
+
+        let _guard = HomeGuard::new(tmp.path());
+
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --squash"}}"#;
+        let verdict = evaluate(input);
+
+        match verdict {
+            Verdict::Deny { reason } => {
+                assert!(reason.contains("gh pr merge"));
+            }
+            Verdict::Allow => {
+                panic!("expected Deny for branch-scoped merge_prs when target branch is unknown")
+            }
+        }
     }
 
     #[test]

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -322,6 +322,32 @@ mod tests {
     }
 
     #[test]
+    fn test_verdict_deny_gh_pr_merge_when_observe_mode() {
+        // Even with merge_prs=true, observe mode forces it off — must deny.
+        let tmp = tempfile::tempdir().unwrap();
+        let ws_dir = tmp.path().join(".config/apiari/workspaces");
+        std::fs::create_dir_all(&ws_dir).unwrap();
+
+        let cwd = std::env::current_dir().unwrap();
+        let config_content = format!(
+            "root = {cwd:?}\nauthority = \"observe\"\n\n[capabilities]\nmerge_prs = true\n",
+        );
+        std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
+
+        let _guard = HomeGuard::new(tmp.path());
+
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --squash"}}"#;
+        let verdict = evaluate(input);
+
+        match verdict {
+            Verdict::Deny { reason } => {
+                assert!(reason.contains("gh pr merge"));
+            }
+            Verdict::Allow => panic!("expected Deny when authority is observe"),
+        }
+    }
+
+    #[test]
     fn test_verdict_deny_gh_pr_merge_when_capability_disabled() {
         // When merge_prs is explicitly false, gh pr merge should be denied.
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -74,10 +74,13 @@ fn evaluate(input: &str) -> Verdict {
         BashClassification::PotentiallyMutating { matched_pattern } => {
             // Allow gh pr merge if the workspace has merge_prs capability enabled
             // AND the command is a single invocation (no chaining).
-            if matched_pattern == "gh pr merge"
-                && !contains_command_chaining(&command)
-                && is_merge_allowed()
-            {
+            // Check both matched_pattern (the audit classifier's match) and the
+            // raw command start as a fallback — the command could match a broader
+            // pattern first (e.g. a shell passthrough) while still being a
+            // plain `gh pr merge` invocation that should be allowed.
+            let is_gh_pr_merge =
+                matched_pattern == "gh pr merge" || command.trim_start().starts_with("gh pr merge");
+            if is_gh_pr_merge && !contains_command_chaining(&command) && is_merge_allowed() {
                 return Verdict::Allow;
             }
             Verdict::Deny {

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -147,18 +147,22 @@ fn check_merge_allowed(cwd: &std::path::Path, workspaces: &[config::Workspace]) 
 /// Check if a command contains shell chaining operators that could bypass
 /// the allowlist (e.g. `gh pr merge 123 && git push`).
 ///
-/// Strips quoted strings first so that metacharacters inside arguments
-/// (e.g. `--body "a | b"`) don't trigger false positives.
+/// Command substitution (`$(...)` and backticks) is checked on the RAW
+/// command before quote-stripping, because the shell executes substitutions
+/// inside double quotes (e.g. `--body "$(rm -rf /)"` is still dangerous).
+/// Other metacharacters are checked on the quote-stripped form to avoid
+/// false positives from literal pipe/semicolons in argument values.
 fn contains_command_chaining(command: &str) -> bool {
+    // Check command substitution on raw command — these execute inside quotes.
+    if command.contains("$(") || command.contains('`') {
+        return true;
+    }
     let stripped = audit::strip_quoted_strings(command);
-    // Check for shell operators that chain or compose commands.
-    // This is intentionally conservative — reject anything suspicious.
+    // Check remaining shell operators on the stripped form.
     stripped.contains("&&")
         || stripped.contains("||")
         || stripped.contains('|')
         || stripped.contains(';')
-        || stripped.contains('`')
-        || stripped.contains("$(")
         || stripped.contains('&')
         || stripped.contains('\n')
         || stripped.contains('\r')
@@ -431,6 +435,23 @@ mod tests {
         // But unquoted metacharacters still trigger.
         assert!(contains_command_chaining(
             r#"gh pr merge 123 --body "safe" && git push"#
+        ));
+    }
+
+    #[test]
+    fn test_chaining_check_catches_substitution_inside_quotes() {
+        // Command substitution executes even inside double quotes — must be
+        // caught on the raw command before quote-stripping.
+        assert!(contains_command_chaining(
+            r#"gh pr merge 123 --body "$(rm -rf /)""#
+        ));
+        assert!(contains_command_chaining(
+            r#"gh pr merge 123 --body "`rm -rf /`""#
+        ));
+        // Single-quoted substitution: shell does NOT expand $() inside '', so
+        // this won't execute — but we still flag $(  for safety.
+        assert!(contains_command_chaining(
+            "gh pr merge 123 --body '$(rm -rf /)'"
         ));
     }
 

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -92,6 +92,12 @@ fn evaluate(input: &str) -> Verdict {
 /// checks the `merge_prs` capability. Fails closed (returns false) if the
 /// config can't be loaded or no matching workspace is found.
 fn is_merge_allowed() -> bool {
+    // Fail closed if home dir can't be determined — config_dir() falls back
+    // to "." which could read arbitrary workspace configs from CWD.
+    if dirs::home_dir().is_none() {
+        return false;
+    }
+
     let cwd = match std::env::current_dir() {
         Ok(p) => p,
         Err(_) => return false,
@@ -102,6 +108,14 @@ fn is_merge_allowed() -> bool {
         Err(_) => return false,
     };
 
+    check_merge_allowed(&cwd, &workspaces)
+}
+
+/// Pure logic: check if merging is allowed for the given cwd and workspace list.
+///
+/// Separated from `is_merge_allowed()` so tests can inject workspaces directly
+/// without mutating environment variables.
+fn check_merge_allowed(cwd: &std::path::Path, workspaces: &[config::Workspace]) -> bool {
     // Find the most specific (longest root) matching workspace to handle
     // nested workspace roots correctly.
     let best = workspaces
@@ -111,9 +125,10 @@ fn is_merge_allowed() -> bool {
 
     if let Some(ws) = best {
         let caps = ws.config.capabilities.resolved(ws.config.authority);
-        // Pass Some("") so branch-scoped configs (e.g. ["main"]) fail closed
-        // when the target branch is unknown from the command line.
-        return caps.merge_prs.is_allowed(Some(""));
+        // Match directly: Bool(true) allows, everything else denies.
+        // Branch-scoped configs fail closed because validate-bash doesn't
+        // know the target branch from the command line.
+        return matches!(caps.merge_prs, config::MergePrsCapability::Bool(true));
     }
 
     false
@@ -131,35 +146,13 @@ fn extract_command(input: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    /// Tests that mutate HOME must hold this lock to avoid interfering with each other.
-    static HOME_LOCK: Mutex<()> = Mutex::new(());
-
-    /// RAII guard that sets HOME on creation and restores (or removes) it on drop.
-    /// Holds the HOME_LOCK for the duration, and handles panics via Drop.
-    struct HomeGuard {
-        orig: Option<String>,
-        _lock: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl HomeGuard {
-        fn new(new_home: &std::path::Path) -> Self {
-            let lock = HOME_LOCK
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let orig = std::env::var("HOME").ok();
-            unsafe { std::env::set_var("HOME", new_home) };
-            Self { orig, _lock: lock }
-        }
-    }
-
-    impl Drop for HomeGuard {
-        fn drop(&mut self) {
-            match &self.orig {
-                Some(h) => unsafe { std::env::set_var("HOME", h) },
-                None => unsafe { std::env::remove_var("HOME") },
-            }
+    /// Build a test workspace by parsing a TOML config string.
+    fn test_workspace(toml_content: &str) -> config::Workspace {
+        let cfg: config::WorkspaceConfig = toml::from_str(toml_content).expect("invalid test TOML");
+        config::Workspace {
+            name: "test".to_string(),
+            config: cfg,
         }
     }
 
@@ -278,128 +271,63 @@ mod tests {
         );
     }
 
+    // -- check_merge_allowed tests: use injected workspaces, no env var mutation --
+
     #[test]
-    fn test_verdict_deny_for_gh_pr_merge_squash() {
-        // gh pr merge is mutating — denied when no workspace config matches
-        // (is_merge_allowed fails closed). The reason should reference
-        // "gh pr merge", NOT "shell passthrough".
-        // Use an empty temp HOME so no real workspace config interferes.
-        let tmp = tempfile::tempdir().unwrap();
-        let _guard = HomeGuard::new(tmp.path());
-
-        let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --repo Org/repo --squash --delete-branch"}}"#;
-        let verdict = evaluate(input);
-
-        match verdict {
-            Verdict::Deny { reason } => {
-                assert!(
-                    reason.contains("gh pr merge"),
-                    "reason should reference gh pr merge, not shell passthrough: {reason}"
-                );
-            }
-            Verdict::Allow => panic!("expected Deny for gh pr merge"),
-        }
+    fn test_merge_denied_when_no_workspaces() {
+        let cwd = std::env::current_dir().unwrap();
+        assert!(!check_merge_allowed(&cwd, &[]));
     }
 
     #[test]
-    fn test_verdict_allow_gh_pr_merge_when_capability_enabled() {
-        // When a workspace config with merge_prs=true exists and its root
-        // matches the current directory, gh pr merge should be allowed.
-        let tmp = tempfile::tempdir().unwrap();
-        let ws_dir = tmp.path().join(".config/apiari/workspaces");
-        std::fs::create_dir_all(&ws_dir).unwrap();
-
+    fn test_merge_allowed_when_capability_enabled() {
         let cwd = std::env::current_dir().unwrap();
-        let config_content = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = true\n",);
-        std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
+        let toml = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = true\n");
+        let ws = test_workspace(&toml);
+        assert!(check_merge_allowed(&cwd, &[ws]));
+    }
 
-        let _guard = HomeGuard::new(tmp.path());
+    #[test]
+    fn test_merge_denied_when_capability_disabled() {
+        let cwd = std::env::current_dir().unwrap();
+        let toml = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = false\n");
+        let ws = test_workspace(&toml);
+        assert!(!check_merge_allowed(&cwd, &[ws]));
+    }
 
-        let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --squash"}}"#;
-        let verdict = evaluate(input);
+    #[test]
+    fn test_merge_denied_when_branch_scoped() {
+        // Branch-scoped configs fail closed — validate-bash can't determine
+        // the target branch from the command line.
+        let cwd = std::env::current_dir().unwrap();
+        let toml = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = [\"main\"]\n");
+        let ws = test_workspace(&toml);
+        assert!(!check_merge_allowed(&cwd, &[ws]));
+    }
 
-        assert_eq!(
-            verdict,
-            Verdict::Allow,
-            "gh pr merge should be allowed when merge_prs capability is enabled"
+    #[test]
+    fn test_merge_denied_when_observe_mode() {
+        // Observe mode forces merge_prs off even if config says true.
+        let cwd = std::env::current_dir().unwrap();
+        let toml = format!(
+            "root = {cwd:?}\nauthority = \"observe\"\n\n[capabilities]\nmerge_prs = true\n"
         );
+        let ws = test_workspace(&toml);
+        assert!(!check_merge_allowed(&cwd, &[ws]));
     }
 
     #[test]
-    fn test_verdict_deny_gh_pr_merge_when_branch_scoped() {
-        // merge_prs = ["main"] should deny because we can't determine the
-        // target branch from the command — fails closed with Some("").
-        let tmp = tempfile::tempdir().unwrap();
-        let ws_dir = tmp.path().join(".config/apiari/workspaces");
-        std::fs::create_dir_all(&ws_dir).unwrap();
-
+    fn test_merge_uses_most_specific_workspace() {
+        // Nested roots: inner workspace (merge_prs=false) should win over
+        // outer workspace (merge_prs=true).
         let cwd = std::env::current_dir().unwrap();
-        let config_content = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = [\"main\"]\n",);
-        std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
-
-        let _guard = HomeGuard::new(tmp.path());
-
-        let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --squash"}}"#;
-        let verdict = evaluate(input);
-
-        match verdict {
-            Verdict::Deny { reason } => {
-                assert!(reason.contains("gh pr merge"));
-            }
-            Verdict::Allow => {
-                panic!("expected Deny for branch-scoped merge_prs when target branch is unknown")
-            }
-        }
-    }
-
-    #[test]
-    fn test_verdict_deny_gh_pr_merge_when_observe_mode() {
-        // Even with merge_prs=true, observe mode forces it off — must deny.
-        let tmp = tempfile::tempdir().unwrap();
-        let ws_dir = tmp.path().join(".config/apiari/workspaces");
-        std::fs::create_dir_all(&ws_dir).unwrap();
-
-        let cwd = std::env::current_dir().unwrap();
-        let config_content = format!(
-            "root = {cwd:?}\nauthority = \"observe\"\n\n[capabilities]\nmerge_prs = true\n",
-        );
-        std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
-
-        let _guard = HomeGuard::new(tmp.path());
-
-        let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --squash"}}"#;
-        let verdict = evaluate(input);
-
-        match verdict {
-            Verdict::Deny { reason } => {
-                assert!(reason.contains("gh pr merge"));
-            }
-            Verdict::Allow => panic!("expected Deny when authority is observe"),
-        }
-    }
-
-    #[test]
-    fn test_verdict_deny_gh_pr_merge_when_capability_disabled() {
-        // When merge_prs is explicitly false, gh pr merge should be denied.
-        let tmp = tempfile::tempdir().unwrap();
-        let ws_dir = tmp.path().join(".config/apiari/workspaces");
-        std::fs::create_dir_all(&ws_dir).unwrap();
-
-        let cwd = std::env::current_dir().unwrap();
-        let config_content = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = false\n",);
-        std::fs::write(ws_dir.join("test.toml"), &config_content).unwrap();
-
-        let _guard = HomeGuard::new(tmp.path());
-
-        let input = r#"{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --squash"}}"#;
-        let verdict = evaluate(input);
-
-        match verdict {
-            Verdict::Deny { reason } => {
-                assert!(reason.contains("gh pr merge"));
-            }
-            Verdict::Allow => panic!("expected Deny when merge_prs is false"),
-        }
+        let parent = cwd.parent().unwrap();
+        let outer_toml = format!("root = {parent:?}\n\n[capabilities]\nmerge_prs = true\n");
+        let inner_toml = format!("root = {cwd:?}\n\n[capabilities]\nmerge_prs = false\n");
+        let outer = test_workspace(&outer_toml);
+        let inner = test_workspace(&inner_toml);
+        // Order shouldn't matter — longest prefix wins.
+        assert!(!check_merge_allowed(&cwd, &[outer, inner]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- The validate-bash hook was blocking all `gh pr merge` commands unconditionally, even when the workspace config had `merge_prs = true`
- Added `is_merge_allowed()` / `check_merge_allowed()` which discovers the workspace config by matching `cwd` against workspace roots in `~/.config/apiari/workspaces/*.toml`, then checks the `merge_prs` capability (respecting authority level)
- Matches on `MergePrsCapability` directly: `Bool(true)` allows, `Bool(false)` and `Branches(_)` deny (branch-scoped fails closed since validate-bash can't determine the target branch)
- Rejects commands with shell chaining operators (`&&`, `||`, `;`, `|`, backticks, `$()`) to prevent allowlist bypass
- Fails closed: denies if HOME is missing, no matching workspace is found, or config can't be loaded

## Test plan
- [x] `test_evaluate_denies_gh_pr_merge_without_config` — evaluate() denies when no workspace matches
- [x] `test_evaluate_allows_gh_pr_merge_with_config` — evaluate() allows when merge_prs=true
- [x] `test_evaluate_denies_gh_pr_merge_with_chaining` — evaluate() denies chained commands (&&, ||, ;, |, backticks, $())
- [x] `test_merge_allowed_when_capability_enabled` — check_merge_allowed allows with merge_prs=true
- [x] `test_merge_denied_when_capability_disabled` — denies with merge_prs=false
- [x] `test_merge_denied_when_branch_scoped` — denies with merge_prs=["main"]
- [x] `test_merge_denied_when_observe_mode` — denies when authority=observe
- [x] `test_merge_denied_when_no_workspaces` — denies with empty workspace list
- [x] `test_merge_uses_most_specific_workspace` — longest-prefix workspace wins
- [x] All 21 validate_bash tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)