### PR TITLE
feat: add repo/pr_number metadata to GitHub CI and PR signals

### DIFF
--- a/crates/apiari/src/buzz/watcher/github.rs
+++ b/crates/apiari/src/buzz/watcher/github.rs
@@ -865,8 +865,13 @@ impl GithubWatcher {
                 let key = format!("pr-push-{repo}-{number}-{sha}");
                 let msg = format!("New commits on PR #{number}: {title} ({repo})");
                 let url = format!("https://github.com/{repo}/pull/{number}");
-                let signal =
-                    SignalUpdate::new("github_pr_push", &key, &msg, Severity::Info).with_url(url);
+                let metadata = serde_json::json!({
+                    "repo": repo,
+                    "pr_number": number,
+                });
+                let signal = SignalUpdate::new("github_pr_push", &key, &msg, Severity::Info)
+                    .with_url(url)
+                    .with_metadata(metadata.to_string());
                 signals.push(signal);
             }
         }
@@ -1065,7 +1070,12 @@ impl GithubWatcher {
                 }
                 let key = format!("merged-{repo}-{}", pr.number);
                 let msg = format!("\u{2705} Merged: {} #{}", pr.title, pr.number);
-                let mut signal = SignalUpdate::new("github_merged_pr", &key, &msg, Severity::Info);
+                let metadata = serde_json::json!({
+                    "repo": repo,
+                    "pr_number": pr.number,
+                });
+                let mut signal = SignalUpdate::new("github_merged_pr", &key, &msg, Severity::Info)
+                    .with_metadata(metadata.to_string());
                 if !pr.url.is_empty() {
                     signal = signal.with_url(&pr.url);
                 }
@@ -1102,12 +1112,17 @@ impl GithubWatcher {
                     ci_pass_prs.remove(&pr.number);
                     let sha_short = &pr.head_sha[..7.min(pr.head_sha.len())];
                     let key = format!("ci-failure-{repo}-{}-{sha_short}", pr.number);
+                    let metadata = serde_json::json!({
+                        "repo": repo,
+                        "pr_number": pr.number,
+                    });
                     let mut signal = SignalUpdate::new(
                         "github_ci_failure",
                         &key,
                         format!("CI failed: {} (#{})", pr.title, pr.number),
                         Severity::Error,
-                    );
+                    )
+                    .with_metadata(metadata.to_string());
                     if let Some(url) = first_failing_url(&pr.check_suites) {
                         signal = signal.with_body(&url).with_url(&url);
                     }
