### PR TITLE
feat: add keyboard navigation and card actions to kanban strip

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -422,6 +422,24 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
     cards
 }
 
+/// Remove stale entries from `kanban_dismissed` so it doesn't grow without
+/// bound over a long TUI session.  An ID is kept only if its underlying
+/// worker or signal still exists in the workspace.
+fn prune_kanban_dismissed(ws: &mut WorkspaceState) {
+    ws.kanban_dismissed.retain(|id| {
+        if let Some(worker_id) = id.strip_prefix("worker:") {
+            ws.workers.iter().any(|w| w.id == worker_id)
+        } else if let Some(sig_id_str) = id.strip_prefix("signal:") {
+            sig_id_str
+                .parse::<i64>()
+                .map(|sig_id| ws.signals.iter().any(|s| s.id == sig_id))
+                .unwrap_or(false)
+        } else {
+            false
+        }
+    });
+}
+
 /// Check if a signal is already represented by a worker's PR card.
 fn signal_covered_by_worker(
     sig: &SignalRecord,
@@ -444,9 +462,12 @@ fn signal_covered_by_worker(
     false
 }
 
-/// How many cards in `stage` are actually visible in the kanban strip,
-/// using the same height formula as `render::kanban_strip_height`.
-/// Navigation and clamping use this to avoid selecting off-screen cards.
+/// How many cards in `stage` are actually visible in the kanban strip.
+/// Uses the same strip-height formula as the renderer (inlined here to
+/// avoid a circular dependency on the render module): strip height is
+/// `(max_cards * 2 + 3).clamp(3, 8)`, cards_fit = `(strip_h - 3) / 2`.
+/// Navigation and clamping use this so Enter/Dismiss never target an
+/// off-screen card.
 fn ws_kanban_visible_count(ws: &WorkspaceState, stage: KanbanStage) -> usize {
     let total = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
     if total == 0 {
@@ -2753,7 +2774,8 @@ impl App {
             }
 
             ws.prev_signal_ids = current_ids;
-            // Rebuild kanban cards from updated state
+            // Rebuild kanban cards from updated state (prune stale dismissed IDs first)
+            prune_kanban_dismissed(ws);
             ws.kanban_cards = build_kanban_cards(ws);
         }
         self.last_signal_refresh = Instant::now();
@@ -2866,7 +2888,8 @@ impl App {
                     .collect();
 
                 ws.workers = new_workers;
-                // Rebuild kanban cards from updated state
+                // Rebuild kanban cards from updated state (prune stale dismissed IDs first)
+                prune_kanban_dismissed(ws);
                 ws.kanban_cards = build_kanban_cards(ws);
             }
         }
@@ -2915,7 +2938,8 @@ impl App {
 
                 ws.prev_signal_ids = current_ids;
                 ws.signals = new_signals;
-                // Rebuild kanban cards from updated state
+                // Rebuild kanban cards from updated state (prune stale dismissed IDs first)
+                prune_kanban_dismissed(ws);
                 ws.kanban_cards = build_kanban_cards(ws);
             }
         }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -4773,4 +4773,21 @@ mod tests {
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].icon, "⚡");
     }
