### PR TITLE
feat: improve kanban strip UX — 5 stages, always-visible columns, stage-aware subtitles (Phase 3 of #162)

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -4862,7 +4862,7 @@ mod tests {
         )];
         let cards = build_kanban_cards(&ws);
         assert_eq!(cards.len(), 1);
-        assert_eq!(cards[0].stage, KanbanStage::NeedsMe);
+        assert_eq!(cards[0].stage, KanbanStage::MergeReady);
         assert!(cards[0].subtitle.contains("merge?"));
     }
 
@@ -4961,7 +4961,7 @@ mod tests {
         ws.signals = vec![make_signal("sentry", "sentry-err-1", None)];
         let cards = build_kanban_cards(&ws);
         assert_eq!(cards.len(), 1);
-        assert_eq!(cards[0].stage, KanbanStage::Incoming);
+        assert_eq!(cards[0].stage, KanbanStage::Triage);
         assert_eq!(cards[0].icon, "⚡");
     }
 
@@ -4975,7 +4975,7 @@ mod tests {
         )];
         let cards = build_kanban_cards(&ws);
         assert_eq!(cards.len(), 1);
-        assert_eq!(cards[0].stage, KanbanStage::NeedsMe);
+        assert_eq!(cards[0].stage, KanbanStage::MergeReady);
         assert_eq!(cards[0].icon, "🔍");
     }
 
@@ -5070,10 +5070,10 @@ mod tests {
         let cards = build_kanban_cards_from_tasks(&tasks);
         // Dismissed is filtered out
         assert_eq!(cards.len(), 5);
-        assert_eq!(cards[0].stage, KanbanStage::Incoming); // Triage
+        assert_eq!(cards[0].stage, KanbanStage::Triage); // Triage
         assert_eq!(cards[1].stage, KanbanStage::InProgress); // InProgress
-        assert_eq!(cards[2].stage, KanbanStage::InProgress); // InAiReview
-        assert_eq!(cards[3].stage, KanbanStage::NeedsMe); // MergeReady
+        assert_eq!(cards[2].stage, KanbanStage::InReview); // InAiReview
+        assert_eq!(cards[3].stage, KanbanStage::MergeReady); // MergeReady
         assert_eq!(cards[4].stage, KanbanStage::Done); // Merged
     }
 

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -236,9 +236,10 @@ pub enum WorkerEventKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KanbanStage {
-    Incoming,
+    Triage,
     InProgress,
-    NeedsMe,
+    InReview,
+    MergeReady,
     Done,
 }
 
