### PR TITLE
feat: add schedule/active_hours support to pause watchers and signal hooks

### DIFF
--- a/crates/apiari/src/buzz/mod.rs
+++ b/crates/apiari/src/buzz/mod.rs
@@ -6,5 +6,6 @@ pub mod conversation;
 pub mod coordinator;
 pub mod daemon;
 pub mod pipeline;
+pub mod schedule;
 pub mod signal;
 pub mod watcher;

--- a/crates/apiari/src/buzz/schedule.rs
+++ b/crates/apiari/src/buzz/schedule.rs
@@ -13,9 +13,12 @@ const VALID_DAYS: &[&str] = &["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
 /// malformed fields.  Call this once per watcher/workspace at startup — not
 /// in the poll hot path.
 ///
-/// Malformed constraints are silently ignored at runtime (the constraint is
-/// treated as absent) so that a misconfigured schedule does not break polling
-/// entirely.  This function is the single place where the user is notified.
+/// Runtime behaviour for malformed entries:
+/// - `active_hours`: a string that cannot be parsed is treated as absent (no
+///   hours constraint), so polling continues unrestricted.
+/// - `active_days`: unknown day strings never match, so if every entry in the
+///   list is invalid the schedule will never be active.  `warn_if_invalid`
+///   surfaces this at startup so the user can correct the config.
 pub fn warn_if_invalid(schedule: &Schedule) {
     if let Some(ref hours) = schedule.active_hours
         && parse_active_hours(hours).is_none()

--- a/crates/apiari/src/buzz/schedule.rs
+++ b/crates/apiari/src/buzz/schedule.rs
@@ -51,10 +51,28 @@ fn is_within_active_hours_at(schedule: &Schedule, now: NaiveDateTime) -> bool {
         return true;
     }
 
-    // Check active days first (cheap).  Day strings are compared case-insensitively
-    // without allocation; malformed entries silently never match.
+    // Determine whether we're in the post-midnight tail of an overnight window.
+    // For active_days purposes the "logical day" for such times is the *previous*
+    // calendar day — e.g. 01:00 Saturday during a "22:00-06:00 fri" window should
+    // still be considered Friday.
+    let is_overnight_tail = if let Some(ref hours) = schedule.active_hours
+        && let Some((start, end)) = parse_active_hours(hours)
+        && start > end
+    {
+        now.time() < end
+    } else {
+        false
+    };
+
+    // Check active days.  Day strings are compared case-insensitively without
+    // allocation; malformed entries silently never match.
     if let Some(ref days) = schedule.active_days {
-        let day_str = weekday_str(now.weekday());
+        let logical_day = if is_overnight_tail {
+            now.weekday().pred()
+        } else {
+            now.weekday()
+        };
+        let day_str = weekday_str(logical_day);
         if !days.iter().any(|d| d.eq_ignore_ascii_case(day_str)) {
             return false;
         }
@@ -130,6 +148,9 @@ mod tests {
     }
     fn wed(h: u32, m: u32) -> NaiveDateTime {
         at(2, h, m)
+    }
+    fn fri(h: u32, m: u32) -> NaiveDateTime {
+        at(4, h, m)
     }
     fn sat(h: u32, m: u32) -> NaiveDateTime {
         at(5, h, m)
@@ -209,6 +230,29 @@ mod tests {
         assert!(!is_within_active_hours_at(&s, mon(6, 0)));
         assert!(!is_within_active_hours_at(&s, mon(12, 0)));
         assert!(!is_within_active_hours_at(&s, mon(21, 59)));
+    }
+
+    #[test]
+    fn test_overnight_days_pre_midnight_uses_current_day() {
+        // 22:30 Friday is within "22:00-06:00" and the logical day is Friday.
+        let s = schedule(Some("22:00-06:00"), Some(vec!["fri"]));
+        assert!(is_within_active_hours_at(&s, fri(22, 30)));
+    }
+
+    #[test]
+    fn test_overnight_days_post_midnight_uses_previous_day() {
+        // 01:00 Saturday is the post-midnight tail of a "22:00-06:00 fri" window.
+        // The logical day for this time is Friday, so it should be active.
+        let s = schedule(Some("22:00-06:00"), Some(vec!["fri"]));
+        assert!(is_within_active_hours_at(&s, sat(1, 0)));
+    }
+
+    #[test]
+    fn test_overnight_days_post_midnight_excluded_day() {
+        // 01:00 Saturday is the post-midnight tail, logical day = Friday.
+        // If only Saturday is configured, the window should NOT match.
+        let s = schedule(Some("22:00-06:00"), Some(vec!["sat"]));
+        assert!(!is_within_active_hours_at(&s, sat(1, 0)));
     }
 
     #[test]

--- a/crates/apiari/src/buzz/schedule.rs
+++ b/crates/apiari/src/buzz/schedule.rs
@@ -6,9 +6,16 @@ use tracing::warn;
 
 use crate::config::Schedule;
 
-/// Validate a schedule at configuration-load time and emit a `warn!` for any
+/// Valid lowercase day abbreviations accepted in `active_days`.
+const VALID_DAYS: &[&str] = &["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+
+/// Validate a schedule at configuration-load time and emit `warn!` for any
 /// malformed fields.  Call this once per watcher/workspace at startup — not
 /// in the poll hot path.
+///
+/// Malformed constraints are silently ignored at runtime (the constraint is
+/// treated as absent) so that a misconfigured schedule does not break polling
+/// entirely.  This function is the single place where the user is notified.
 pub fn warn_if_invalid(schedule: &Schedule) {
     if let Some(ref hours) = schedule.active_hours
         && parse_active_hours(hours).is_none()
@@ -18,6 +25,17 @@ pub fn warn_if_invalid(schedule: &Schedule) {
              hours constraint will be ignored",
             hours
         );
+    }
+    if let Some(ref days) = schedule.active_days {
+        for day in days {
+            if !VALID_DAYS.iter().any(|&v| day.eq_ignore_ascii_case(v)) {
+                warn!(
+                    "schedule.active_days contains unknown day {:?} \
+                     (expected one of mon/tue/wed/thu/fri/sat/sun); entry will never match",
+                    day
+                );
+            }
+        }
     }
 }
 
@@ -33,20 +51,24 @@ fn is_within_active_hours_at(schedule: &Schedule, now: NaiveDateTime) -> bool {
         return true;
     }
 
-    // Check active days first (cheap).
+    // Check active days first (cheap).  Day strings are compared case-insensitively
+    // without allocation; malformed entries silently never match.
     if let Some(ref days) = schedule.active_days {
         let day_str = weekday_str(now.weekday());
-        if !days.iter().any(|d| d.to_lowercase() == day_str) {
+        if !days.iter().any(|d| d.eq_ignore_ascii_case(day_str)) {
             return false;
         }
     }
 
-    // Check active hours window.  Malformed strings are silently ignored (no hours
-    // constraint applied) — callers should invoke `warn_if_invalid` at startup.
+    // Check active hours window.  Malformed strings are silently ignored (treated as
+    // "no hours constraint") — `warn_if_invalid` is called at startup to surface them.
     if let Some(ref hours) = schedule.active_hours
         && let Some((start, end)) = parse_active_hours(hours)
     {
         let current = now.time();
+        // When start == end (e.g. "00:00-00:00"), start <= end is true and the window
+        // `current >= start && current < end` is empty — the schedule is never active.
+        // This is intentional: an equal-endpoint range means "always inactive".
         let within = if start <= end {
             // Normal range e.g. 09:00-18:00
             current >= start && current < end
@@ -190,6 +212,15 @@ mod tests {
     }
 
     #[test]
+    fn test_equal_start_end_is_never_active() {
+        // "00:00-00:00": start == end means the window is empty — always inactive.
+        let s = schedule(Some("00:00-00:00"), None);
+        assert!(!is_within_active_hours_at(&s, mon(0, 0)));
+        assert!(!is_within_active_hours_at(&s, mon(12, 0)));
+        assert!(!is_within_active_hours_at(&s, mon(23, 59)));
+    }
+
+    #[test]
     fn test_weekday_filter_active_on_configured_days() {
         let s = schedule(Some("09:00-18:00"), Some(vec!["mon", "wed"]));
         assert!(is_within_active_hours_at(&s, mon(10, 0)));
@@ -230,11 +261,20 @@ mod tests {
 
     #[test]
     fn test_malformed_hours_treated_as_unrestricted() {
-        // When hours is malformed, the hours constraint is ignored (warn is emitted
-        // at runtime but doesn't panic). Days constraint still applies.
+        // When hours is malformed, the hours constraint is silently ignored at runtime
+        // (warn_if_invalid logs a warning at startup). Days constraint still applies.
         let s = schedule(Some("9am-5pm"), Some(vec!["mon"]));
         // Monday — days pass; malformed hours → hours ignored → active
         assert!(is_within_active_hours_at(&s, mon(10, 0)));
+    }
+
+    #[test]
+    fn test_active_days_case_insensitive() {
+        // Day names are matched case-insensitively.
+        let s = schedule(None, Some(vec!["Mon", "WED", "FRI"]));
+        assert!(is_within_active_hours_at(&s, mon(10, 0)));
+        assert!(is_within_active_hours_at(&s, wed(10, 0)));
+        assert!(!is_within_active_hours_at(&s, sat(10, 0)));
     }
 
     #[test]
@@ -253,15 +293,40 @@ mod tests {
         }
     }
 
+    // ── is_within_active_hours (public API, uses Local::now()) ─────────────
+
     #[test]
-    fn test_is_within_active_hours_delegates_to_local_now() {
-        // Smoke-test the public API: an empty schedule is always active regardless of time.
+    fn test_is_within_active_hours_empty_schedule_always_active() {
+        // An unconstrained schedule is always active regardless of Local::now().
         assert!(is_within_active_hours(&Schedule::default()));
-        // All 7 days — never blocked by day filter.
-        let all_days = schedule(
+    }
+
+    #[test]
+    fn test_is_within_active_hours_all_days_no_hours() {
+        // All 7 days configured, no hours constraint — always active.
+        let s = schedule(
             None,
             Some(vec!["mon", "tue", "wed", "thu", "fri", "sat", "sun"]),
         );
-        assert!(is_within_active_hours(&all_days));
+        assert!(is_within_active_hours(&s));
+    }
+
+    // ── warn_if_invalid ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_warn_if_invalid_valid_schedule_no_panic() {
+        warn_if_invalid(&schedule(Some("09:00-18:00"), Some(vec!["mon", "fri"])));
+    }
+
+    #[test]
+    fn test_warn_if_invalid_malformed_hours_no_panic() {
+        // Should log a warning but not panic.
+        warn_if_invalid(&schedule(Some("not-a-time"), None));
+    }
+
+    #[test]
+    fn test_warn_if_invalid_unknown_day_no_panic() {
+        // Should log a warning but not panic.
+        warn_if_invalid(&schedule(None, Some(vec!["monday", "xyz"])));
     }
 }

--- a/crates/apiari/src/buzz/schedule.rs
+++ b/crates/apiari/src/buzz/schedule.rs
@@ -114,7 +114,7 @@ fn weekday_str(weekday: Weekday) -> &'static str {
     }
 }
 
-fn parse_active_hours(s: &str) -> Option<(NaiveTime, NaiveTime)> {
+pub(crate) fn parse_active_hours(s: &str) -> Option<(NaiveTime, NaiveTime)> {
     let (start_str, end_str) = s.split_once('-')?;
     let start = NaiveTime::parse_from_str(start_str.trim(), "%H:%M").ok()?;
     let end = NaiveTime::parse_from_str(end_str.trim(), "%H:%M").ok()?;

--- a/crates/apiari/src/buzz/schedule.rs
+++ b/crates/apiari/src/buzz/schedule.rs
@@ -1,0 +1,189 @@
+//! Schedule checking — determines whether the current local time falls within
+//! a configured active-hours window.
+
+use chrono::{Datelike, Local, NaiveTime, Weekday};
+
+use crate::config::Schedule;
+
+/// Returns `true` if the current local time is within the active window defined
+/// by `schedule`.  Returns `true` (always active) when no constraints are set.
+pub fn is_within_active_hours(schedule: &Schedule) -> bool {
+    if schedule.active_hours.is_none() && schedule.active_days.is_none() {
+        return true;
+    }
+
+    let now = Local::now();
+
+    // Check active days first (cheap).
+    if let Some(ref days) = schedule.active_days {
+        let day_str = weekday_str(now.weekday());
+        if !days.iter().any(|d| d.to_lowercase() == day_str) {
+            return false;
+        }
+    }
+
+    // Check active hours window.
+    if let Some(ref hours) = schedule.active_hours
+        && let Some((start, end)) = parse_active_hours(hours)
+    {
+        let current = now.time();
+        let within = if start <= end {
+            // Normal range e.g. 09:00-18:00
+            current >= start && current < end
+        } else {
+            // Overnight range e.g. 22:00-06:00: active if >= 22:00 OR < 06:00
+            current >= start || current < end
+        };
+        if !within {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn weekday_str(weekday: Weekday) -> &'static str {
+    match weekday {
+        Weekday::Mon => "mon",
+        Weekday::Tue => "tue",
+        Weekday::Wed => "wed",
+        Weekday::Thu => "thu",
+        Weekday::Fri => "fri",
+        Weekday::Sat => "sat",
+        Weekday::Sun => "sun",
+    }
+}
+
+fn parse_active_hours(s: &str) -> Option<(NaiveTime, NaiveTime)> {
+    let (start_str, end_str) = s.split_once('-')?;
+    let start = NaiveTime::parse_from_str(start_str.trim(), "%H:%M").ok()?;
+    let end = NaiveTime::parse_from_str(end_str.trim(), "%H:%M").ok()?;
+    Some((start, end))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schedule(hours: Option<&str>, days: Option<Vec<&str>>) -> Schedule {
+        Schedule {
+            active_hours: hours.map(str::to_string),
+            active_days: days.map(|v| v.into_iter().map(str::to_string).collect()),
+        }
+    }
+
+    // ── parse_active_hours ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_normal_range() {
+        let (s, e) = parse_active_hours("09:00-18:00").unwrap();
+        assert_eq!(s, NaiveTime::from_hms_opt(9, 0, 0).unwrap());
+        assert_eq!(e, NaiveTime::from_hms_opt(18, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn test_parse_overnight_range() {
+        let (s, e) = parse_active_hours("22:00-06:00").unwrap();
+        assert_eq!(s, NaiveTime::from_hms_opt(22, 0, 0).unwrap());
+        assert_eq!(e, NaiveTime::from_hms_opt(6, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn test_parse_invalid_returns_none() {
+        assert!(parse_active_hours("not-valid").is_none());
+        assert!(parse_active_hours("25:00-26:00").is_none());
+        assert!(parse_active_hours("0900-1800").is_none());
+    }
+
+    // ── is_within_active_hours ──────────────────────────────────────────────
+
+    #[test]
+    fn test_empty_schedule_always_active() {
+        assert!(is_within_active_hours(&Schedule::default()));
+        assert!(is_within_active_hours(&schedule(None, None)));
+    }
+
+    #[test]
+    fn test_normal_range_inside() {
+        // 10:30 is inside 09:00-18:00 — but we can't control Local::now() in tests.
+        // So we test the logic directly via parse_active_hours + manual check.
+        let (start, end) = parse_active_hours("09:00-18:00").unwrap();
+        let t = NaiveTime::from_hms_opt(10, 30, 0).unwrap();
+        assert!(t >= start && t < end);
+    }
+
+    #[test]
+    fn test_normal_range_outside_before() {
+        let (start, end) = parse_active_hours("09:00-18:00").unwrap();
+        let t = NaiveTime::from_hms_opt(8, 0, 0).unwrap();
+        assert!(!(t >= start && t < end));
+    }
+
+    #[test]
+    fn test_normal_range_outside_after() {
+        let (start, end) = parse_active_hours("09:00-18:00").unwrap();
+        let t = NaiveTime::from_hms_opt(19, 0, 0).unwrap();
+        assert!(!(t >= start && t < end));
+    }
+
+    #[test]
+    fn test_overnight_range_active_before_midnight() {
+        let (start, end) = parse_active_hours("22:00-06:00").unwrap();
+        // 23:00 is active (>= 22:00)
+        let t = NaiveTime::from_hms_opt(23, 0, 0).unwrap();
+        assert!(t >= start || t < end);
+    }
+
+    #[test]
+    fn test_overnight_range_active_after_midnight() {
+        let (start, end) = parse_active_hours("22:00-06:00").unwrap();
+        // 03:00 is active (< 06:00)
+        let t = NaiveTime::from_hms_opt(3, 0, 0).unwrap();
+        assert!(t >= start || t < end);
+    }
+
+    #[test]
+    fn test_overnight_range_inactive_midday() {
+        let (start, end) = parse_active_hours("22:00-06:00").unwrap();
+        // 12:00 is NOT active
+        let t = NaiveTime::from_hms_opt(12, 0, 0).unwrap();
+        assert!(!(t >= start || t < end));
+    }
+
+    #[test]
+    fn test_weekday_str_roundtrip() {
+        let days = [
+            (Weekday::Mon, "mon"),
+            (Weekday::Tue, "tue"),
+            (Weekday::Wed, "wed"),
+            (Weekday::Thu, "thu"),
+            (Weekday::Fri, "fri"),
+            (Weekday::Sat, "sat"),
+            (Weekday::Sun, "sun"),
+        ];
+        for (wd, expected) in days {
+            assert_eq!(weekday_str(wd), expected);
+        }
+    }
+
+    #[test]
+    fn test_days_filter_accepts_configured_day() {
+        // We can't control today's weekday, but we can verify that when all 7
+        // days are listed the schedule is never blocked by the day filter.
+        let all_days = schedule(
+            None,
+            Some(vec!["mon", "tue", "wed", "thu", "fri", "sat", "sun"]),
+        );
+        assert!(is_within_active_hours(&all_days));
+    }
+
+    #[test]
+    fn test_days_filter_rejects_empty_list() {
+        // An empty active_days list means no days are active.
+        let s = Schedule {
+            active_hours: None,
+            active_days: Some(vec![]),
+        };
+        assert!(!is_within_active_hours(&s));
+    }
+}

--- a/crates/apiari/src/buzz/schedule.rs
+++ b/crates/apiari/src/buzz/schedule.rs
@@ -1,18 +1,22 @@
 //! Schedule checking — determines whether the current local time falls within
 //! a configured active-hours window.
 
-use chrono::{Datelike, Local, NaiveTime, Weekday};
+use chrono::{Datelike, Local, NaiveDateTime, NaiveTime, Weekday};
+use tracing::warn;
 
 use crate::config::Schedule;
 
 /// Returns `true` if the current local time is within the active window defined
 /// by `schedule`.  Returns `true` (always active) when no constraints are set.
 pub fn is_within_active_hours(schedule: &Schedule) -> bool {
+    is_within_active_hours_at(schedule, Local::now().naive_local())
+}
+
+/// Inner implementation — accepts an injected `now` so tests can use fixed times.
+fn is_within_active_hours_at(schedule: &Schedule, now: NaiveDateTime) -> bool {
     if schedule.active_hours.is_none() && schedule.active_days.is_none() {
         return true;
     }
-
-    let now = Local::now();
 
     // Check active days first (cheap).
     if let Some(ref days) = schedule.active_days {
@@ -23,19 +27,29 @@ pub fn is_within_active_hours(schedule: &Schedule) -> bool {
     }
 
     // Check active hours window.
-    if let Some(ref hours) = schedule.active_hours
-        && let Some((start, end)) = parse_active_hours(hours)
-    {
-        let current = now.time();
-        let within = if start <= end {
-            // Normal range e.g. 09:00-18:00
-            current >= start && current < end
-        } else {
-            // Overnight range e.g. 22:00-06:00: active if >= 22:00 OR < 06:00
-            current >= start || current < end
-        };
-        if !within {
-            return false;
+    if let Some(ref hours) = schedule.active_hours {
+        match parse_active_hours(hours) {
+            Some((start, end)) => {
+                let current = now.time();
+                let within = if start <= end {
+                    // Normal range e.g. 09:00-18:00
+                    current >= start && current < end
+                } else {
+                    // Overnight range e.g. 22:00-06:00: active if >= 22:00 OR < 06:00
+                    current >= start || current < end
+                };
+                if !within {
+                    return false;
+                }
+            }
+            None => {
+                // Malformed — warn once and treat as no hours restriction for this field.
+                warn!(
+                    "schedule.active_hours {:?} is malformed (expected HH:MM-HH:MM); \
+                     ignoring hours constraint",
+                    hours
+                );
+            }
         }
     }
 
@@ -63,6 +77,8 @@ fn parse_active_hours(s: &str) -> Option<(NaiveTime, NaiveTime)> {
 
 #[cfg(test)]
 mod tests {
+    use chrono::NaiveDate;
+
     use super::*;
 
     fn schedule(hours: Option<&str>, days: Option<Vec<&str>>) -> Schedule {
@@ -70,6 +86,25 @@ mod tests {
             active_hours: hours.map(str::to_string),
             active_days: days.map(|v| v.into_iter().map(str::to_string).collect()),
         }
+    }
+
+    /// Build a NaiveDateTime for a known weekday + time (2024-01-08 = Monday).
+    fn at(weekday_offset_from_monday: u32, h: u32, m: u32) -> NaiveDateTime {
+        // 2024-01-08 is a Monday; adding days gives Tue, Wed, …, Sun.
+        NaiveDate::from_ymd_opt(2024, 1, 8 + weekday_offset_from_monday)
+            .unwrap()
+            .and_hms_opt(h, m, 0)
+            .unwrap()
+    }
+
+    fn mon(h: u32, m: u32) -> NaiveDateTime {
+        at(0, h, m)
+    }
+    fn wed(h: u32, m: u32) -> NaiveDateTime {
+        at(2, h, m)
+    }
+    fn sat(h: u32, m: u32) -> NaiveDateTime {
+        at(5, h, m)
     }
 
     // ── parse_active_hours ──────────────────────────────────────────────────
@@ -95,59 +130,105 @@ mod tests {
         assert!(parse_active_hours("0900-1800").is_none());
     }
 
-    // ── is_within_active_hours ──────────────────────────────────────────────
+    // ── is_within_active_hours_at ───────────────────────────────────────────
 
     #[test]
     fn test_empty_schedule_always_active() {
-        assert!(is_within_active_hours(&Schedule::default()));
-        assert!(is_within_active_hours(&schedule(None, None)));
+        assert!(is_within_active_hours_at(&Schedule::default(), mon(10, 0)));
+        assert!(is_within_active_hours_at(&schedule(None, None), sat(0, 0)));
     }
 
     #[test]
     fn test_normal_range_inside() {
-        // 10:30 is inside 09:00-18:00 — but we can't control Local::now() in tests.
-        // So we test the logic directly via parse_active_hours + manual check.
-        let (start, end) = parse_active_hours("09:00-18:00").unwrap();
-        let t = NaiveTime::from_hms_opt(10, 30, 0).unwrap();
-        assert!(t >= start && t < end);
+        let s = schedule(Some("09:00-18:00"), None);
+        assert!(is_within_active_hours_at(&s, mon(9, 0)));
+        assert!(is_within_active_hours_at(&s, mon(12, 30)));
+        assert!(is_within_active_hours_at(&s, mon(17, 59)));
     }
 
     #[test]
     fn test_normal_range_outside_before() {
-        let (start, end) = parse_active_hours("09:00-18:00").unwrap();
-        let t = NaiveTime::from_hms_opt(8, 0, 0).unwrap();
-        assert!(!(t >= start && t < end));
+        let s = schedule(Some("09:00-18:00"), None);
+        assert!(!is_within_active_hours_at(&s, mon(8, 59)));
+        assert!(!is_within_active_hours_at(&s, mon(0, 0)));
     }
 
     #[test]
     fn test_normal_range_outside_after() {
-        let (start, end) = parse_active_hours("09:00-18:00").unwrap();
-        let t = NaiveTime::from_hms_opt(19, 0, 0).unwrap();
-        assert!(!(t >= start && t < end));
+        let s = schedule(Some("09:00-18:00"), None);
+        assert!(!is_within_active_hours_at(&s, mon(18, 0)));
+        assert!(!is_within_active_hours_at(&s, mon(23, 0)));
     }
 
     #[test]
     fn test_overnight_range_active_before_midnight() {
-        let (start, end) = parse_active_hours("22:00-06:00").unwrap();
-        // 23:00 is active (>= 22:00)
-        let t = NaiveTime::from_hms_opt(23, 0, 0).unwrap();
-        assert!(t >= start || t < end);
+        let s = schedule(Some("22:00-06:00"), None);
+        assert!(is_within_active_hours_at(&s, mon(22, 0)));
+        assert!(is_within_active_hours_at(&s, mon(23, 30)));
     }
 
     #[test]
     fn test_overnight_range_active_after_midnight() {
-        let (start, end) = parse_active_hours("22:00-06:00").unwrap();
-        // 03:00 is active (< 06:00)
-        let t = NaiveTime::from_hms_opt(3, 0, 0).unwrap();
-        assert!(t >= start || t < end);
+        let s = schedule(Some("22:00-06:00"), None);
+        assert!(is_within_active_hours_at(&s, mon(0, 0)));
+        assert!(is_within_active_hours_at(&s, mon(3, 0)));
+        assert!(is_within_active_hours_at(&s, mon(5, 59)));
     }
 
     #[test]
     fn test_overnight_range_inactive_midday() {
-        let (start, end) = parse_active_hours("22:00-06:00").unwrap();
-        // 12:00 is NOT active
-        let t = NaiveTime::from_hms_opt(12, 0, 0).unwrap();
-        assert!(!(t >= start || t < end));
+        let s = schedule(Some("22:00-06:00"), None);
+        assert!(!is_within_active_hours_at(&s, mon(6, 0)));
+        assert!(!is_within_active_hours_at(&s, mon(12, 0)));
+        assert!(!is_within_active_hours_at(&s, mon(21, 59)));
+    }
+
+    #[test]
+    fn test_weekday_filter_active_on_configured_days() {
+        let s = schedule(Some("09:00-18:00"), Some(vec!["mon", "wed"]));
+        assert!(is_within_active_hours_at(&s, mon(10, 0)));
+        assert!(is_within_active_hours_at(&s, wed(10, 0)));
+    }
+
+    #[test]
+    fn test_weekday_filter_inactive_on_excluded_days() {
+        let s = schedule(
+            Some("09:00-18:00"),
+            Some(vec!["mon", "tue", "wed", "thu", "fri"]),
+        );
+        // Saturday is excluded
+        assert!(!is_within_active_hours_at(&s, sat(10, 0)));
+    }
+
+    #[test]
+    fn test_days_only_no_hours_weekday_active() {
+        let s = schedule(None, Some(vec!["mon"]));
+        assert!(is_within_active_hours_at(&s, mon(3, 0)));
+        assert!(is_within_active_hours_at(&s, mon(23, 59)));
+    }
+
+    #[test]
+    fn test_days_only_no_hours_weekend_inactive() {
+        let s = schedule(None, Some(vec!["mon", "tue", "wed", "thu", "fri"]));
+        assert!(!is_within_active_hours_at(&s, sat(12, 0)));
+    }
+
+    #[test]
+    fn test_days_filter_rejects_empty_list() {
+        let s = Schedule {
+            active_hours: None,
+            active_days: Some(vec![]),
+        };
+        assert!(!is_within_active_hours_at(&s, mon(10, 0)));
+    }
+
+    #[test]
+    fn test_malformed_hours_treated_as_unrestricted() {
+        // When hours is malformed, the hours constraint is ignored (warn is emitted
+        // at runtime but doesn't panic). Days constraint still applies.
+        let s = schedule(Some("9am-5pm"), Some(vec!["mon"]));
+        // Monday — days pass; malformed hours → hours ignored → active
+        assert!(is_within_active_hours_at(&s, mon(10, 0)));
     }
 
     #[test]
@@ -167,23 +248,14 @@ mod tests {
     }
 
     #[test]
-    fn test_days_filter_accepts_configured_day() {
-        // We can't control today's weekday, but we can verify that when all 7
-        // days are listed the schedule is never blocked by the day filter.
+    fn test_is_within_active_hours_delegates_to_local_now() {
+        // Smoke-test the public API: an empty schedule is always active regardless of time.
+        assert!(is_within_active_hours(&Schedule::default()));
+        // All 7 days — never blocked by day filter.
         let all_days = schedule(
             None,
             Some(vec!["mon", "tue", "wed", "thu", "fri", "sat", "sun"]),
         );
         assert!(is_within_active_hours(&all_days));
-    }
-
-    #[test]
-    fn test_days_filter_rejects_empty_list() {
-        // An empty active_days list means no days are active.
-        let s = Schedule {
-            active_hours: None,
-            active_days: Some(vec![]),
-        };
-        assert!(!is_within_active_hours(&s));
     }
 }

--- a/crates/apiari/src/buzz/schedule.rs
+++ b/crates/apiari/src/buzz/schedule.rs
@@ -6,6 +6,21 @@ use tracing::warn;
 
 use crate::config::Schedule;
 
+/// Validate a schedule at configuration-load time and emit a `warn!` for any
+/// malformed fields.  Call this once per watcher/workspace at startup — not
+/// in the poll hot path.
+pub fn warn_if_invalid(schedule: &Schedule) {
+    if let Some(ref hours) = schedule.active_hours
+        && parse_active_hours(hours).is_none()
+    {
+        warn!(
+            "schedule.active_hours {:?} is malformed (expected HH:MM-HH:MM); \
+             hours constraint will be ignored",
+            hours
+        );
+    }
+}
+
 /// Returns `true` if the current local time is within the active window defined
 /// by `schedule`.  Returns `true` (always active) when no constraints are set.
 pub fn is_within_active_hours(schedule: &Schedule) -> bool {
@@ -26,30 +41,21 @@ fn is_within_active_hours_at(schedule: &Schedule, now: NaiveDateTime) -> bool {
         }
     }
 
-    // Check active hours window.
-    if let Some(ref hours) = schedule.active_hours {
-        match parse_active_hours(hours) {
-            Some((start, end)) => {
-                let current = now.time();
-                let within = if start <= end {
-                    // Normal range e.g. 09:00-18:00
-                    current >= start && current < end
-                } else {
-                    // Overnight range e.g. 22:00-06:00: active if >= 22:00 OR < 06:00
-                    current >= start || current < end
-                };
-                if !within {
-                    return false;
-                }
-            }
-            None => {
-                // Malformed — warn once and treat as no hours restriction for this field.
-                warn!(
-                    "schedule.active_hours {:?} is malformed (expected HH:MM-HH:MM); \
-                     ignoring hours constraint",
-                    hours
-                );
-            }
+    // Check active hours window.  Malformed strings are silently ignored (no hours
+    // constraint applied) — callers should invoke `warn_if_invalid` at startup.
+    if let Some(ref hours) = schedule.active_hours
+        && let Some((start, end)) = parse_active_hours(hours)
+    {
+        let current = now.time();
+        let within = if start <= end {
+            // Normal range e.g. 09:00-18:00
+            current >= start && current < end
+        } else {
+            // Overnight range e.g. 22:00-06:00: active if >= 22:00 OR < 06:00
+            current >= start || current < end
+        };
+        if !within {
+            return false;
         }
     }
 

--- a/crates/apiari/src/buzz/watcher/mod.rs
+++ b/crates/apiari/src/buzz/watcher/mod.rs
@@ -25,6 +25,7 @@ use tracing::info;
 
 use crate::buzz::signal::SignalUpdate;
 use crate::buzz::signal::store::SignalStore;
+use crate::config::Schedule;
 
 /// A pluggable source that can be polled for new signals.
 #[async_trait]
@@ -68,9 +69,11 @@ pub struct ThrottledWatcher {
     last_poll: Option<Instant>,
     /// External IDs from the last successful poll, for auto-reconciliation.
     last_poll_ids: Option<Vec<String>>,
-    /// Optional per-watcher active-hours override (e.g. "09:00-17:00").
-    /// When set, this overrides the workspace-level schedule for this watcher.
-    active_hours: Option<String>,
+    /// Precomputed effective schedule for this watcher.
+    /// Combines the per-watcher `active_hours` override (if any) with the workspace-level
+    /// `active_days`. Only `active_hours` can be overridden per-watcher; `active_days`
+    /// always comes from the workspace schedule. Defaults to an empty (always-active) schedule.
+    effective_schedule: Schedule,
 }
 
 impl ThrottledWatcher {
@@ -80,18 +83,13 @@ impl ThrottledWatcher {
             interval: Duration::from_secs(interval_secs),
             last_poll: None,
             last_poll_ids: None,
-            active_hours: None,
+            effective_schedule: Schedule::default(),
         }
     }
 
-    /// Set a per-watcher active-hours override.
-    pub fn set_active_hours(&mut self, hours: Option<String>) {
-        self.active_hours = hours;
-    }
-
-    /// Return the per-watcher active-hours override, if set.
-    pub fn active_hours(&self) -> Option<&str> {
-        self.active_hours.as_deref()
+    /// Return the precomputed effective schedule for this watcher.
+    pub fn effective_schedule(&self) -> &Schedule {
+        &self.effective_schedule
     }
 
     /// Returns true if this watcher has never been polled or enough time has elapsed.
@@ -174,16 +172,17 @@ impl WatcherRegistry {
             .push(ThrottledWatcher::new(watcher, interval_secs));
     }
 
-    /// Add a watcher with a poll interval and an optional per-watcher active-hours override.
-    /// Prefer this over `add_with_interval` + `last_watcher_mut` to keep wiring in one place.
+    /// Add a watcher with a poll interval and a precomputed effective schedule.
+    /// The caller is responsible for merging per-watcher and workspace schedules before calling.
+    /// Prefer this over `add_with_interval` to keep schedule wiring in one place.
     pub fn add_with_interval_and_hours(
         &mut self,
         watcher: Box<dyn Watcher>,
         interval_secs: u64,
-        active_hours: Option<String>,
+        effective_schedule: Schedule,
     ) {
         let mut tw = ThrottledWatcher::new(watcher, interval_secs);
-        tw.set_active_hours(active_hours);
+        tw.effective_schedule = effective_schedule;
         self.watchers.push(tw);
     }
 

--- a/crates/apiari/src/buzz/watcher/mod.rs
+++ b/crates/apiari/src/buzz/watcher/mod.rs
@@ -174,6 +174,19 @@ impl WatcherRegistry {
             .push(ThrottledWatcher::new(watcher, interval_secs));
     }
 
+    /// Add a watcher with a poll interval and an optional per-watcher active-hours override.
+    /// Prefer this over `add_with_interval` + `last_watcher_mut` to keep wiring in one place.
+    pub fn add_with_interval_and_hours(
+        &mut self,
+        watcher: Box<dyn Watcher>,
+        interval_secs: u64,
+        active_hours: Option<String>,
+    ) {
+        let mut tw = ThrottledWatcher::new(watcher, interval_secs);
+        tw.set_active_hours(active_hours);
+        self.watchers.push(tw);
+    }
+
     pub fn watchers_mut(&mut self) -> &mut [ThrottledWatcher] {
         &mut self.watchers
     }

--- a/crates/apiari/src/buzz/watcher/mod.rs
+++ b/crates/apiari/src/buzz/watcher/mod.rs
@@ -68,6 +68,9 @@ pub struct ThrottledWatcher {
     last_poll: Option<Instant>,
     /// External IDs from the last successful poll, for auto-reconciliation.
     last_poll_ids: Option<Vec<String>>,
+    /// Optional per-watcher active-hours override (e.g. "09:00-17:00").
+    /// When set, this overrides the workspace-level schedule for this watcher.
+    active_hours: Option<String>,
 }
 
 impl ThrottledWatcher {
@@ -77,7 +80,18 @@ impl ThrottledWatcher {
             interval: Duration::from_secs(interval_secs),
             last_poll: None,
             last_poll_ids: None,
+            active_hours: None,
         }
+    }
+
+    /// Set a per-watcher active-hours override.
+    pub fn set_active_hours(&mut self, hours: Option<String>) {
+        self.active_hours = hours;
+    }
+
+    /// Return the per-watcher active-hours override, if set.
+    pub fn active_hours(&self) -> Option<&str> {
+        self.active_hours.as_deref()
     }
 
     /// Returns true if this watcher has never been polled or enough time has elapsed.
@@ -162,6 +176,11 @@ impl WatcherRegistry {
 
     pub fn watchers_mut(&mut self) -> &mut [ThrottledWatcher] {
         &mut self.watchers
+    }
+
+    /// Return a mutable reference to the most-recently-added watcher.
+    pub fn last_watcher_mut(&mut self) -> Option<&mut ThrottledWatcher> {
+        self.watchers.last_mut()
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/apiari/src/buzz/watcher/mod.rs
+++ b/crates/apiari/src/buzz/watcher/mod.rs
@@ -175,7 +175,7 @@ impl WatcherRegistry {
     /// Add a watcher with a poll interval and a precomputed effective schedule.
     /// The caller is responsible for merging per-watcher and workspace schedules before calling.
     /// Prefer this over `add_with_interval` to keep schedule wiring in one place.
-    pub fn add_with_interval_and_hours(
+    pub fn add_with_interval_and_schedule(
         &mut self,
         watcher: Box<dyn Watcher>,
         interval_secs: u64,

--- a/crates/apiari/src/buzz/watcher/mod.rs
+++ b/crates/apiari/src/buzz/watcher/mod.rs
@@ -190,11 +190,6 @@ impl WatcherRegistry {
         &mut self.watchers
     }
 
-    /// Return a mutable reference to the most-recently-added watcher.
-    pub fn last_watcher_mut(&mut self) -> Option<&mut ThrottledWatcher> {
-        self.watchers.last_mut()
-    }
-
     pub fn is_empty(&self) -> bool {
         self.watchers.is_empty()
     }

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -122,7 +122,15 @@ impl MergePrsCapability {
     }
 }
 
-/// Current workspace config version. Bump when adding new fields or changing semantics.
+/// Current workspace config version.
+///
+/// Bump this constant whenever you:
+/// - Add, remove, or rename a config field
+/// - Change the meaning or valid values of an existing field
+/// - Change default behaviour in a way that affects existing configs
+///
+/// The daemon's doctor check (`apiari doctor`) compares the on-disk `config_version`
+/// against this value and warns users whose configs are older than the current version.
 pub const CURRENT_CONFIG_VERSION: u32 = 2;
 
 /// Schedule configuration — defines when watchers and signal hooks are active.

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -125,6 +125,21 @@ impl MergePrsCapability {
 /// Current workspace config version. Bump when adding new fields or changing semantics.
 pub const CURRENT_CONFIG_VERSION: u32 = 1;
 
+/// Schedule configuration — defines when watchers and signal hooks are active.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Schedule {
+    /// Active time window in "HH:MM-HH:MM" 24h local time (e.g. "09:00-18:00").
+    /// Supports overnight ranges like "22:00-06:00".
+    /// If absent, all hours are active.
+    #[serde(default)]
+    pub active_hours: Option<String>,
+    /// Active days of the week as lowercase 3-letter abbreviations
+    /// (e.g. ["mon", "tue", "wed", "thu", "fri"]).
+    /// If absent, all days are active.
+    #[serde(default)]
+    pub active_days: Option<Vec<String>>,
+}
+
 /// A fully self-contained workspace configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
@@ -205,6 +220,10 @@ pub struct WorkspaceConfig {
     /// Shell management configuration (tmux integration).
     #[serde(default)]
     pub shells: ShellsConfig,
+
+    /// Active-hours schedule — when absent, watchers and signal hooks run 24/7.
+    #[serde(default)]
+    pub schedule: Option<Schedule>,
 }
 
 /// A single daemon TCP endpoint (host + port).
@@ -408,6 +427,9 @@ pub struct EmailMailboxConfig {
     pub interval_secs: u64,
     #[serde(default)]
     pub summarizer: Option<EmailSummarizerConfig>,
+    /// Per-watcher active hours override. Overrides workspace schedule.
+    #[serde(default)]
+    pub active_hours: Option<String>,
 }
 
 /// Ollama/OpenAI-compatible summarizer configuration.
@@ -427,6 +449,9 @@ pub struct NotionWatcherConfig {
     pub poll_database_ids: Option<Vec<String>>,
     #[serde(default = "default_notion_interval")]
     pub interval_secs: u64,
+    /// Per-watcher active hours override. Overrides workspace schedule.
+    #[serde(default)]
+    pub active_hours: Option<String>,
 }
 
 /// Linear watcher configuration.
@@ -438,6 +463,9 @@ pub struct LinearWatcherConfig {
     pub poll_interval_secs: u64,
     #[serde(default)]
     pub review_queue: Vec<LinearReviewQueueEntry>,
+    /// Per-watcher active hours override. Overrides workspace schedule.
+    #[serde(default)]
+    pub active_hours: Option<String>,
 }
 
 /// A single review queue query for Linear.
@@ -460,6 +488,9 @@ pub struct ScriptWatcherConfig {
     pub severity_on_fail: String,
     #[serde(default = "default_script_timeout")]
     pub timeout_secs: u64,
+    /// Per-watcher active hours override. Overrides workspace schedule.
+    #[serde(default)]
+    pub active_hours: Option<String>,
 }
 
 fn default_script_interval() -> u64 {
@@ -520,6 +551,9 @@ pub struct GithubWatcherConfig {
     /// Per-event-type filters (e.g. `github_pr_push = "author:@me"`).
     #[serde(default)]
     pub filters: HashMap<String, String>,
+    /// Per-watcher active hours override (e.g. "09:00-17:00"). Overrides workspace schedule.
+    #[serde(default)]
+    pub active_hours: Option<String>,
 }
 
 /// A named review queue query.
@@ -539,6 +573,9 @@ pub struct SentryWatcherConfig {
     pub token: String,
     #[serde(default = "default_watcher_interval")]
     pub interval_secs: u64,
+    /// Per-watcher active hours override. Overrides workspace schedule.
+    #[serde(default)]
+    pub active_hours: Option<String>,
 }
 
 /// Swarm watcher configuration.
@@ -547,6 +584,9 @@ pub struct SwarmWatcherConfig {
     pub state_path: PathBuf,
     #[serde(default = "default_swarm_interval")]
     pub interval_secs: u64,
+    /// Per-watcher active hours override. Overrides workspace schedule.
+    #[serde(default)]
+    pub active_hours: Option<String>,
 }
 
 /// Morning brief configuration.
@@ -1235,6 +1275,7 @@ max_session_turns = 0
             daemon_port: None,
             daemon_endpoints: vec![],
             shells: ShellsConfig::default(),
+            schedule: None,
         };
         assert_eq!(resolve_repos(&config), vec!["Org/Repo"]);
     }
@@ -1261,6 +1302,7 @@ max_session_turns = 0
             daemon_port: None,
             daemon_endpoints: vec![],
             shells: ShellsConfig::default(),
+            schedule: None,
         };
         assert!(resolve_repos(&config).is_empty());
     }
@@ -1291,6 +1333,7 @@ max_session_turns = 0
             daemon_port: None,
             daemon_endpoints: vec![],
             shells: ShellsConfig::default(),
+            schedule: None,
         };
 
         let buzz = to_buzz_config(&ws);
@@ -1534,6 +1577,7 @@ max_session_turns = 0
                     interval_secs: default_watcher_interval(),
                     review_queue: vec![],
                     filters: HashMap::new(),
+                    active_hours: None,
                 }),
                 ..Default::default()
             },
@@ -1547,6 +1591,7 @@ max_session_turns = 0
             daemon_port: None,
             daemon_endpoints: vec![],
             shells: ShellsConfig::default(),
+            schedule: None,
         }
     }
 

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -123,7 +123,7 @@ impl MergePrsCapability {
 }
 
 /// Current workspace config version. Bump when adding new fields or changing semantics.
-pub const CURRENT_CONFIG_VERSION: u32 = 1;
+pub const CURRENT_CONFIG_VERSION: u32 = 2;
 
 /// Schedule configuration — defines when watchers and signal hooks are active.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/apiari/src/daemon/doctor.rs
+++ b/crates/apiari/src/daemon/doctor.rs
@@ -248,6 +248,7 @@ mod tests {
             daemon_port: None,
             daemon_endpoints: vec![],
             shells: ShellsConfig::default(),
+            schedule: None,
         }
     }
 

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1005,7 +1005,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .as_ref()
                     .and_then(|g| g.active_hours.as_deref()),
             );
-            crate::buzz::schedule::warn_if_invalid(&gh_sched);
             registry.add_with_interval_and_hours(
                 Box::new(gh_watcher),
                 gh_config.interval_secs,
@@ -1052,7 +1051,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .as_ref()
                     .and_then(|s| s.active_hours.as_deref()),
             );
-            crate::buzz::schedule::warn_if_invalid(&sentry_sched);
             registry.add_with_interval_and_hours(
                 Box::new(SentryWatcher::new(sentry_config.clone())),
                 sentry_config.interval_secs,
@@ -1079,7 +1077,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .as_ref()
                     .and_then(|s| s.active_hours.as_deref()),
             );
-            crate::buzz::schedule::warn_if_invalid(&swarm_sched);
             registry.add_with_interval_and_hours(
                 Box::new(SwarmWatcher::new(ws.config.root.clone())),
                 swarm_config.interval_secs,
@@ -1111,7 +1108,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .get(i)
                     .and_then(|e| e.active_hours.as_deref()),
             );
-            crate::buzz::schedule::warn_if_invalid(&email_sched);
             registry.add_with_interval_and_hours(
                 Box::new(watcher),
                 email_config.interval_secs,
@@ -1141,7 +1137,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .get(i)
                     .and_then(|n| n.active_hours.as_deref()),
             );
-            crate::buzz::schedule::warn_if_invalid(&notion_sched);
             registry.add_with_interval_and_hours(
                 Box::new(watcher),
                 notion_config.interval_secs,
@@ -1189,7 +1184,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .get(i)
                     .and_then(|l| l.active_hours.as_deref()),
             );
-            crate::buzz::schedule::warn_if_invalid(&linear_sched);
             registry.add_with_interval_and_hours(
                 Box::new(watcher),
                 linear_config.poll_interval_secs,
@@ -1210,7 +1204,6 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .get(i)
                     .and_then(|s| s.active_hours.as_deref()),
             );
-            crate::buzz::schedule::warn_if_invalid(&script_sched);
             registry.add_with_interval_and_hours(
                 Box::new(ScriptWatcher::new(script_config.clone())),
                 script_config.interval_secs,
@@ -1761,9 +1754,11 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                         .map(crate::buzz::schedule::is_within_active_hours)
                         .unwrap_or(true);
                     if !follow_through_active && !hook_events.is_empty() {
+                        let dropped: usize = hook_events.values().map(|(sigs, _)| sigs.len()).sum();
                         info!(
-                            "[{}] skipping signal follow-through: outside active hours ({} event(s) dropped)",
+                            "[{}] skipping signal follow-through: outside active hours ({} signal(s) across {} source(s) dropped)",
                             slot.name,
+                            dropped,
                             hook_events.len()
                         );
                     }
@@ -3113,21 +3108,34 @@ async fn build_full_status(slot: &WorkspaceSlot) -> String {
     summary
 }
 
-/// Compute the effective schedule for a single watcher.
+/// Compute the effective schedule for a single watcher and validate the
+/// per-watcher override (if any).
 ///
 /// A per-watcher `active_hours` string overrides the workspace-level `active_hours`.
 /// `active_days` is always inherited from the workspace schedule — per-watcher configs
 /// cannot override it.  The result is precomputed once at registration time so the
 /// poll loop never allocates.
+///
+/// When a per-watcher `active_hours` override is provided it is validated here
+/// (emitting a `warn!` if malformed).  The workspace-level schedule must be
+/// validated separately at startup (once, before any watchers are registered) to
+/// avoid duplicate warnings.
 fn effective_watcher_schedule(
     workspace: Option<&crate::config::Schedule>,
     watcher_hours: Option<&str>,
 ) -> crate::config::Schedule {
     match watcher_hours {
-        Some(ah) => crate::config::Schedule {
-            active_hours: Some(ah.to_string()),
-            active_days: workspace.and_then(|s| s.active_days.clone()),
-        },
+        Some(ah) => {
+            // Validate only the per-watcher override; workspace hours were validated at startup.
+            crate::buzz::schedule::warn_if_invalid(&crate::config::Schedule {
+                active_hours: Some(ah.to_string()),
+                active_days: None,
+            });
+            crate::config::Schedule {
+                active_hours: Some(ah.to_string()),
+                active_days: workspace.and_then(|s| s.active_days.clone()),
+            }
+        }
         None => workspace.cloned().unwrap_or_default(),
     }
 }

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -992,16 +992,17 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             );
             let mut gh_watcher = GithubWatcher::new(gh_config.clone());
             gh_watcher.load_cursors(&store);
-            registry.add_with_interval(Box::new(gh_watcher), gh_config.interval_secs);
-            if let Some(tw) = registry.last_watcher_mut() {
-                tw.set_active_hours(
-                    ws.config
-                        .watchers
-                        .github
-                        .as_ref()
-                        .and_then(|g| g.active_hours.clone()),
-                );
-            }
+            let gh_active_hours = ws
+                .config
+                .watchers
+                .github
+                .as_ref()
+                .and_then(|g| g.active_hours.clone());
+            registry.add_with_interval_and_hours(
+                Box::new(gh_watcher),
+                gh_config.interval_secs,
+                gh_active_hours.clone(),
+            );
 
             if !gh_config.review_queue.is_empty() {
                 let query_names: Vec<&str> = gh_config
@@ -1020,19 +1021,11 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     },
                     query_names.join(", ")
                 );
-                registry.add_with_interval(
+                registry.add_with_interval_and_hours(
                     Box::new(ReviewQueueWatcher::new(gh_config)),
                     gh_config.interval_secs,
+                    gh_active_hours,
                 );
-                if let Some(tw) = registry.last_watcher_mut() {
-                    tw.set_active_hours(
-                        ws.config
-                            .watchers
-                            .github
-                            .as_ref()
-                            .and_then(|g| g.active_hours.clone()),
-                    );
-                }
             }
         }
 
@@ -1043,19 +1036,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 "[{}] enabling sentry watcher ({}/{})",
                 ws.name, sentry_config.org, sentry_config.project
             );
-            registry.add_with_interval(
+            registry.add_with_interval_and_hours(
                 Box::new(SentryWatcher::new(sentry_config.clone())),
                 sentry_config.interval_secs,
+                ws.config
+                    .watchers
+                    .sentry
+                    .as_ref()
+                    .and_then(|s| s.active_hours.clone()),
             );
-            if let Some(tw) = registry.last_watcher_mut() {
-                tw.set_active_hours(
-                    ws.config
-                        .watchers
-                        .sentry
-                        .as_ref()
-                        .and_then(|s| s.active_hours.clone()),
-                );
-            }
         }
 
         if let Some(swarm_config) = &buzz_config.watchers.swarm
@@ -1069,19 +1058,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 ws.name,
                 ws.config.root.display()
             );
-            registry.add_with_interval(
+            registry.add_with_interval_and_hours(
                 Box::new(SwarmWatcher::new(ws.config.root.clone())),
                 swarm_config.interval_secs,
+                ws.config
+                    .watchers
+                    .swarm
+                    .as_ref()
+                    .and_then(|s| s.active_hours.clone()),
             );
-            if let Some(tw) = registry.last_watcher_mut() {
-                tw.set_active_hours(
-                    ws.config
-                        .watchers
-                        .swarm
-                        .as_ref()
-                        .and_then(|s| s.active_hours.clone()),
-                );
-            }
         }
 
         for (i, email_config) in buzz_config.watchers.email.iter().enumerate() {
@@ -1100,16 +1085,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 "[{}] enabling email watcher '{}' ({})",
                 ws.name, email_config.name, email_config.host
             );
-            registry.add_with_interval(Box::new(watcher), email_config.interval_secs);
-            if let Some(tw) = registry.last_watcher_mut() {
-                tw.set_active_hours(
-                    ws.config
-                        .watchers
-                        .email
-                        .get(i)
-                        .and_then(|e| e.active_hours.clone()),
-                );
-            }
+            registry.add_with_interval_and_hours(
+                Box::new(watcher),
+                email_config.interval_secs,
+                ws.config
+                    .watchers
+                    .email
+                    .get(i)
+                    .and_then(|e| e.active_hours.clone()),
+            );
         }
 
         for (i, notion_config) in buzz_config.watchers.notion.iter().enumerate() {
@@ -1126,16 +1110,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 "[{}] enabling notion watcher '{}'",
                 ws.name, notion_config.name
             );
-            registry.add_with_interval(Box::new(watcher), notion_config.interval_secs);
-            if let Some(tw) = registry.last_watcher_mut() {
-                tw.set_active_hours(
-                    ws.config
-                        .watchers
-                        .notion
-                        .get(i)
-                        .and_then(|n| n.active_hours.clone()),
-                );
-            }
+            registry.add_with_interval_and_hours(
+                Box::new(watcher),
+                notion_config.interval_secs,
+                ws.config
+                    .watchers
+                    .notion
+                    .get(i)
+                    .and_then(|n| n.active_hours.clone()),
+            );
         }
 
         for (i, linear_config) in buzz_config.watchers.linear.iter().enumerate() {
@@ -1170,16 +1153,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 },
                 query_names.join(", ")
             );
-            registry.add_with_interval(Box::new(watcher), linear_config.poll_interval_secs);
-            if let Some(tw) = registry.last_watcher_mut() {
-                tw.set_active_hours(
-                    ws.config
-                        .watchers
-                        .linear
-                        .get(i)
-                        .and_then(|l| l.active_hours.clone()),
-                );
-            }
+            registry.add_with_interval_and_hours(
+                Box::new(watcher),
+                linear_config.poll_interval_secs,
+                ws.config
+                    .watchers
+                    .linear
+                    .get(i)
+                    .and_then(|l| l.active_hours.clone()),
+            );
         }
 
         for (i, script_config) in buzz_config.watchers.script.iter().enumerate() {
@@ -1187,19 +1169,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 "[{}] enabling script watcher '{}'",
                 ws.name, script_config.name
             );
-            registry.add_with_interval(
+            registry.add_with_interval_and_hours(
                 Box::new(ScriptWatcher::new(script_config.clone())),
                 script_config.interval_secs,
+                ws.config
+                    .watchers
+                    .script
+                    .get(i)
+                    .and_then(|s| s.active_hours.clone()),
             );
-            if let Some(tw) = registry.last_watcher_mut() {
-                tw.set_active_hours(
-                    ws.config
-                        .watchers
-                        .script
-                        .get(i)
-                        .and_then(|s| s.active_hours.clone()),
-                );
-            }
         }
 
         let mut coordinator = build_coordinator(&ws.name, &ws.config);

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -979,6 +979,11 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
         };
         let buzz_config = to_buzz_config(&ws.config);
 
+        // Validate workspace-level schedule once at startup (warns on malformed active_hours).
+        if let Some(ref ws_sched) = ws.config.schedule {
+            crate::buzz::schedule::warn_if_invalid(ws_sched);
+        }
+
         let mut registry = WatcherRegistry::new();
 
         if let Some(gh_config) = &buzz_config.watchers.github
@@ -992,16 +997,19 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             );
             let mut gh_watcher = GithubWatcher::new(gh_config.clone());
             gh_watcher.load_cursors(&store);
-            let gh_active_hours = ws
-                .config
-                .watchers
-                .github
-                .as_ref()
-                .and_then(|g| g.active_hours.clone());
+            let gh_sched = effective_watcher_schedule(
+                ws.config.schedule.as_ref(),
+                ws.config
+                    .watchers
+                    .github
+                    .as_ref()
+                    .and_then(|g| g.active_hours.as_deref()),
+            );
+            crate::buzz::schedule::warn_if_invalid(&gh_sched);
             registry.add_with_interval_and_hours(
                 Box::new(gh_watcher),
                 gh_config.interval_secs,
-                gh_active_hours.clone(),
+                gh_sched.clone(),
             );
 
             if !gh_config.review_queue.is_empty() {
@@ -1024,7 +1032,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 registry.add_with_interval_and_hours(
                     Box::new(ReviewQueueWatcher::new(gh_config)),
                     gh_config.interval_secs,
-                    gh_active_hours,
+                    gh_sched,
                 );
             }
         }
@@ -1036,14 +1044,19 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 "[{}] enabling sentry watcher ({}/{})",
                 ws.name, sentry_config.org, sentry_config.project
             );
-            registry.add_with_interval_and_hours(
-                Box::new(SentryWatcher::new(sentry_config.clone())),
-                sentry_config.interval_secs,
+            let sentry_sched = effective_watcher_schedule(
+                ws.config.schedule.as_ref(),
                 ws.config
                     .watchers
                     .sentry
                     .as_ref()
-                    .and_then(|s| s.active_hours.clone()),
+                    .and_then(|s| s.active_hours.as_deref()),
+            );
+            crate::buzz::schedule::warn_if_invalid(&sentry_sched);
+            registry.add_with_interval_and_hours(
+                Box::new(SentryWatcher::new(sentry_config.clone())),
+                sentry_config.interval_secs,
+                sentry_sched,
             );
         }
 
@@ -1058,14 +1071,19 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 ws.name,
                 ws.config.root.display()
             );
-            registry.add_with_interval_and_hours(
-                Box::new(SwarmWatcher::new(ws.config.root.clone())),
-                swarm_config.interval_secs,
+            let swarm_sched = effective_watcher_schedule(
+                ws.config.schedule.as_ref(),
                 ws.config
                     .watchers
                     .swarm
                     .as_ref()
-                    .and_then(|s| s.active_hours.clone()),
+                    .and_then(|s| s.active_hours.as_deref()),
+            );
+            crate::buzz::schedule::warn_if_invalid(&swarm_sched);
+            registry.add_with_interval_and_hours(
+                Box::new(SwarmWatcher::new(ws.config.root.clone())),
+                swarm_config.interval_secs,
+                swarm_sched,
             );
         }
 
@@ -1085,14 +1103,19 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 "[{}] enabling email watcher '{}' ({})",
                 ws.name, email_config.name, email_config.host
             );
-            registry.add_with_interval_and_hours(
-                Box::new(watcher),
-                email_config.interval_secs,
+            let email_sched = effective_watcher_schedule(
+                ws.config.schedule.as_ref(),
                 ws.config
                     .watchers
                     .email
                     .get(i)
-                    .and_then(|e| e.active_hours.clone()),
+                    .and_then(|e| e.active_hours.as_deref()),
+            );
+            crate::buzz::schedule::warn_if_invalid(&email_sched);
+            registry.add_with_interval_and_hours(
+                Box::new(watcher),
+                email_config.interval_secs,
+                email_sched,
             );
         }
 
@@ -1110,14 +1133,19 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 "[{}] enabling notion watcher '{}'",
                 ws.name, notion_config.name
             );
-            registry.add_with_interval_and_hours(
-                Box::new(watcher),
-                notion_config.interval_secs,
+            let notion_sched = effective_watcher_schedule(
+                ws.config.schedule.as_ref(),
                 ws.config
                     .watchers
                     .notion
                     .get(i)
-                    .and_then(|n| n.active_hours.clone()),
+                    .and_then(|n| n.active_hours.as_deref()),
+            );
+            crate::buzz::schedule::warn_if_invalid(&notion_sched);
+            registry.add_with_interval_and_hours(
+                Box::new(watcher),
+                notion_config.interval_secs,
+                notion_sched,
             );
         }
 
@@ -1153,14 +1181,19 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 },
                 query_names.join(", ")
             );