+
+    #[test]
+    fn test_kanban_dismissed_cards_filtered() {
+        let mut ws = empty_ws();
+        ws.workers = vec![
+            make_worker("abc-1234", "running", None),
+            make_worker("def-5678", "running", None),
+        ];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 2);
+
+        // Dismiss the first card
+        ws.kanban_dismissed.insert(cards[0].id.clone());
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(cards.len(), 1, "dismissed card should be filtered out");
+        assert!(!cards[0].id.contains("abc-1234"));
+    }
 }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1743,7 +1743,8 @@ impl App {
         };
         let visible = ws_kanban_visible_count(ws, stage, self.kanban_allocated_height.get());
         if visible > 0 {
-            let new_idx = (idx + 1) % visible;
+            let clamped = idx.min(visible - 1);
+            let new_idx = (clamped + 1) % visible;
             if let Some(ws) = self.current_ws_mut() {
                 ws.kanban_selected = Some((stage, new_idx));
             }
@@ -1775,7 +1776,12 @@ impl App {
         };
         let visible = ws_kanban_visible_count(ws, stage, self.kanban_allocated_height.get());
         if visible > 0 {
-            let new_idx = if idx == 0 { visible - 1 } else { idx - 1 };
+            let clamped = idx.min(visible - 1);
+            let new_idx = if clamped == 0 {
+                visible - 1
+            } else {
+                clamped - 1
+            };
             if let Some(ws) = self.current_ws_mut() {
                 ws.kanban_selected = Some((stage, new_idx));
             }
@@ -1787,6 +1793,10 @@ impl App {
     pub fn kanban_action_selected(&self) -> Option<String> {
         let ws = self.current_ws()?;
         let (stage, idx) = ws.kanban_selected?;
+        let visible = ws_kanban_visible_count(ws, stage, self.kanban_allocated_height.get());
+        if idx >= visible {
+            return None;
+        }
         let card = ws
             .kanban_cards
             .iter()
@@ -1829,6 +1839,7 @@ impl App {
 
     /// Dismiss the currently selected kanban card (remove from board).
     pub fn kanban_dismiss_selected(&mut self) {
+        let allocated_h = self.kanban_allocated_height.get();
         let ws = match self.current_ws_mut() {
             Some(w) => w,
             None => return,
@@ -1837,6 +1848,10 @@ impl App {
             Some(s) => s,
             None => return,
         };
+        let visible = ws_kanban_visible_count(ws, stage, allocated_h);
+        if idx >= visible {
+            return;
+        }
         let card_id = ws
             .kanban_cards
             .iter()

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -463,11 +463,8 @@ fn signal_covered_by_worker(
 }
 
 /// How many cards in `stage` are actually visible in the kanban strip.
-/// Uses the same strip-height formula as the renderer (inlined here to
-/// avoid a circular dependency on the render module): strip height is
-/// `(max_cards * 2 + 3).clamp(3, 8)`, cards_fit = `(strip_h - 3) / 2`.
-/// Navigation and clamping use this so Enter/Dismiss never target an
-/// off-screen card.
+/// Mirrors the height logic in `render::compute_kanban_height` and the
+/// per-column clamping based on `area.height` in `render::draw_kanban_column`.
 fn ws_kanban_visible_count(ws: &WorkspaceState, stage: KanbanStage) -> usize {
     let total = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
     if total == 0 {

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -416,6 +416,9 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
     let cutoff = now - chrono::Duration::minutes(30);
     cards.retain(|c| c.stage != KanbanStage::Done || c.entered_stage_at > cutoff);
 
+    // Filter out dismissed cards
+    cards.retain(|c| !ws.kanban_dismissed.contains(&c.id));
+
     cards
 }
 
@@ -439,6 +442,16 @@ fn signal_covered_by_worker(
         }
     }
     false
+}
+
+/// Extract PR number from a kanban card subtitle like "PR #42 · merge?".
+fn kanban_extract_pr_number(subtitle: &str) -> Option<u64> {
+    let start = subtitle.find("PR #")? + 4;
+    let end = subtitle[start..]
+        .find(|c: char| !c.is_ascii_digit())
+        .map(|i| start + i)
+        .unwrap_or(subtitle.len());
+    subtitle[start..end].parse().ok()
 }
 
 /// Try to extract a PR number from a signal's external_id or metadata.
@@ -699,6 +712,10 @@ pub struct WorkspaceState {
     pub pending_notifications: Vec<String>,
     /// Derived kanban cards (rebuilt on signal/worker refresh).
     pub kanban_cards: Vec<KanbanCard>,
+    /// Currently selected kanban card: (stage, card_index_within_that_stage).
+    pub kanban_selected: Option<(KanbanStage, usize)>,
+    /// Dismissed kanban card IDs (filtered out when building cards).
+    pub kanban_dismissed: std::collections::HashSet<String>,
 }
 
 // ── App ───────────────────────────────────────────────────
@@ -818,6 +835,8 @@ impl App {
                     shell_windows: Vec::new(),
                     pending_notifications: Vec::new(),
                     kanban_cards: Vec::new(),
+                    kanban_selected: None,
+                    kanban_dismissed: std::collections::HashSet::new(),
                 }
             })
             .collect();
@@ -960,6 +979,8 @@ impl App {
             shell_windows: Vec::new(),
             pending_notifications: Vec::new(),
             kanban_cards: Vec::new(),
+            kanban_selected: None,
+            kanban_dismissed: std::collections::HashSet::new(),
         };
 
         let setup = SetupState {
@@ -1089,6 +1110,8 @@ impl App {
             shell_windows: Vec::new(),
             pending_notifications: Vec::new(),
             kanban_cards: Vec::new(),
+            kanban_selected: None,
+            kanban_dismissed: std::collections::HashSet::new(),
         };
 
         ws_state.chat_history.push(ChatLine::Assistant(
@@ -1286,6 +1309,8 @@ impl App {
             shell_windows: Vec::new(),
             pending_notifications: Vec::new(),
             kanban_cards: Vec::new(),
+            kanban_selected: None,
+            kanban_dismissed: std::collections::HashSet::new(),
         };
 
         if is_add {
@@ -1571,6 +1596,202 @@ impl App {
         self.needs_redraw = true;
     }
 
+    // ── Kanban navigation ─────────────────────────────────
+
+    const KANBAN_STAGES: [KanbanStage; 4] = [
+        KanbanStage::Incoming,
+        KanbanStage::InProgress,
+        KanbanStage::NeedsMe,
+        KanbanStage::Done,
+    ];
+
+    /// Move kanban selection to the next non-empty column (right).
+    pub fn kanban_navigate_right(&mut self) {
+        let ws = match self.current_ws() {
+            Some(w) => w,
+            None => return,
+        };
+        let current_stage = ws
+            .kanban_selected
+            .map(|(s, _)| s)
+            .unwrap_or(Self::KANBAN_STAGES[0]);
+        let current_idx = Self::KANBAN_STAGES
+            .iter()
+            .position(|&s| s == current_stage)
+            .unwrap_or(0);
+        for &stage in &Self::KANBAN_STAGES[current_idx + 1..] {
+            if ws.kanban_cards.iter().any(|c| c.stage == stage) {
+                if let Some(ws) = self.current_ws_mut() {
+                    ws.kanban_selected = Some((stage, 0));
+                }
+                self.needs_redraw = true;
+                return;
+            }
+        }
+    }
+
+    /// Move kanban selection to the previous non-empty column (left).
+    pub fn kanban_navigate_left(&mut self) {
+        let ws = match self.current_ws() {
+            Some(w) => w,
+            None => return,
+        };
+        let current_stage = ws
+            .kanban_selected
+            .map(|(s, _)| s)
+            .unwrap_or(Self::KANBAN_STAGES[0]);
+        let current_idx = Self::KANBAN_STAGES
+            .iter()
+            .position(|&s| s == current_stage)
+            .unwrap_or(0);
+        for &stage in Self::KANBAN_STAGES[..current_idx].iter().rev() {
+            if ws.kanban_cards.iter().any(|c| c.stage == stage) {
+                if let Some(ws) = self.current_ws_mut() {
+                    ws.kanban_selected = Some((stage, 0));
+                }
+                self.needs_redraw = true;
+                return;
+            }
+        }
+    }
+
+    /// Move kanban selection down within the current column (wraps).
+    pub fn kanban_navigate_down(&mut self) {
+        let ws = match self.current_ws() {
+            Some(w) => w,
+            None => return,
+        };
+        let (stage, idx) = match ws.kanban_selected {
+            Some(s) => s,
+            None => {
+                // Auto-select first card in first non-empty column
+                for &stage in &Self::KANBAN_STAGES {
+                    if ws.kanban_cards.iter().any(|c| c.stage == stage) {
+                        if let Some(ws) = self.current_ws_mut() {
+                            ws.kanban_selected = Some((stage, 0));
+                        }
+                        self.needs_redraw = true;
+                        return;
+                    }
+                }
+                return;
+            }
+        };
+        let count = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
+        if count > 0 {
+            let new_idx = (idx + 1) % count;
+            if let Some(ws) = self.current_ws_mut() {
+                ws.kanban_selected = Some((stage, new_idx));
+            }
+            self.needs_redraw = true;
+        }
+    }
+
+    /// Move kanban selection up within the current column (wraps).
+    pub fn kanban_navigate_up(&mut self) {
+        let ws = match self.current_ws() {
+            Some(w) => w,
+            None => return,
+        };
+        let (stage, idx) = match ws.kanban_selected {
+            Some(s) => s,
+            None => {
+                // Auto-select first card in first non-empty column
+                for &stage in &Self::KANBAN_STAGES {
+                    if ws.kanban_cards.iter().any(|c| c.stage == stage) {
+                        if let Some(ws) = self.current_ws_mut() {
+                            ws.kanban_selected = Some((stage, 0));
+                        }
+                        self.needs_redraw = true;
+                        return;
+                    }
+                }
+                return;
+            }
+        };
+        let count = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
+        if count > 0 {
+            let new_idx = if idx == 0 { count - 1 } else { idx - 1 };
+            if let Some(ws) = self.current_ws_mut() {
+                ws.kanban_selected = Some((stage, new_idx));
+            }
+            self.needs_redraw = true;
+        }
+    }
+
+    /// Return the chat message to inject for the currently selected kanban card, or None.
+    pub fn kanban_action_selected(&self) -> Option<String> {
+        let ws = self.current_ws()?;
+        let (stage, idx) = ws.kanban_selected?;
+        let card = ws
+            .kanban_cards
+            .iter()
+            .filter(|c| c.stage == stage)
+            .nth(idx)?;
+        let msg = match stage {
+            KanbanStage::Done => return None,
+            KanbanStage::NeedsMe => {
+                if card.source == "worker" {
+                    // subtitle like "PR #42 · merge?"
+                    if let Some(num) = kanban_extract_pr_number(&card.subtitle) {
+                        format!("Merge PR #{num}")
+                    } else {
+                        format!("What's the status of {}?", card.title)
+                    }
+                } else if card.source == "github_review_queue" {
+                    format!("Review {}", card.title)
+                } else {
+                    format!("Tell me about this signal: {}", card.title)
+                }
+            }
+            KanbanStage::Incoming => {
+                if card.source == "github_review_queue" {
+                    format!("Review {}", card.title)
+                } else {
+                    format!("Tell me about this signal: {}", card.title)
+                }
+            }
+            KanbanStage::InProgress => {
+                if card.source == "worker" {
+                    let worker_id = card.id.strip_prefix("worker:").unwrap_or(&card.id);
+                    format!("What's the status of worker {worker_id}?")
+                } else {
+                    format!("Tell me about this signal: {}", card.title)
+                }
+            }
+        };
+        Some(msg)
+    }
+
+    /// Dismiss the currently selected kanban card (remove from board).
+    pub fn kanban_dismiss_selected(&mut self) {
+        let ws = match self.current_ws_mut() {
+            Some(w) => w,
+            None => return,
+        };
+        let (stage, idx) = match ws.kanban_selected {
+            Some(s) => s,
+            None => return,
+        };
+        let card_id = ws
+            .kanban_cards
+            .iter()
+            .filter(|c| c.stage == stage)
+            .nth(idx)
+            .map(|c| c.id.clone());
+        if let Some(id) = card_id {
+            ws.kanban_dismissed.insert(id.clone());
+            ws.kanban_cards.retain(|c| c.id != id);
+            let count = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
+            ws.kanban_selected = if count == 0 {
+                None
+            } else {
+                Some((stage, idx.min(count - 1)))
+            };
+        }
+        self.needs_redraw = true;
+    }
+
     fn signal_selectable_count(&self) -> usize {
         self.current_ws().map_or(0, |ws| {
             ws.signals
@@ -1640,6 +1861,20 @@ impl App {
             self.shell_selection = 0;
         } else if self.shell_selection >= shell_count {
             self.shell_selection = shell_count - 1;
+        }
+
+        // Clamp kanban selection
+        if let Some(ws) = self.current_ws_mut()
+            && let Some((stage, idx)) = ws.kanban_selected
+        {
+            let count = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
+            ws.kanban_selected = if count == 0 {
+                None
+            } else if idx >= count {
+                Some((stage, count - 1))
+            } else {
+                Some((stage, idx))
+            };
         }
     }
 
@@ -4096,6 +4331,8 @@ mod tests {
             shell_windows: Vec::new(),
             pending_notifications: Vec::new(),
             kanban_cards: Vec::new(),
+            kanban_selected: None,
+            kanban_dismissed: Default::default(),
         };
         app.workspaces = vec![ws];
         app.setup = None;
@@ -4347,6 +4584,8 @@ mod tests {
             shell_windows: Vec::new(),
             pending_notifications: Vec::new(),
             kanban_cards: Vec::new(),
+            kanban_selected: None,
+            kanban_dismissed: Default::default(),
         }
     }
 

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -462,15 +462,12 @@ fn signal_covered_by_worker(
     false
 }
 
-/// How many cards in `stage` are actually visible in the kanban strip.
-/// Mirrors the height logic in `render::compute_kanban_height` and the
-/// per-column clamping based on `area.height` in `render::draw_kanban_column`.
-fn ws_kanban_visible_count(ws: &WorkspaceState, stage: KanbanStage) -> usize {
-    let total = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
-    if total == 0 {
-        return 0;
+/// Compute the ideal height (in terminal rows) for the kanban strip.
+/// Called by the renderer for layout; also used as a fallback before the first frame.
+pub fn compute_kanban_height(ws: &WorkspaceState) -> u16 {
+    if ws.kanban_cards.is_empty() {
+        return 3; // header + "all clear" + border
     }
-    // strip_h = (max_cards_any * 2 + 1 + 2).clamp(3, 8)  [mirrors render.rs]
     let max_cards = [
         KanbanStage::Incoming,
         KanbanStage::InProgress,
@@ -478,13 +475,29 @@ fn ws_kanban_visible_count(ws: &WorkspaceState, stage: KanbanStage) -> usize {
         KanbanStage::Done,
     ]
     .iter()
-    .map(|&s| ws.kanban_cards.iter().filter(|c| c.stage == s).count())
+    .map(|&s| ws.kanban_cards.iter().filter(|c| c.stage == s).count() as u16)
     .max()
     .unwrap_or(0);
-    let content_h = max_cards * 2 + 1;
-    let strip_h = (content_h + 2).clamp(3, 8); // includes 2-row border
-    // inner = strip_h - 2 (borders), available = inner - 1 (header row)
-    let available = strip_h.saturating_sub(3);
+    let content_h = max_cards * 2 + 1; // header line + cards
+    (content_h + 2).clamp(3, 8) // +2 for borders
+}
+
+/// How many cards in `stage` are actually visible given `strip_h` terminal rows.
+/// Pass `App::kanban_allocated_height` (recorded by the renderer after layout) so
+/// navigation never targets a card that ratatui shrank off-screen.
+fn ws_kanban_visible_count(ws: &WorkspaceState, stage: KanbanStage, strip_h: u16) -> usize {
+    let total = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
+    if total == 0 {
+        return 0;
+    }
+    // Use actual allocated height; fall back to ideal height before the first frame.
+    let h = if strip_h > 0 {
+        strip_h
+    } else {
+        compute_kanban_height(ws)
+    };
+    // inner = h - 2 borders; available for cards = inner - 1 header row
+    let available = (h as usize).saturating_sub(3);
     let cards_fit = available / 2;
     cards_fit.min(total)
 }
@@ -809,6 +822,10 @@ pub struct App {
     pub last_extras_refresh: Instant,
     // Terminal size (updated each frame)
     pub terminal_width: u16,
+    /// Actual height (rows) allocated to the kanban strip by ratatui's layout engine.
+    /// Set during each render pass so navigation never targets a card clipped by
+    /// the `Min(5)` chat constraint.
+    pub kanban_allocated_height: std::cell::Cell<u16>,
     // Activity graph (network-style throughput chart in status bar)
     pub activity_buf: Vec<u8>, // fixed array, each value = bar height 0-7
     // Snooze
@@ -941,6 +958,7 @@ impl App {
             daemon_uptime_secs: None,
             last_extras_refresh: Instant::now(),
             terminal_width: 80,
+            kanban_allocated_height: std::cell::Cell::new(0),
             activity_buf: vec![0; 18],
             snooze_selection: 0,
             signals_debug_mode: false,
@@ -1075,6 +1093,7 @@ impl App {
             daemon_uptime_secs: None,
             last_extras_refresh: Instant::now(),
             terminal_width: 80,
+            kanban_allocated_height: std::cell::Cell::new(0),
             activity_buf: vec![0; 18],
             snooze_selection: 0,
             onboarding: OnboardingState::new_active(), // only Chat panel visible
@@ -1722,7 +1741,7 @@ impl App {
                 return;
             }
         };
-        let visible = ws_kanban_visible_count(ws, stage);
+        let visible = ws_kanban_visible_count(ws, stage, self.kanban_allocated_height.get());
         if visible > 0 {
             let new_idx = (idx + 1) % visible;
             if let Some(ws) = self.current_ws_mut() {
@@ -1754,7 +1773,7 @@ impl App {
                 return;
             }
         };
-        let visible = ws_kanban_visible_count(ws, stage);
+        let visible = ws_kanban_visible_count(ws, stage, self.kanban_allocated_height.get());
         if visible > 0 {
             let new_idx = if idx == 0 { visible - 1 } else { idx - 1 };
             if let Some(ws) = self.current_ws_mut() {
@@ -1910,10 +1929,11 @@ impl App {
 
         // Clamp kanban selection to the visible range (not just total count).
         // This ensures Enter/Dismiss never act on an off-screen card.
+        let allocated_h = self.kanban_allocated_height.get();
         if let Some(ws) = self.current_ws_mut()
             && let Some((stage, idx)) = ws.kanban_selected
         {
-            let visible = ws_kanban_visible_count(ws, stage);
+            let visible = ws_kanban_visible_count(ws, stage, allocated_h);
             ws.kanban_selected = if visible == 0 {
                 None
             } else if idx >= visible {

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -444,6 +444,33 @@ fn signal_covered_by_worker(
     false
 }
 
+/// How many cards in `stage` are actually visible in the kanban strip,
+/// using the same height formula as `render::kanban_strip_height`.
+/// Navigation and clamping use this to avoid selecting off-screen cards.
+fn ws_kanban_visible_count(ws: &WorkspaceState, stage: KanbanStage) -> usize {
+    let total = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
+    if total == 0 {
+        return 0;
+    }
+    // strip_h = (max_cards_any * 2 + 1 + 2).clamp(3, 8)  [mirrors render.rs]
+    let max_cards = [
+        KanbanStage::Incoming,
+        KanbanStage::InProgress,
+        KanbanStage::NeedsMe,
+        KanbanStage::Done,
+    ]
+    .iter()
+    .map(|&s| ws.kanban_cards.iter().filter(|c| c.stage == s).count())
+    .max()
+    .unwrap_or(0);
+    let content_h = max_cards * 2 + 1;
+    let strip_h = (content_h + 2).clamp(3, 8); // includes 2-row border
+    // inner = strip_h - 2 (borders), available = inner - 1 (header row)
+    let available = strip_h.saturating_sub(3);
+    let cards_fit = available / 2;
+    cards_fit.min(total)
+}
+
 /// Extract PR number from a kanban card subtitle like "PR #42 · merge?".
 fn kanban_extract_pr_number(subtitle: &str) -> Option<u64> {
     let start = subtitle.find("PR #")? + 4;
@@ -1677,9 +1704,9 @@ impl App {
                 return;
             }
         };
-        let count = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
-        if count > 0 {
-            let new_idx = (idx + 1) % count;
+        let visible = ws_kanban_visible_count(ws, stage);
+        if visible > 0 {
+            let new_idx = (idx + 1) % visible;
             if let Some(ws) = self.current_ws_mut() {
                 ws.kanban_selected = Some((stage, new_idx));
             }
@@ -1709,9 +1736,9 @@ impl App {
                 return;
             }
         };
-        let count = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
-        if count > 0 {
-            let new_idx = if idx == 0 { count - 1 } else { idx - 1 };
+        let visible = ws_kanban_visible_count(ws, stage);
+        if visible > 0 {
+            let new_idx = if idx == 0 { visible - 1 } else { idx - 1 };
             if let Some(ws) = self.current_ws_mut() {
                 ws.kanban_selected = Some((stage, new_idx));
             }
@@ -1863,15 +1890,16 @@ impl App {
             self.shell_selection = shell_count - 1;
         }
 
-        // Clamp kanban selection
+        // Clamp kanban selection to the visible range (not just total count).
+        // This ensures Enter/Dismiss never act on an off-screen card.
         if let Some(ws) = self.current_ws_mut()
             && let Some((stage, idx)) = ws.kanban_selected
         {
-            let count = ws.kanban_cards.iter().filter(|c| c.stage == stage).count();
-            ws.kanban_selected = if count == 0 {
+            let visible = ws_kanban_visible_count(ws, stage);
+            ws.kanban_selected = if visible == 0 {
                 None
-            } else if idx >= count {
-                Some((stage, count - 1))
+            } else if idx >= visible {
+                Some((stage, visible - 1))
             } else {
                 Some((stage, idx))
             };

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -2645,6 +2645,7 @@ mod tests {
             shell_selection: 0,
             shell_input_active: false,
             shell_input: String::new(),
+            kanban_allocated_height: std::cell::Cell::new(0),
         }
     }
 

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -922,6 +922,47 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
         }
     }
 
+    // Home panel (kanban strip) navigation — intercept before common handlers
+    if app.focused_panel == Panel::Home {
+        match key.code {
+            KeyCode::Left | KeyCode::Char('h') if app.zoomed_panel.is_none() => {
+                app.kanban_navigate_left();
+                return KeyAction::Redraw;
+            }
+            KeyCode::Right | KeyCode::Char('l') if app.zoomed_panel.is_none() => {
+                app.kanban_navigate_right();
+                return KeyAction::Redraw;
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                app.kanban_navigate_down();
+                return KeyAction::Redraw;
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                app.kanban_navigate_up();
+                return KeyAction::Redraw;
+            }
+            KeyCode::Enter => {
+                let maybe_msg = app.kanban_action_selected();
+                if let Some(msg) = maybe_msg {
+                    let msg_len = msg.len();
+                    if let Some(ws) = app.current_ws_mut() {
+                        ws.input = msg;
+                        ws.cursor_pos = msg_len;
+                    }
+                    app.focused_panel = Panel::Chat;
+                    app.chat_focused = true;
+                }
+                app.needs_redraw = true;
+                return KeyAction::Redraw;
+            }
+            KeyCode::Char('d') | KeyCode::Delete => {
+                app.kanban_dismiss_selected();
+                return KeyAction::Redraw;
+            }
+            _ => {}
+        }
+    }
+
     match key.code {
         KeyCode::Tab => app.next_panel(),
         KeyCode::BackTab => app.prev_panel(),

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -950,6 +950,7 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
                     if let Some(ws) = app.current_ws_mut() {
                         ws.input = msg;
                         ws.cursor_pos = msg_len;
+                        ws.has_unread_response = false;
                     }
                     app.focused_panel = Panel::Chat;
                     app.chat_focused = true;

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -2592,6 +2592,8 @@ mod tests {
             shell_windows: Vec::new(),
             pending_notifications: Vec::new(),
             kanban_cards: Vec::new(),
+            kanban_selected: None,
+            kanban_dismissed: Default::default(),
         };
         let ws_name = ws.name.clone();
         App {

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -925,6 +925,8 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
     // Home panel (kanban strip) navigation — intercept before common handlers
     if app.focused_panel == Panel::Home {
         match key.code {
+            // Note: narrow-terminal auto-focus doesn't set zoomed_panel, so
+            // Left/Right column navigation won't fire in that edge case.
             KeyCode::Left | KeyCode::Char('h') if app.zoomed_panel.is_none() => {
                 app.kanban_navigate_left();
                 return KeyAction::Redraw;
@@ -3131,5 +3133,224 @@ mod tests {
         handle_dashboard_key(&mut app, key(KeyCode::Char('n')));
 
         assert!(!app.shell_input_active, "n should be ignored without tmux");
+    }
+
+    // ── Kanban navigation tests ───────────────────────────
+
+    fn push_kanban_card(
+        app: &mut App,
+        id: &str,
+        stage: app::KanbanStage,
+        source: &str,
+        subtitle: &str,
+    ) {
+        app.workspaces[0].kanban_cards.push(app::KanbanCard {
+            id: id.to_string(),
+            stage,
+            icon: "🐛".to_string(),
+            title: id.to_string(),
+            subtitle: subtitle.to_string(),
+            source: source.to_string(),
+            url: None,
+            entered_stage_at: chrono::Utc::now(),
+        });
+    }
+
+    #[test]
+    fn test_kanban_navigate_down_selects_first_card_when_none() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Home;
+        push_kanban_card(
+            &mut app,
+            "card-1",
+            app::KanbanStage::InProgress,
+            "worker",
+            "running",
+        );
+
+        handle_dashboard_key(&mut app, key(KeyCode::Down));
+
+        assert_eq!(
+            app.current_ws().unwrap().kanban_selected,
+            Some((app::KanbanStage::InProgress, 0))
+        );
+    }
+
+    #[test]
+    fn test_kanban_navigate_down_wraps_to_first() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Home;
+        push_kanban_card(
+            &mut app,
+            "card-1",
+            app::KanbanStage::InProgress,
+            "worker",
+            "running",
+        );
+        push_kanban_card(
+            &mut app,
+            "card-2",
+            app::KanbanStage::InProgress,
+            "worker",
+            "running",
+        );
+        app.workspaces[0].kanban_selected = Some((app::KanbanStage::InProgress, 1));
+
+        handle_dashboard_key(&mut app, key(KeyCode::Down));
+
+        assert_eq!(
+            app.current_ws().unwrap().kanban_selected,
+            Some((app::KanbanStage::InProgress, 0)),
+            "down from last card should wrap to first"
+        );
+    }
+
+    #[test]
+    fn test_kanban_navigate_up_wraps_to_last() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Home;
+        push_kanban_card(
+            &mut app,
+            "card-1",
+            app::KanbanStage::InProgress,
+            "worker",
+            "running",
+        );
+        push_kanban_card(
+            &mut app,
+            "card-2",
+            app::KanbanStage::InProgress,
+            "worker",
+            "running",
+        );
+        app.workspaces[0].kanban_selected = Some((app::KanbanStage::InProgress, 0));
+
+        handle_dashboard_key(&mut app, key(KeyCode::Up));
+
+        assert_eq!(
+            app.current_ws().unwrap().kanban_selected,
+            Some((app::KanbanStage::InProgress, 1)),
+            "up from first card should wrap to last"
+        );
+    }
+
+    #[test]
+    fn test_kanban_navigate_right_skips_empty_column() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Home;
+        // Incoming is empty; only InProgress and NeedsMe have cards
+        push_kanban_card(
+            &mut app,
+            "card-1",
+            app::KanbanStage::InProgress,
+            "worker",
+            "running",
+        );
+        push_kanban_card(
+            &mut app,
+            "card-2",
+            app::KanbanStage::NeedsMe,
+            "worker",
+            "PR #1 · merge?",
+        );
+        app.workspaces[0].kanban_selected = Some((app::KanbanStage::InProgress, 0));
+
+        handle_dashboard_key(&mut app, key(KeyCode::Right));
+
+        assert_eq!(
+            app.current_ws().unwrap().kanban_selected,
+            Some((app::KanbanStage::NeedsMe, 0)),
+            "right should skip to next non-empty column"
+        );
+    }
+
+    #[test]
+    fn test_kanban_enter_injects_merge_message_for_needsme_worker() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Home;
+        push_kanban_card(
+            &mut app,
+            "card-1",
+            app::KanbanStage::NeedsMe,
+            "worker",
+            "PR #42 · merge?",
+        );
+        app.workspaces[0].kanban_selected = Some((app::KanbanStage::NeedsMe, 0));
+
+        handle_dashboard_key(&mut app, key(KeyCode::Enter));
+
+        assert_eq!(app.current_ws().unwrap().input, "Merge PR #42");
+        assert_eq!(app.focused_panel, Panel::Chat);
+        assert!(app.chat_focused);
+    }
+
+    #[test]
+    fn test_kanban_enter_injects_status_message_for_inprogress_worker() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Home;
+        push_kanban_card(
+            &mut app,
+            "worker:abc-1234",
+            app::KanbanStage::InProgress,
+            "worker",
+            "running 5m",
+        );
+        app.workspaces[0].kanban_selected = Some((app::KanbanStage::InProgress, 0));
+
+        handle_dashboard_key(&mut app, key(KeyCode::Enter));
+
+        assert_eq!(
+            app.current_ws().unwrap().input,
+            "What's the status of worker abc-1234?"
+        );
+    }
+
+    #[test]
+    fn test_kanban_enter_noop_for_done_card() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Home;
+        push_kanban_card(
+            &mut app,
+            "card-1",
+            app::KanbanStage::Done,
+            "worker",
+            "completed",
+        );
+        app.workspaces[0].kanban_selected = Some((app::KanbanStage::Done, 0));
+
+        handle_dashboard_key(&mut app, key(KeyCode::Enter));
+
+        // Focus should NOT shift to Chat for done cards
+        assert_eq!(app.focused_panel, Panel::Home);
+        assert!(app.current_ws().unwrap().input.is_empty());
+    }
+
+    #[test]
+    fn test_kanban_dismiss_removes_card_and_clamps_selection() {
+        let mut app = test_app();
+        app.focused_panel = Panel::Home;
+        push_kanban_card(
+            &mut app,
+            "card-1",
+            app::KanbanStage::InProgress,
+            "worker",
+            "running",
+        );
+        push_kanban_card(
+            &mut app,
+            "card-2",
+            app::KanbanStage::InProgress,
+            "worker",
+            "running",
+        );
+        app.workspaces[0].kanban_selected = Some((app::KanbanStage::InProgress, 1));
+
+        handle_dashboard_key(&mut app, key(KeyCode::Char('d')));
+
+        let ws = app.current_ws().unwrap();
+        assert_eq!(ws.kanban_cards.len(), 1, "dismissed card should be gone");
+        assert!(ws.kanban_dismissed.contains("card-2"));
+        // Selection should clamp to last remaining card (index 0)
+        assert_eq!(ws.kanban_selected, Some((app::KanbanStage::InProgress, 0)));
     }
 }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -922,16 +922,16 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
         }
     }
 
-    // Home panel (kanban strip) navigation — intercept before common handlers
-    if app.focused_panel == Panel::Home {
+    // Home panel (kanban strip) navigation — only when the strip is actually
+    // visible (not zoomed away, and terminal wide enough that we're not in the
+    // auto-zoom fallback path which collapses the strip).
+    if app.focused_panel == Panel::Home && app.zoomed_panel.is_none() && app.terminal_width >= 50 {
         match key.code {
-            // Note: narrow-terminal auto-focus doesn't set zoomed_panel, so
-            // Left/Right column navigation won't fire in that edge case.
-            KeyCode::Left | KeyCode::Char('h') if app.zoomed_panel.is_none() => {
+            KeyCode::Left | KeyCode::Char('h') => {
                 app.kanban_navigate_left();
                 return KeyAction::Redraw;
             }
-            KeyCode::Right | KeyCode::Char('l') if app.zoomed_panel.is_none() => {
+            KeyCode::Right | KeyCode::Char('l') => {
                 app.kanban_navigate_right();
                 return KeyAction::Redraw;
             }

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -196,7 +196,7 @@ fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     // Kanban strip + Chat layout
-    let kanban_h = compute_kanban_height(ws);
+    let kanban_h = app::compute_kanban_height(ws);
 
     let rows = Layout::default()
         .direction(Direction::Vertical)
@@ -205,6 +205,9 @@ fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
             Constraint::Min(5),           // Chat (gets everything else)
         ])
         .split(area);
+
+    // Record actual allocated height so navigation can stay within visible cards.
+    app.kanban_allocated_height.set(rows[0].height);
 
     draw_kanban_strip(frame, app, ws, rows[0]);
     draw_chat_panel(frame, app, ws, rows[1]);
@@ -447,30 +450,6 @@ fn draw_kpi_strip(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area: 
 }
 
 // ── Kanban strip ─────────────────────────────────────────
-
-/// Compute the height of the kanban strip based on card count.
-fn compute_kanban_height(ws: &app::WorkspaceState) -> u16 {
-    if ws.kanban_cards.is_empty() {
-        return 3; // header + "all clear" + border
-    }
-
-    // Count cards per visible column
-    let mut counts = [0u16; 4]; // Incoming, InProgress, NeedsMe, Done
-    for card in &ws.kanban_cards {
-        let idx = match card.stage {
-            app::KanbanStage::Incoming => 0,
-            app::KanbanStage::InProgress => 1,
-            app::KanbanStage::NeedsMe => 2,
-            app::KanbanStage::Done => 3,
-        };
-        counts[idx] += 1;
-    }
-
-    // Tallest column determines height: each card = 2 lines, + 1 header line + 2 border
-    let max_cards = counts.iter().copied().max().unwrap_or(0);
-    let content_h = max_cards * 2 + 1; // header line + cards
-    (content_h + 2).clamp(3, 8) // +2 for borders, clamp to reasonable range
-}
 
 /// Draw the kanban strip with columns for each stage.
 fn draw_kanban_strip(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area: Rect) {

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -666,8 +666,12 @@ fn draw_kanban_column(
         Style::default().fg(theme::SMOKE)
     };
 
+    // Clamp selected index to the visible range; if the selected card is
+    // scrolled off (e.g. narrow terminal fits fewer cards), suppress highlight.
+    let visible_selected = selected.filter(|&i| i < show_count);
+
     for (card_idx, card) in cards.iter().take(show_count).enumerate() {
-        let is_selected = selected == Some(card_idx);
+        let is_selected = visible_selected == Some(card_idx);
 
         let effective_card_style = if is_selected {
             card_style.add_modifier(Modifier::REVERSED)

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -473,7 +473,7 @@ fn compute_kanban_height(ws: &app::WorkspaceState) -> u16 {
 }
 
 /// Draw the kanban strip with columns for each stage.
-fn draw_kanban_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, area: Rect) {
+fn draw_kanban_strip(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, area: Rect) {
     // Build status line for the header
     let healthy = ws.watcher_health.iter().filter(|w| w.healthy).count();
     let total = ws.watcher_health.len();
@@ -562,10 +562,26 @@ fn draw_kanban_strip(frame: &mut Frame, _app: &App, ws: &app::WorkspaceState, ar
         .constraints(constraints)
         .split(inner);
 
+    let is_focused = app.focused_panel == app::Panel::Home;
+
     for (i, (stage, cards)) in columns.iter().enumerate() {
         let area_idx = i * 2; // skip divider slots
         let col_area = col_areas[area_idx];
-        draw_kanban_column(frame, *stage, cards, col_area);
+
+        // Determine selected card index within this column
+        let selected_idx = if is_focused {
+            ws.kanban_selected.and_then(|(sel_stage, sel_idx)| {
+                if sel_stage == *stage {
+                    Some(sel_idx)
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        };
+
+        draw_kanban_column(frame, *stage, cards, col_area, selected_idx);
 
         // Draw divider after this column (before the next)
         if i + 1 < columns.len() {
@@ -583,6 +599,7 @@ fn draw_kanban_column(
     stage: app::KanbanStage,
     cards: &[&app::KanbanCard],
     area: Rect,
+    selected: Option<usize>,
 ) {
     if area.height == 0 || area.width == 0 {
         return;
@@ -649,19 +666,36 @@ fn draw_kanban_column(
         Style::default().fg(theme::SMOKE)
     };
 
-    for card in cards.iter().take(show_count) {
+    for (card_idx, card) in cards.iter().take(show_count).enumerate() {
+        let is_selected = selected == Some(card_idx);
+
+        let effective_card_style = if is_selected {
+            Style::default().add_modifier(Modifier::REVERSED)
+        } else {
+            card_style
+        };
+        let effective_subtitle_style = if is_selected {
+            Style::default().add_modifier(Modifier::REVERSED)
+        } else {
+            subtitle_style
+        };
+
         // Line 1: icon + title + action hint for NeedsMe
         let mut title_spans = vec![
-            Span::styled(&card.icon, card_style),
+            Span::styled(&card.icon, effective_card_style),
             Span::raw(" "),
-            Span::styled(&card.title, card_style),
+            Span::styled(&card.title, effective_card_style),
         ];
         if is_needs_me {
             title_spans.push(Span::styled(
                 " \u{2192}",
-                Style::default()
-                    .fg(theme::HONEY)
-                    .add_modifier(Modifier::BOLD),
+                if is_selected {
+                    Style::default().add_modifier(Modifier::REVERSED)
+                } else {
+                    Style::default()
+                        .fg(theme::HONEY)
+                        .add_modifier(Modifier::BOLD)
+                },
             ));
         }
         lines.push(Line::from(title_spans));
@@ -669,7 +703,7 @@ fn draw_kanban_column(
         // Line 2: subtitle (indented)
         let sub_line = Line::from(vec![
             Span::raw("  "),
-            Span::styled(&card.subtitle, subtitle_style),
+            Span::styled(&card.subtitle, effective_subtitle_style),
         ]);
         lines.push(sub_line);
     }

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -670,12 +670,12 @@ fn draw_kanban_column(
         let is_selected = selected == Some(card_idx);
 
         let effective_card_style = if is_selected {
-            Style::default().add_modifier(Modifier::REVERSED)
+            card_style.add_modifier(Modifier::REVERSED)
         } else {
             card_style
         };
         let effective_subtitle_style = if is_selected {
-            Style::default().add_modifier(Modifier::REVERSED)
+            subtitle_style.add_modifier(Modifier::REVERSED)
         } else {
             subtitle_style
         };
@@ -690,7 +690,9 @@ fn draw_kanban_column(
             title_spans.push(Span::styled(
                 " \u{2192}",
                 if is_selected {
-                    Style::default().add_modifier(Modifier::REVERSED)
+                    Style::default()
+                        .fg(theme::HONEY)
+                        .add_modifier(Modifier::BOLD | Modifier::REVERSED)
                 } else {
                     Style::default()
                         .fg(theme::HONEY)


### PR DESCRIPTION
## Summary

- **Card selection**: When `Panel::Home` is focused, arrow keys navigate the kanban strip — Left/Right moves between columns (skipping empty ones), Up/Down moves between cards within a column with wrap-around
- **Selection highlight**: The selected card is shown with reverse-video styling
- **Card actions** (Enter): Injects a contextual chat message and shifts focus to the chat input:
  - Worker (InProgress): `"What's the status of worker {id}?"`
  - Worker waiting on PR (NeedsMe): `"Merge PR #{number}"`
  - Review request: `"Review {title}"`
  - Signal (Incoming): `"Tell me about this signal: {title}"`
  - Done: no action
- **Dismiss** (`d` / Delete): Removes the card from the board and stores its ID in `kanban_dismissed` so it doesn't reappear on the next data rebuild
- Selection is clamped automatically after each data refresh

## Files changed

- `crates/apiari/src/ui/app.rs` — `kanban_selected`, `kanban_dismissed` fields on `WorkspaceState`; navigation/action/dismiss methods on `App`; dismissed filter in `build_kanban_cards`; selection clamping in `clamp_selections`
- `crates/apiari/src/ui/mod.rs` — Key handling for `Panel::Home` in `handle_dashboard_key`
- `crates/apiari/src/ui/render.rs` — Pass selection to `draw_kanban_column`; reverse-video highlight on selected card

## Test plan

- [ ] Cargo fmt + clippy pass (verified clean)
- [ ] Tab to `Panel::Home`, use arrow keys to navigate — selection highlights and wraps correctly
- [ ] Press Enter on an InProgress worker card — correct message appears in chat input
- [ ] Press Enter on a NeedsMe worker card — "Merge PR #…" appears
- [ ] Press Enter on a Done card — no action (focus stays on kanban)
- [ ] Press `d` on a card — it disappears and doesn't return after next refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)