@@ -263,10 +264,10 @@ pub fn build_kanban_cards_from_tasks(tasks: &[crate::buzz::task::Task]) -> Vec<K
         .filter(|t| !matches!(t.stage, crate::buzz::task::TaskStage::Dismissed))
         .map(|t| {
             let stage = match t.stage {
-                crate::buzz::task::TaskStage::Triage => KanbanStage::Incoming,
+                crate::buzz::task::TaskStage::Triage => KanbanStage::Triage,
                 crate::buzz::task::TaskStage::InProgress => KanbanStage::InProgress,
-                crate::buzz::task::TaskStage::InAiReview => KanbanStage::InProgress,
-                crate::buzz::task::TaskStage::MergeReady => KanbanStage::NeedsMe,
+                crate::buzz::task::TaskStage::InAiReview => KanbanStage::InReview,
+                crate::buzz::task::TaskStage::MergeReady => KanbanStage::MergeReady,
                 crate::buzz::task::TaskStage::Merged => KanbanStage::Done,
                 crate::buzz::task::TaskStage::Dismissed => KanbanStage::Done, // filtered above
             };
@@ -277,12 +278,54 @@ pub fn build_kanban_cards_from_tasks(tasks: &[crate::buzz::task::Task]) -> Vec<K
                 Some("email") => "📧",
                 _ => "📋",
             };
-            let subtitle = if let Some(pr_num) = t.pr_number {
-                format!("PR #{pr_num}")
-            } else if let Some(ref worker_id) = t.worker_id {
-                format!("worker: {}", worker_id)
-            } else {
-                t.stage.as_str().to_string()
+            let subtitle = match t.stage {
+                crate::buzz::task::TaskStage::Triage => {
+                    if let Some(ref src) = t.source {
+                        format!("from {src}")
+                    } else {
+                        "needs triage".to_string()
+                    }
+                }
+                crate::buzz::task::TaskStage::InProgress => {
+                    if t.pr_url.is_some() {
+                        if let Some(pr_num) = t.pr_number {
+                            format!("PR #{pr_num} · coding")
+                        } else {
+                            "coding · PR open".to_string()
+                        }
+                    } else if let Some(ref wid) = t.worker_id {
+                        let short = if wid.len() > 12 {
+                            &wid[wid.len() - 8..]
+                        } else {
+                            wid.as_str()
+                        };
+                        format!("{short} · coding")
+                    } else {
+                        "in progress".to_string()
+                    }
+                }
+                crate::buzz::task::TaskStage::InAiReview => {
+                    if let Some(pr_num) = t.pr_number {
+                        format!("PR #{pr_num} · awaiting CI/review")
+                    } else {
+                        "awaiting review".to_string()
+                    }
+                }
+                crate::buzz::task::TaskStage::MergeReady => {
+                    if let Some(pr_num) = t.pr_number {
+                        format!("PR #{pr_num} · ready to merge")
+                    } else {
+                        "ready to merge".to_string()
+                    }
+                }
+                crate::buzz::task::TaskStage::Merged => {
+                    if let Some(pr_num) = t.pr_number {
+                        format!("PR #{pr_num} · merged \u{2713}")
+                    } else {
+                        "merged \u{2713}".to_string()
+                    }
+                }
+                crate::buzz::task::TaskStage::Dismissed => "dismissed".to_string(),
             };
             KanbanCard {
                 id: format!("task:{}", t.id),
@@ -353,7 +396,7 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
                 // Waiting worker with a PR → likely needs user attention
                 cards.push(KanbanCard {
                     id: format!("worker:{}", w.id),
-                    stage: KanbanStage::NeedsMe,
+                    stage: KanbanStage::MergeReady,
                     icon: "👷".to_string(),
                     title: short_id(&w.id),
                     subtitle: format!("PR #{} · merge?", pr.number),
@@ -424,24 +467,24 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
                     })
                     .unwrap_or_default();
                 if query.contains("Review Requested") {
-                    (KanbanStage::NeedsMe, "🔍")
+                    (KanbanStage::MergeReady, "🔍")
                 } else {
-                    (KanbanStage::Incoming, "🔍")
+                    (KanbanStage::Triage, "🔍")
                 }
             }
             "github_ci_failure" => {
                 // If there's a matching worker, it's in progress via the worker card already.
-                // Otherwise incoming.
-                (KanbanStage::Incoming, "🐛")
+                // Otherwise triage.
+                (KanbanStage::Triage, "🐛")
             }
             "github_ci_pass" | "github_bot_review" => continue,
             "github_merged_pr" => (KanbanStage::Done, "📋"),
             "github_release" => (KanbanStage::Done, "🚀"),
-            "sentry" => (KanbanStage::Incoming, "⚡"),
-            "linear" => (KanbanStage::Incoming, "📋"),
-            "email" => (KanbanStage::Incoming, "📧"),
-            "notion" => (KanbanStage::Incoming, "📓"),
-            _ => (KanbanStage::Incoming, "⚡"),
+            "sentry" => (KanbanStage::Triage, "⚡"),
+            "linear" => (KanbanStage::Triage, "📋"),
+            "email" => (KanbanStage::Triage, "📧"),
+            "notion" => (KanbanStage::Triage, "📓"),
+            _ => (KanbanStage::Triage, "⚡"),
         };
 
         cards.push(KanbanCard {
@@ -531,12 +574,13 @@ fn signal_covered_by_worker(
 /// Called by the renderer for layout; also used as a fallback before the first frame.
 pub fn compute_kanban_height(ws: &WorkspaceState) -> u16 {
     if ws.kanban_cards.is_empty() {
-        return 3; // header + "all clear" + border
+        return 5; // header + empty placeholders + borders
     }
     let max_cards = [
-        KanbanStage::Incoming,
+        KanbanStage::Triage,
         KanbanStage::InProgress,
-        KanbanStage::NeedsMe,
+        KanbanStage::InReview,
+        KanbanStage::MergeReady,
         KanbanStage::Done,
     ]
     .iter()
@@ -544,7 +588,7 @@ pub fn compute_kanban_height(ws: &WorkspaceState) -> u16 {
     .max()
     .unwrap_or(0);
     let content_h = max_cards * 2 + 1; // header line + cards
-    (content_h + 2).clamp(3, 8) // +2 for borders
+    (content_h + 2).clamp(5, 12) // +2 for borders
 }
 
 /// How many cards in `stage` are actually visible given `strip_h` terminal rows.
@@ -1733,10 +1777,11 @@ impl App {
 
     // ── Kanban navigation ─────────────────────────────────
 
-    const KANBAN_STAGES: [KanbanStage; 4] = [
-        KanbanStage::Incoming,
+    const KANBAN_STAGES: [KanbanStage; 5] = [
+        KanbanStage::Triage,
         KanbanStage::InProgress,
-        KanbanStage::NeedsMe,
+        KanbanStage::InReview,
+        KanbanStage::MergeReady,
         KanbanStage::Done,
     ];
 
@@ -1875,7 +1920,7 @@ impl App {
             .nth(idx)?;
         let msg = match stage {
             KanbanStage::Done => return None,
-            KanbanStage::NeedsMe => {
+            KanbanStage::MergeReady => {
                 if card.source == "worker" {
                     // subtitle like "PR #42 · merge?"
                     if let Some(num) = kanban_extract_pr_number(&card.subtitle) {
@@ -1889,11 +1934,18 @@ impl App {
                     format!("Tell me about this signal: {}", card.title)
                 }
             }
-            KanbanStage::Incoming => {
+            KanbanStage::Triage => {
                 if card.source == "github_review_queue" {
                     format!("Review {}", card.title)
                 } else {
                     format!("Tell me about this signal: {}", card.title)
+                }
+            }
+            KanbanStage::InReview => {
+                if let Some(num) = kanban_extract_pr_number(&card.subtitle) {
+                    format!("What's the review status of PR #{num}?")
+                } else {
+                    format!("What's the review status of {}?", card.title)
                 }
             }
             KanbanStage::InProgress => {

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -3271,7 +3271,7 @@ mod tests {
         push_kanban_card(
             &mut app,
             "card-2",
-            app::KanbanStage::NeedsMe,
+            app::KanbanStage::MergeReady,
             "worker",
             "PR #1 · merge?",
         );
@@ -3281,23 +3281,23 @@ mod tests {
 
         assert_eq!(
             app.current_ws().unwrap().kanban_selected,
-            Some((app::KanbanStage::NeedsMe, 0)),
+            Some((app::KanbanStage::MergeReady, 0)),
             "right should skip to next non-empty column"
         );
     }
 
     #[test]
-    fn test_kanban_enter_injects_merge_message_for_needsme_worker() {
+    fn test_kanban_enter_injects_merge_message_for_mergeready_worker() {
         let mut app = test_app();
         app.focused_panel = Panel::Home;
         push_kanban_card(
             &mut app,
             "card-1",
-            app::KanbanStage::NeedsMe,
+            app::KanbanStage::MergeReady,
             "worker",
             "PR #42 · merge?",
         );
-        app.workspaces[0].kanban_selected = Some((app::KanbanStage::NeedsMe, 0));
+        app.workspaces[0].kanban_selected = Some((app::KanbanStage::MergeReady, 0));
 
         handle_dashboard_key(&mut app, key(KeyCode::Enter));
 

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -491,41 +491,26 @@ fn draw_kanban_strip(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    if ws.kanban_cards.is_empty() {
-        let line = Line::from(vec![
-            Span::styled(" \u{1f41d} ", Style::default().fg(theme::HONEY)),
-            Span::styled(
-                "All clear \u{2014} nothing in flight",
-                Style::default().fg(theme::SMOKE),
-            ),
-        ]);
-        frame.render_widget(Paragraph::new(vec![line]), inner);
-        return;
-    }
-
-    // Group cards by stage
+    // Always show all 5 columns — empty columns show a placeholder
     let stages = [
-        app::KanbanStage::Incoming,
+        app::KanbanStage::Triage,
         app::KanbanStage::InProgress,
-        app::KanbanStage::NeedsMe,
+        app::KanbanStage::InReview,
+        app::KanbanStage::MergeReady,
         app::KanbanStage::Done,
     ];
 
-    let mut columns: Vec<(app::KanbanStage, Vec<&app::KanbanCard>)> = Vec::new();
-    for stage in &stages {
-        let cards: Vec<&app::KanbanCard> = ws
-            .kanban_cards
-            .iter()
-            .filter(|c| c.stage == *stage)
-            .collect();
-        if !cards.is_empty() {
-            columns.push((*stage, cards));
-        }
-    }
-
-    if columns.is_empty() {
-        return;
-    }
+    let columns: Vec<(app::KanbanStage, Vec<&app::KanbanCard>)> = stages
+        .iter()
+        .map(|&stage| {
+            let cards: Vec<&app::KanbanCard> = ws
+                .kanban_cards
+                .iter()
+                .filter(|c| c.stage == stage)
+                .collect();
+            (stage, cards)
+        })
+        .collect();
 
     // Build constraints with 1-char gaps for dividers between columns
     let num_cols = columns.len() as u32;
@@ -585,8 +570,8 @@ fn draw_kanban_column(
     }
 
     let (header_text, header_style) = match stage {
-        app::KanbanStage::Incoming => (
-            "INCOMING",
+        app::KanbanStage::Triage => (
+            "TRIAGE",
             Style::default()
                 .fg(theme::FROST)
                 .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
@@ -597,8 +582,14 @@ fn draw_kanban_column(
                 .fg(theme::MINT)
                 .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
         ),
-        app::KanbanStage::NeedsMe => (
-            "NEEDS ME",
+        app::KanbanStage::InReview => (
+            "AI REVIEW",
+            Style::default()
+                .fg(theme::POLLEN)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        ),
+        app::KanbanStage::MergeReady => (
+            "MERGE READY",
             Style::default()
                 .fg(theme::HONEY)
                 .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
@@ -616,15 +607,27 @@ fn draw_kanban_column(
     // Header line
     lines.push(Line::from(Span::styled(header_text, header_style)));
 
+    // Empty column placeholder
+    if cards.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  \u{2014}",
+            Style::default()
+                .fg(theme::STEEL)
+                .add_modifier(Modifier::DIM),
+        )));
+        frame.render_widget(Paragraph::new(lines), area);
+        return;
+    }
+
     // How many cards can we fit? Each card = 2 lines, reserve 1 for header
     let available = area.height.saturating_sub(1) as usize;
     let cards_fit = available / 2;
     let show_count = cards_fit.min(cards.len());
     let overflow = cards.len().saturating_sub(show_count);
 
-    let is_needs_me = stage == app::KanbanStage::NeedsMe;
+    let is_merge_ready = stage == app::KanbanStage::MergeReady;
     let is_done = stage == app::KanbanStage::Done;
-    let card_style = if is_needs_me {
+    let card_style = if is_merge_ready {
         Style::default()
             .fg(theme::HONEY)
             .add_modifier(Modifier::BOLD)
@@ -635,7 +638,7 @@ fn draw_kanban_column(
     } else {
         Style::default().fg(theme::FROST)
     };
-    let subtitle_style = if is_needs_me {
+    let subtitle_style = if is_merge_ready {
         Style::default().fg(theme::HONEY)
     } else if is_done {
         Style::default()
@@ -663,13 +666,13 @@ fn draw_kanban_column(
             subtitle_style
         };
 
-        // Line 1: icon + title + action hint for NeedsMe
+        // Line 1: icon + title + action hint for MergeReady
         let mut title_spans = vec![
             Span::styled(&card.icon, effective_card_style),
             Span::raw(" "),
             Span::styled(&card.title, effective_card_style),
         ];
-        if is_needs_me {
+        if is_merge_ready {
             title_spans.push(Span::styled(
                 " \u{2192}",
                 if is_selected {


### PR DESCRIPTION
## Summary

- **5-stage kanban**: `KanbanStage` enum gains `InReview` and renames `Incoming→Triage`, `NeedsMe→MergeReady`. `TaskStage::InAiReview` now maps to its own column instead of collapsing into InProgress.
- **Always-visible columns**: Removed the early-return for empty boards and the `if !cards.is_empty()` guard. All 5 columns always render; empty ones show a dim `—` placeholder so spatial layout is preserved.
- **Taller strip**: Min height 3→5, max height 8→12 rows.
- **Stage-aware subtitles**: Triage shows `from <source>`, InProgress shows worker ID or PR number + "coding", InReview shows "awaiting CI/review", MergeReady shows "ready to merge", Done shows "merged ✓".
- **Updated column headers + colors**: TRIAGE (FROST), IN PROGRESS (MINT), AI REVIEW (POLLEN), MERGE READY (HONEY), DONE (STEEL+DIM).
- **Navigation + actions updated**: `KANBAN_STAGES` const expanded to 5 entries; `kanban_action_selected` handles all new variants including an `InReview` action.

## Test plan

- [ ] `cargo clippy --workspace -- -D warnings` passes (verified in CI)
- [ ] `cargo fmt -p apiari` applied
- [ ] All 5 columns visible even when kanban board is empty
- [ ] Cards route to correct columns for each `TaskStage` value
- [ ] Stage-aware subtitles render correctly per stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)