-            registry.add_with_interval_and_hours(
-                Box::new(watcher),
-                linear_config.poll_interval_secs,
+            let linear_sched = effective_watcher_schedule(
+                ws.config.schedule.as_ref(),
                 ws.config
                     .watchers
                     .linear
                     .get(i)
-                    .and_then(|l| l.active_hours.clone()),
+                    .and_then(|l| l.active_hours.as_deref()),
+            );
+            crate::buzz::schedule::warn_if_invalid(&linear_sched);
+            registry.add_with_interval_and_hours(
+                Box::new(watcher),
+                linear_config.poll_interval_secs,
+                linear_sched,
             );
         }
 
@@ -1169,14 +1202,19 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 "[{}] enabling script watcher '{}'",
                 ws.name, script_config.name
             );
-            registry.add_with_interval_and_hours(
-                Box::new(ScriptWatcher::new(script_config.clone())),
-                script_config.interval_secs,
+            let script_sched = effective_watcher_schedule(
+                ws.config.schedule.as_ref(),
                 ws.config
                     .watchers
                     .script
                     .get(i)
-                    .and_then(|s| s.active_hours.clone()),
+                    .and_then(|s| s.active_hours.as_deref()),
+            );
+            crate::buzz::schedule::warn_if_invalid(&script_sched);
+            registry.add_with_interval_and_hours(
+                Box::new(ScriptWatcher::new(script_config.clone())),
+                script_config.interval_secs,
+                script_sched,
             );
         }
 