@@ -1116,12 +1131,17 @@ impl GithubWatcher {
                     ci_pass_prs.insert(pr.number);
                     let sha_short = &pr.head_sha[..7.min(pr.head_sha.len())];
                     let key = format!("ci-pass-{repo}-{}-{sha_short}", pr.number);
+                    let metadata = serde_json::json!({
+                        "repo": repo,
+                        "pr_number": pr.number,
+                    });
                     let mut signal = SignalUpdate::new(
                         "github_ci_pass",
                         &key,
                         format!("\u{2705} CI passed on PR #{}: {}", pr.number, pr.title),
                         Severity::Info,
-                    );
+                    )
+                    .with_metadata(metadata.to_string());
                     if let Some(suite) = pr.check_suites.first()
                         && !suite.url.is_empty()
                     {
@@ -1390,12 +1410,14 @@ mod tests {
         let run_url = "https://github.com/org/repo/actions/runs/456";
 
         let key = format!("ci-failure-{repo}-{pr_number}-{sha_short}");
+        let metadata = serde_json::json!({ "repo": repo, "pr_number": pr_number });
         let signal = SignalUpdate::new(
             "github_ci_failure",
             &key,
             format!("CI failed: {pr_title} (#{pr_number})"),
             Severity::Error,
         )
+        .with_metadata(metadata.to_string())
         .with_body(run_url)
         .with_url(run_url);
 
@@ -1405,6 +1427,10 @@ mod tests {
         assert!(signal.title.contains("#42"));
         assert_eq!(signal.url.as_deref(), Some(run_url));
         assert_eq!(signal.body.as_deref(), Some(run_url));
+        let meta: serde_json::Value =
+            serde_json::from_str(signal.metadata.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["repo"], "org/repo");
+        assert_eq!(meta["pr_number"], 42);
     }
 
     #[test]
@@ -1415,18 +1441,24 @@ mod tests {
         let sha_short = "def5678";
 
         let key = format!("ci-pass-{repo}-{pr_number}-{sha_short}");
+        let metadata = serde_json::json!({ "repo": repo, "pr_number": pr_number });
         let signal = SignalUpdate::new(
             "github_ci_pass",
             &key,
             format!("\u{2705} CI passed on PR #{pr_number}: {pr_title}"),
             Severity::Info,
-        );
+        )
+        .with_metadata(metadata.to_string());
 
         assert_eq!(signal.source, "github_ci_pass");
         assert_eq!(signal.external_id, "ci-pass-org/repo-42-def5678");
         assert_eq!(signal.severity, Severity::Info);
         assert!(signal.title.contains("CI passed on PR #42"));
         assert!(signal.title.contains("Add feature X"));
+        let meta: serde_json::Value =
+            serde_json::from_str(signal.metadata.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["repo"], "org/repo");
+        assert_eq!(meta["pr_number"], 42);
     }
 
     #[test]
@@ -1480,8 +1512,10 @@ mod tests {
 
         let key = format!("merged-{repo}-{pr_number}");
         let msg = format!("\u{2705} Merged: {title} #{pr_number}");
-        let signal =
-            SignalUpdate::new("github_merged_pr", &key, &msg, Severity::Info).with_url(url);
+        let metadata = serde_json::json!({ "repo": repo, "pr_number": pr_number });
+        let signal = SignalUpdate::new("github_merged_pr", &key, &msg, Severity::Info)
+            .with_metadata(metadata.to_string())
+            .with_url(url);
 
         assert_eq!(signal.source, "github_merged_pr");
         assert_eq!(signal.external_id, "merged-org/repo-53");
@@ -1489,6 +1523,10 @@ mod tests {
         assert!(signal.title.contains("Merged:"));
         assert!(signal.title.contains("#53"));
         assert_eq!(signal.url.as_deref(), Some(url));
+        let meta: serde_json::Value =
+            serde_json::from_str(signal.metadata.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["repo"], "org/repo");
+        assert_eq!(meta["pr_number"], 53);
     }
 
     #[test]
@@ -1630,6 +1668,10 @@ mod tests {
             signal.url.as_deref(),
             Some("https://github.com/org/repo/pull/42")
         );
+        let meta: serde_json::Value =
+            serde_json::from_str(signal.metadata.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["repo"], "org/repo");
+        assert_eq!(meta["pr_number"], 42);
         assert_eq!(new_cursors[&42], "newsha999");
     }
 


### PR DESCRIPTION
## Summary

- `github_ci_failure` and `github_ci_pass` signals now include `{"repo": "owner/repo", "pr_number": N}` metadata, enabling `match_signal_to_task_pr()` to match them to tasks — previously their URLs pointed to Actions runs (not PR URLs) so matching never worked
- `github_merged_pr` and `github_pr_push` also get the same metadata for consistency (they already had PR URLs but structured metadata is more reliable)
- `github_bot_review` already had the metadata; unchanged

## Test plan

- [x] Updated `test_ci_failure_signal` to assert `repo` and `pr_number` in metadata
- [x] Updated `test_ci_pass_signal` to assert `repo` and `pr_number` in metadata
- [x] Updated `test_merged_pr_signal` to assert `repo` and `pr_number` in metadata
- [x] Updated `test_pr_push_new_commit_emits_signal` to assert `repo` and `pr_number` in metadata
- [x] All 696 tests pass
- [x] `cargo fmt` and `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)