@@ -1509,18 +1547,8 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                         }
                         let watcher_name = throttled.watcher().name().to_string();
 
-                        // Check active-hours schedule before polling.
-                        // Per-watcher active_hours overrides workspace schedule (hours only;
-                        // active_days still come from workspace schedule when a per-watcher
-                        // override is set).
-                        let effective_schedule = match throttled.active_hours() {
-                            Some(ah) => crate::config::Schedule {
-                                active_hours: Some(ah.to_string()),
-                                active_days: slot.config.schedule.as_ref().and_then(|s| s.active_days.clone()),
-                            },
-                            None => slot.config.schedule.clone().unwrap_or_default(),
-                        };
-                        if !crate::buzz::schedule::is_within_active_hours(&effective_schedule) {
+                        // Schedule check: effective_schedule was precomputed at registration.
+                        if !crate::buzz::schedule::is_within_active_hours(throttled.effective_schedule()) {
                             tracing::trace!(
                                 "[{}] [{}] skipping poll: outside active hours",
                                 slot.name,
@@ -3083,6 +3111,25 @@ async fn build_full_status(slot: &WorkspaceSlot) -> String {
     }
 
     summary
+}
+
+/// Compute the effective schedule for a single watcher.
+///
+/// A per-watcher `active_hours` string overrides the workspace-level `active_hours`.
+/// `active_days` is always inherited from the workspace schedule — per-watcher configs
+/// cannot override it.  The result is precomputed once at registration time so the
+/// poll loop never allocates.
+fn effective_watcher_schedule(
+    workspace: Option<&crate::config::Schedule>,
+    watcher_hours: Option<&str>,
+) -> crate::config::Schedule {
+    match watcher_hours {
+        Some(ah) => crate::config::Schedule {
+            active_hours: Some(ah.to_string()),
+            active_days: workspace.and_then(|s| s.active_days.clone()),
+        },
+        None => workspace.cloned().unwrap_or_default(),
+    }
 }
 
 /// Format signal events into a system notification for the coordinator.

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1005,7 +1005,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .as_ref()
                     .and_then(|g| g.active_hours.as_deref()),
             );
-            registry.add_with_interval_and_hours(
+            registry.add_with_interval_and_schedule(
                 Box::new(gh_watcher),
                 gh_config.interval_secs,
                 gh_sched.clone(),
@@ -1028,7 +1028,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     },
                     query_names.join(", ")
                 );
-                registry.add_with_interval_and_hours(
+                registry.add_with_interval_and_schedule(
                     Box::new(ReviewQueueWatcher::new(gh_config)),
                     gh_config.interval_secs,
                     gh_sched,
@@ -1051,7 +1051,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .as_ref()
                     .and_then(|s| s.active_hours.as_deref()),
             );
-            registry.add_with_interval_and_hours(
+            registry.add_with_interval_and_schedule(
                 Box::new(SentryWatcher::new(sentry_config.clone())),
                 sentry_config.interval_secs,
                 sentry_sched,
@@ -1077,7 +1077,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .as_ref()
                     .and_then(|s| s.active_hours.as_deref()),
             );
-            registry.add_with_interval_and_hours(
+            registry.add_with_interval_and_schedule(
                 Box::new(SwarmWatcher::new(ws.config.root.clone())),
                 swarm_config.interval_secs,
                 swarm_sched,
@@ -1108,7 +1108,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .get(i)
                     .and_then(|e| e.active_hours.as_deref()),
             );
-            registry.add_with_interval_and_hours(
+            registry.add_with_interval_and_schedule(
                 Box::new(watcher),
                 email_config.interval_secs,
                 email_sched,
@@ -1137,7 +1137,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .get(i)
                     .and_then(|n| n.active_hours.as_deref()),
             );
-            registry.add_with_interval_and_hours(
+            registry.add_with_interval_and_schedule(
                 Box::new(watcher),
                 notion_config.interval_secs,
                 notion_sched,
@@ -1184,7 +1184,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .get(i)
                     .and_then(|l| l.active_hours.as_deref()),
             );
-            registry.add_with_interval_and_hours(
+            registry.add_with_interval_and_schedule(
                 Box::new(watcher),
                 linear_config.poll_interval_secs,
                 linear_sched,
@@ -1204,7 +1204,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .get(i)
                     .and_then(|s| s.active_hours.as_deref()),
             );
-            registry.add_with_interval_and_hours(
+            registry.add_with_interval_and_schedule(
                 Box::new(ScriptWatcher::new(script_config.clone())),
                 script_config.interval_secs,
                 script_sched,
@@ -2340,7 +2340,7 @@ pub fn show_status(workspace_filter: Option<&str>) -> Result<()> {
                         .join(", ")
                 })
                 .unwrap_or_else(|| "all days".to_string());
-            println!("  Schedule: paused (active {hours_str}, {days_str})\n");
+            println!("  Schedule: paused (active {hours_str}, {days_str})");
         }
     }
 

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1004,6 +1004,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .github
                     .as_ref()
                     .and_then(|g| g.active_hours.as_deref()),
+                "github",
             );
             registry.add_with_interval_and_schedule(
                 Box::new(gh_watcher),
@@ -1050,6 +1051,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .sentry
                     .as_ref()
                     .and_then(|s| s.active_hours.as_deref()),
+                "sentry",
             );
             registry.add_with_interval_and_schedule(
                 Box::new(SentryWatcher::new(sentry_config.clone())),
@@ -1076,6 +1078,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .swarm
                     .as_ref()
                     .and_then(|s| s.active_hours.as_deref()),
+                "swarm",
             );
             registry.add_with_interval_and_schedule(
                 Box::new(SwarmWatcher::new(ws.config.root.clone())),
@@ -1107,6 +1110,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .email
                     .get(i)
                     .and_then(|e| e.active_hours.as_deref()),
+                &email_config.name,
             );
             registry.add_with_interval_and_schedule(
                 Box::new(watcher),
@@ -1136,6 +1140,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .notion
                     .get(i)
                     .and_then(|n| n.active_hours.as_deref()),
+                &notion_config.name,
             );
             registry.add_with_interval_and_schedule(
                 Box::new(watcher),
@@ -1183,6 +1188,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .linear
                     .get(i)
                     .and_then(|l| l.active_hours.as_deref()),
+                &linear_config.name,
             );
             registry.add_with_interval_and_schedule(
                 Box::new(watcher),
@@ -1203,6 +1209,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     .script
                     .get(i)
                     .and_then(|s| s.active_hours.as_deref()),
+                &script_config.name,
             );
             registry.add_with_interval_and_schedule(
                 Box::new(ScriptWatcher::new(script_config.clone())),
@@ -1763,21 +1770,17 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                         );
                     }
 
-                    for (source, (signals, hook)) in &hook_events {
-                        if follow_through_active {
-                            info!(
-                                "[follow-through] dispatching: workspace={} source={source} signal_count={} has_action={} ttl_secs={}",
-                                slot.name,
-                                signals.len(),
-                                hook.action.is_some(),
-                                hook.ttl_secs,
-                            );
-                        }
-                    }
                     for (source, (signals, hook)) in hook_events {
                         if !follow_through_active {
                             continue;
                         }
+                        info!(
+                            "[follow-through] dispatching: workspace={} source={source} signal_count={} has_action={} ttl_secs={}",
+                            slot.name,
+                            signals.len(),
+                            hook.action.is_some(),
+                            hook.ttl_secs,
+                        );
                         let telegram_info = slot.config.telegram.as_ref().and_then(|tg| {
                             telegram_channels.get(&tg.bot_token).map(|ch| {
                                 (ch.clone(), tg.chat_id, tg.topic_id)
@@ -2324,22 +2327,21 @@ pub fn show_status(workspace_filter: Option<&str>) -> Result<()> {
             && !crate::buzz::schedule::is_within_active_hours(schedule)
         {
             let hours_str = schedule.active_hours.as_deref().unwrap_or("all hours");
-            let days_str = schedule
-                .active_days
-                .as_ref()
-                .map(|d| {
-                    d.iter()
-                        .map(|s| {
-                            let mut c = s.chars();
-                            match c.next() {
-                                Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
-                                None => String::new(),
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                })
-                .unwrap_or_else(|| "all days".to_string());
+            let days_str = match schedule.active_days.as_ref() {
+                None => "all days".to_string(),
+                Some(d) if d.is_empty() => "no days".to_string(),
+                Some(d) => d
+                    .iter()
+                    .map(|s| {
+                        let mut c = s.chars();
+                        match c.next() {
+                            Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+                            None => String::new(),
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            };
             println!("  Schedule: paused (active {hours_str}, {days_str})");
         }
     }
@@ -3123,14 +3125,19 @@ async fn build_full_status(slot: &WorkspaceSlot) -> String {
 fn effective_watcher_schedule(
     workspace: Option<&crate::config::Schedule>,
     watcher_hours: Option<&str>,
+    watcher_name: &str,
 ) -> crate::config::Schedule {
     match watcher_hours {
         Some(ah) => {
             // Validate only the per-watcher override; workspace hours were validated at startup.
-            crate::buzz::schedule::warn_if_invalid(&crate::config::Schedule {
-                active_hours: Some(ah.to_string()),
-                active_days: None,
-            });
+            // Pass the watcher name so any warning identifies which watcher is misconfigured.
+            if crate::buzz::schedule::parse_active_hours(ah).is_none() {
+                warn!(
+                    "[{}] active_hours {:?} is malformed (expected HH:MM-HH:MM); \
+                     hours constraint will be ignored",
+                    watcher_name, ah
+                );
+            }
             crate::config::Schedule {
                 active_hours: Some(ah.to_string()),
                 active_days: workspace.and_then(|s| s.active_days.clone()),

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -993,6 +993,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
             let mut gh_watcher = GithubWatcher::new(gh_config.clone());
             gh_watcher.load_cursors(&store);
             registry.add_with_interval(Box::new(gh_watcher), gh_config.interval_secs);
+            if let Some(tw) = registry.last_watcher_mut() {
+                tw.set_active_hours(
+                    ws.config
+                        .watchers
+                        .github
+                        .as_ref()
+                        .and_then(|g| g.active_hours.clone()),
+                );
+            }
 
             if !gh_config.review_queue.is_empty() {
                 let query_names: Vec<&str> = gh_config
@@ -1015,6 +1024,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     Box::new(ReviewQueueWatcher::new(gh_config)),
                     gh_config.interval_secs,
                 );
+                if let Some(tw) = registry.last_watcher_mut() {
+                    tw.set_active_hours(
+                        ws.config
+                            .watchers
+                            .github
+                            .as_ref()
+                            .and_then(|g| g.active_hours.clone()),
+                    );
+                }
             }
         }
 
@@ -1029,6 +1047,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 Box::new(SentryWatcher::new(sentry_config.clone())),
                 sentry_config.interval_secs,
             );
+            if let Some(tw) = registry.last_watcher_mut() {
+                tw.set_active_hours(
+                    ws.config
+                        .watchers
+                        .sentry
+                        .as_ref()
+                        .and_then(|s| s.active_hours.clone()),
+                );
+            }
         }
 
         if let Some(swarm_config) = &buzz_config.watchers.swarm
@@ -1046,9 +1073,18 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 Box::new(SwarmWatcher::new(ws.config.root.clone())),
                 swarm_config.interval_secs,
             );
+            if let Some(tw) = registry.last_watcher_mut() {
+                tw.set_active_hours(
+                    ws.config
+                        .watchers
+                        .swarm
+                        .as_ref()
+                        .and_then(|s| s.active_hours.clone()),
+                );
+            }
         }
 
-        for email_config in &buzz_config.watchers.email {
+        for (i, email_config) in buzz_config.watchers.email.iter().enumerate() {
             let mut watcher = EmailWatcher::new(email_config.clone());
             // Pre-load cursor from store so first poll skips already-seen UIDs
             if let Ok(Some(val)) = store.get_cursor(watcher.cursor_key())
@@ -1065,9 +1101,18 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 ws.name, email_config.name, email_config.host
             );
             registry.add_with_interval(Box::new(watcher), email_config.interval_secs);
+            if let Some(tw) = registry.last_watcher_mut() {
+                tw.set_active_hours(
+                    ws.config
+                        .watchers
+                        .email
+                        .get(i)
+                        .and_then(|e| e.active_hours.clone()),
+                );
+            }
         }
 
-        for notion_config in &buzz_config.watchers.notion {
+        for (i, notion_config) in buzz_config.watchers.notion.iter().enumerate() {
             let mut watcher = NotionWatcher::new(notion_config.clone());
             // Pre-load cursor from store so first poll skips already-seen data
             if let Ok(Some(val)) = store.get_cursor(watcher.last_poll_key()) {
@@ -1082,9 +1127,18 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 ws.name, notion_config.name
             );
             registry.add_with_interval(Box::new(watcher), notion_config.interval_secs);
+            if let Some(tw) = registry.last_watcher_mut() {
+                tw.set_active_hours(
+                    ws.config
+                        .watchers
+                        .notion
+                        .get(i)
+                        .and_then(|n| n.active_hours.clone()),
+                );
+            }
         }
 
-        for linear_config in &buzz_config.watchers.linear {
+        for (i, linear_config) in buzz_config.watchers.linear.iter().enumerate() {
             let mut watcher = LinearWatcher::new(linear_config.clone());
             // Pre-load seen map from cursor store so first poll skips unchanged issues
             if let Ok(Some(json)) = store.get_cursor(watcher.cursor_key())
@@ -1117,9 +1171,18 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 query_names.join(", ")
             );
             registry.add_with_interval(Box::new(watcher), linear_config.poll_interval_secs);
+            if let Some(tw) = registry.last_watcher_mut() {
+                tw.set_active_hours(
+                    ws.config
+                        .watchers
+                        .linear
+                        .get(i)
+                        .and_then(|l| l.active_hours.clone()),
+                );
+            }
         }
 
-        for script_config in &buzz_config.watchers.script {
+        for (i, script_config) in buzz_config.watchers.script.iter().enumerate() {
             info!(
                 "[{}] enabling script watcher '{}'",
                 ws.name, script_config.name
@@ -1128,6 +1191,15 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                 Box::new(ScriptWatcher::new(script_config.clone())),
                 script_config.interval_secs,
             );
+            if let Some(tw) = registry.last_watcher_mut() {
+                tw.set_active_hours(
+                    ws.config
+                        .watchers
+                        .script
+                        .get(i)
+                        .and_then(|s| s.active_hours.clone()),
+                );
+            }
         }
 
         let mut coordinator = build_coordinator(&ws.name, &ws.config);
@@ -1458,6 +1530,26 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                             continue;
                         }
                         let watcher_name = throttled.watcher().name().to_string();
+
+                        // Check active-hours schedule before polling.
+                        // Per-watcher active_hours overrides workspace schedule (hours only;
+                        // active_days still come from workspace schedule when a per-watcher
+                        // override is set).
+                        let effective_schedule = match throttled.active_hours() {
+                            Some(ah) => crate::config::Schedule {
+                                active_hours: Some(ah.to_string()),
+                                active_days: slot.config.schedule.as_ref().and_then(|s| s.active_days.clone()),
+                            },
+                            None => slot.config.schedule.clone().unwrap_or_default(),
+                        };
+                        if !crate::buzz::schedule::is_within_active_hours(&effective_schedule) {
+                            tracing::trace!(
+                                "[{}] [{}] skipping poll: outside active hours",
+                                slot.name,
+                                watcher_name
+                            );
+                            continue;
+                        }
                         let poll_result = tokio::time::timeout(
                             std::time::Duration::from_secs(30),
                             throttled.watcher_mut().poll(&slot.store),
@@ -1657,16 +1749,34 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                     }
 
                     // Coordinator follow-through for signal hook events (non-blocking)
-                    for (source, (signals, hook)) in &hook_events {
+
+                    // Check workspace schedule before firing any follow-throughs.
+                    let follow_through_active = slot.config.schedule.as_ref()
+                        .map(crate::buzz::schedule::is_within_active_hours)
+                        .unwrap_or(true);
+                    if !follow_through_active && !hook_events.is_empty() {
                         info!(
-                            "[follow-through] dispatching: workspace={} source={source} signal_count={} has_action={} ttl_secs={}",
+                            "[{}] skipping signal follow-through: outside active hours ({} event(s) dropped)",
                             slot.name,
-                            signals.len(),
-                            hook.action.is_some(),
-                            hook.ttl_secs,
+                            hook_events.len()
                         );
                     }
+
+                    for (source, (signals, hook)) in &hook_events {
+                        if follow_through_active {
+                            info!(
+                                "[follow-through] dispatching: workspace={} source={source} signal_count={} has_action={} ttl_secs={}",
+                                slot.name,
+                                signals.len(),
+                                hook.action.is_some(),
+                                hook.ttl_secs,
+                            );
+                        }
+                    }
                     for (source, (signals, hook)) in hook_events {
+                        if !follow_through_active {
+                            continue;
+                        }
                         let telegram_info = slot.config.telegram.as_ref().and_then(|tg| {
                             telegram_channels.get(&tg.bot_token).map(|ch| {
                                 (ch.clone(), tg.chat_id, tg.topic_id)
@@ -2206,6 +2316,30 @@ pub fn show_status(workspace_filter: Option<&str>) -> Result<()> {
                 println!("  {status}: {count}");
             }
             println!();
+        }
+
+        // Show schedule status if configured and currently outside active hours.
+        if let Some(ref schedule) = ws.config.schedule
+            && !crate::buzz::schedule::is_within_active_hours(schedule)
+        {
+            let hours_str = schedule.active_hours.as_deref().unwrap_or("all hours");
+            let days_str = schedule
+                .active_days
+                .as_ref()
+                .map(|d| {
+                    d.iter()
+                        .map(|s| {
+                            let mut c = s.chars();
+                            match c.next() {
+                                Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+                                None => String::new(),
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_else(|| "all days".to_string());
+            println!("  Schedule: paused (active {hours_str}, {days_str})\n");
         }
     }
 

--- a/crates/apiari/src/ui/settings.rs
+++ b/crates/apiari/src/ui/settings.rs
@@ -277,6 +277,7 @@ impl SettingsState {
                     interval_secs: 120,
                     review_queue: vec![],
                     filters: HashMap::new(),
+                    active_hours: None,
                 });
             config.watchers.github = Some(config::GithubWatcherConfig { repos, ..existing });
         } else {
@@ -293,7 +294,8 @@ impl SettingsState {
                 org: self.sentry_org.trim().to_string(),
                 project: self.sentry_project.trim().to_string(),
                 token: self.sentry_token.trim().to_string(),
-                interval_secs: existing.map(|s| s.interval_secs).unwrap_or(120),
+                interval_secs: existing.as_ref().map(|s| s.interval_secs).unwrap_or(120),
+                active_hours: existing.and_then(|s| s.active_hours),
             });
         } else {
             config.watchers.sentry = None;
@@ -305,13 +307,17 @@ impl SettingsState {
             config.watchers.linear = vec![config::LinearWatcherConfig {
                 name: self.linear_name.trim().to_string(),
                 api_key: self.linear_api_key.trim().to_string(),
-                poll_interval_secs: existing.map(|l| l.poll_interval_secs).unwrap_or(60),
+                poll_interval_secs: existing
+                    .as_ref()
+                    .map(|l| l.poll_interval_secs)
+                    .unwrap_or(60),
                 review_queue: config
                     .watchers
                     .linear
                     .first()
                     .map(|l| l.review_queue.clone())
                     .unwrap_or_default(),
+                active_hours: existing.and_then(|l| l.active_hours),
             }];
         } else {
             config.watchers.linear = vec![];
@@ -322,7 +328,8 @@ impl SettingsState {
             let existing = config.watchers.swarm.take();
             config.watchers.swarm = Some(config::SwarmWatcherConfig {
                 state_path: self.swarm_state_path.trim().into(),
-                interval_secs: existing.map(|s| s.interval_secs).unwrap_or(15),
+                interval_secs: existing.as_ref().map(|s| s.interval_secs).unwrap_or(15),
+                active_hours: existing.and_then(|s| s.active_hours),
             });
         } else {
             config.watchers.swarm = None;

--- a/crates/apiari/src/ui/settings.rs
+++ b/crates/apiari/src/ui/settings.rs
@@ -311,10 +311,8 @@ impl SettingsState {
                     .as_ref()
                     .map(|l| l.poll_interval_secs)
                     .unwrap_or(60),
-                review_queue: config
-                    .watchers
-                    .linear
-                    .first()
+                review_queue: existing
+                    .as_ref()
                     .map(|l| l.review_queue.clone())
                     .unwrap_or_default(),
                 active_hours: existing.and_then(|l| l.active_hours),


### PR DESCRIPTION
## Summary

- Adds a `[schedule]` config section to workspace TOML with `active_hours` ("HH:MM-HH:MM") and `active_days` (["mon"…"sun"])
- Adds optional `active_hours` per-watcher override on all watcher config structs
- Watchers skip polling outside their effective schedule window (per-watcher override takes precedence, falls back to workspace schedule)
- Signal follow-throughs are skipped when outside the workspace schedule
- `apiari status` shows `Schedule: paused (active HH:MM-HH:MM, Day, ...)` when currently outside the window
- Fully backwards compatible: absent `[schedule]` means 24/7 (no behavior change)

## Implementation details

- `buzz/schedule.rs`: pure `is_within_active_hours(&Schedule) -> bool` with overnight-range support, unit-tested
- `ThrottledWatcher` gets an `active_hours: Option<String>` field; `WatcherRegistry` exposes `last_watcher_mut()` for wiring
- Daemon registration sets per-watcher active_hours from config right after each `add_with_interval` call
- All 626 existing tests pass; no breaking changes

## Test plan

- [ ] `cargo test` passes (626 tests)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] Config with no `[schedule]` section works identically to before
- [ ] Config with `active_hours = "09:00-18:00"` + `active_days = ["mon"…"fri"]` shows paused status on weekends/evenings
- [ ] Overnight range (e.g. "22:00-06:00") correctly handles wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)