### PR TITLE
feat: auto-dispatch review worker when task enters InAiReview

### DIFF
--- a/crates/apiari/src/buzz/coordinator/swarm_client.rs
+++ b/crates/apiari/src/buzz/coordinator/swarm_client.rs
@@ -52,6 +52,36 @@ impl SwarmClient {
         }
     }
 
+    /// Create a reviewer worker for a PR. Returns the worktree ID.
+    ///
+    /// Uses the `reviewer` profile, which instructs the agent to review the diff
+    /// and emit a structured verdict (`REVIEW_VERDICT: APPROVED` or
+    /// `REVIEW_VERDICT: CHANGES_REQUESTED`).
+    pub async fn create_reviewer_worker(&self, repo: &str, pr_number: i64) -> Result<String> {
+        let resp = self
+            .request(DaemonRequest::CreateWorker {
+                prompt: format!("Review PR #{pr_number}"),
+                agent: "claude".to_string(),
+                repo: Some(repo.to_string()),
+                start_point: None,
+                workspace: Some(self.work_dir.clone()),
+                profile: Some("reviewer".to_string()),
+                task_dir: None,
+            })
+            .await?;
+
+        match resp {
+            DaemonResponse::Ok { data } => {
+                let id = data
+                    .and_then(|v| v.as_str().map(String::from))
+                    .unwrap_or_default();
+                Ok(id)
+            }
+            DaemonResponse::Error { message } => bail!("create_reviewer_worker failed: {message}"),
+            other => bail!("unexpected response: {other:?}"),
+        }
+    }
+
     /// Send a follow-up message to a running worker.
     pub async fn send_message(&self, worktree_id: &str, message: &str) -> Result<()> {
         let resp = self

--- a/crates/apiari/src/buzz/task/rules.rs
+++ b/crates/apiari/src/buzz/task/rules.rs
@@ -183,6 +183,54 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
             },
         }),
 
+        // ── In AI Review: review verdict from AI reviewer worker ──
+        (TaskStage::InAiReview, "swarm_review_verdict") => {
+            let meta = signal
+                .metadata
+                .as_ref()
+                .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok());
+            let verdict = meta
+                .as_ref()
+                .and_then(|m| m.get("verdict").and_then(|v| v.as_str()))
+                .unwrap_or("");
+            let comments = meta
+                .as_ref()
+                .and_then(|m| m.get("comments").and_then(|c| c.as_str()))
+                .unwrap_or("")
+                .to_string();
+
+            match verdict {
+                "APPROVED" => Some(ProposedTransition {
+                    task_id: task.id.clone(),
+                    from: TaskStage::InAiReview,
+                    to: TaskStage::MergeReady,
+                    reason: "AI reviewer approved PR".to_string(),
+                    approval: Approval::Auto,
+                    action: TransitionAction::Notify {
+                        message: "AI reviewer approved — PR is ready for merge".to_string(),
+                    },
+                }),
+                "CHANGES_REQUESTED" => Some(ProposedTransition {
+                    task_id: task.id.clone(),
+                    from: TaskStage::InAiReview,
+                    to: TaskStage::InProgress,
+                    reason: "AI reviewer requested changes".to_string(),
+                    approval: Approval::Auto,
+                    action: TransitionAction::ForwardToWorker {
+                        message: if comments.is_empty() {
+                            "AI reviewer requested changes. Please address the review feedback."
+                                .to_string()
+                        } else {
+                            format!(
+                                "AI reviewer requested changes. Please address the following:\n\n{comments}"
+                            )
+                        },
+                    },
+                }),
+                _ => None,
+            }
+        }
+
         // ── In AI Review: new commits pushed → stay (re-review needed) ──
         (TaskStage::InAiReview, "github_pr_push") => Some(ProposedTransition {
             task_id: task.id.clone(),
@@ -497,5 +545,76 @@ mod tests {
         assert_eq!(result.from, TaskStage::InAiReview);
         assert_eq!(result.to, TaskStage::InAiReview);
         assert!(matches!(result.action, TransitionAction::Notify { .. }));
+    }
+
+    #[test]
+    fn test_review_verdict_approved_transitions_to_merge_ready() {
+        let task = make_task(TaskStage::InAiReview);
+        let mut signal = make_signal("swarm_review_verdict", None);
+        signal.metadata = Some(
+            r#"{"verdict": "APPROVED", "comments": "", "repo": "org/repo", "pr_number": 42}"#
+                .to_string(),
+        );
+        let result = evaluate_signal(&task, &signal).unwrap();
+        assert_eq!(result.from, TaskStage::InAiReview);
+        assert_eq!(result.to, TaskStage::MergeReady);
+        assert_eq!(result.approval, Approval::Auto);
+        assert!(matches!(result.action, TransitionAction::Notify { .. }));
+    }
+
+    #[test]
+    fn test_review_verdict_changes_requested_transitions_to_in_progress() {
+        let task = make_task(TaskStage::InAiReview);
+        let mut signal = make_signal("swarm_review_verdict", None);
+        signal.metadata = Some(
+            r#"{"verdict": "CHANGES_REQUESTED", "comments": "Fix the null check on line 42.", "repo": "org/repo", "pr_number": 42}"#
+                .to_string(),
+        );
+        let result = evaluate_signal(&task, &signal).unwrap();
+        assert_eq!(result.from, TaskStage::InAiReview);
+        assert_eq!(result.to, TaskStage::InProgress);
+        assert_eq!(result.approval, Approval::Auto);
+        assert!(matches!(
+            result.action,
+            TransitionAction::ForwardToWorker { .. }
+        ));
+        if let TransitionAction::ForwardToWorker { message } = result.action {
+            assert!(message.contains("Fix the null check on line 42."));
+        }
+    }
+
+    #[test]
+    fn test_review_verdict_changes_requested_no_comments_uses_fallback_message() {
+        let task = make_task(TaskStage::InAiReview);
+        let mut signal = make_signal("swarm_review_verdict", None);
+        signal.metadata = Some(
+            r#"{"verdict": "CHANGES_REQUESTED", "comments": "", "repo": "org/repo", "pr_number": 42}"#
+                .to_string(),
+        );
+        let result = evaluate_signal(&task, &signal).unwrap();
+        if let TransitionAction::ForwardToWorker { message } = result.action {
+            assert!(message.contains("review feedback"));
+        } else {
+            panic!("expected ForwardToWorker");
+        }
+    }
+
+    #[test]
+    fn test_review_verdict_unknown_returns_none() {
+        let task = make_task(TaskStage::InAiReview);
+        let mut signal = make_signal("swarm_review_verdict", None);
+        signal.metadata = Some(
+            r#"{"verdict": "UNKNOWN_VERDICT", "repo": "org/repo", "pr_number": 42}"#.to_string(),
+        );
+        // Unknown verdict — no rule matches
+        assert!(evaluate_signal(&task, &signal).is_none());
+    }
+
+    #[test]
+    fn test_review_verdict_no_metadata_returns_none() {
+        let task = make_task(TaskStage::InAiReview);
+        let signal = make_signal("swarm_review_verdict", None);
+        // No metadata → verdict is "" → no rule matches
+        assert!(evaluate_signal(&task, &signal).is_none());
     }
 }

--- a/crates/apiari/src/buzz/task/store.rs
+++ b/crates/apiari/src/buzz/task/store.rs
@@ -242,6 +242,35 @@ impl TaskStore {
         }
     }
 
+    /// Find a task whose metadata JSON contains `reviewer_worker_id == reviewer_id`.
+    pub fn find_task_by_reviewer_worker(
+        &self,
+        workspace: &str,
+        reviewer_id: &str,
+    ) -> Result<Option<Task>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, workspace, title, stage, source, source_url, worker_id,
+             pr_url, pr_number, repo, created_at, updated_at, resolved_at, metadata
+             FROM tasks WHERE workspace = ?1
+             AND json_extract(metadata, '$.reviewer_worker_id') = ?2",
+        )?;
+        let mut tasks = stmt
+            .query_map(params![workspace, reviewer_id], row_to_task)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .wrap_err("failed to find task by reviewer worker")?;
+        Ok(tasks.pop())
+    }
+
+    /// Update the task's metadata JSON blob.
+    pub fn update_task_metadata(&self, id: &str, metadata: &serde_json::Value) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "UPDATE tasks SET metadata = ?1, updated_at = ?2 WHERE id = ?3",
+            params![metadata.to_string(), now, id],
+        )?;
+        Ok(())
+    }
+
     pub fn log_event(&self, event: &TaskEvent) -> Result<()> {
         self.conn.execute(
             "INSERT INTO task_events

--- a/crates/apiari/src/buzz/watcher/swarm.rs
+++ b/crates/apiari/src/buzz/watcher/swarm.rs
@@ -109,6 +109,19 @@ impl SwarmWatcher {
                 );
             }
 
+            // Completed/Failed transition — emit so daemon can read verdict before teardown
+            if phase.is_terminal() && prev.is_some_and(|p| !p.phase.is_terminal()) {
+                signals.push(
+                    SignalUpdate::new(
+                        "swarm",
+                        format!("swarm-completed-{id}"),
+                        format!("Worker completed: {id}"),
+                        Severity::Info,
+                    )
+                    .with_body(format!("Worker {id} has completed")),
+                );
+            }
+
             // Update tracked phase (preserve has_pr since StateChanged doesn't carry it)
             if let Some(tracked) = self.tracked.get_mut(&id) {
                 tracked.phase = phase;
@@ -176,6 +189,19 @@ impl SwarmWatcher {
                 );
             }
 
+            // Completed/Failed transition (from ListWorkers, in case subscription missed it)
+            if w.phase.is_terminal() && prev.is_some_and(|p| !p.phase.is_terminal()) {
+                signals.push(
+                    SignalUpdate::new(
+                        "swarm",
+                        format!("swarm-completed-{id}"),
+                        format!("Worker completed: {id}"),
+                        Severity::Info,
+                    )
+                    .with_body(format!("Worker {id} has completed")),
+                );
+            }
+
             // Update tracked state
             self.tracked.insert(
                 id.clone(),
@@ -197,7 +223,12 @@ impl SwarmWatcher {
             .collect();
 
         for id in &closed {
-            for prefix in &["swarm-spawned", "swarm-waiting", "swarm-pr"] {
+            for prefix in &[
+                "swarm-spawned",
+                "swarm-waiting",
+                "swarm-pr",
+                "swarm-completed",
+            ] {
                 signals.push(
                     SignalUpdate::new(
                         "swarm",
@@ -284,6 +315,7 @@ impl Watcher for SwarmWatcher {
                     format!("swarm-spawned-{id}"),
                     format!("swarm-waiting-{id}"),
                     format!("swarm-pr-{id}"),
+                    format!("swarm-completed-{id}"),
                 ]
             })
             .collect();
@@ -555,8 +587,8 @@ mod tests {
 
         let workers = vec![]; // w1 is gone
         let signals = watcher.diff_workers(&workers);
-        // 3 resolved (spawned/waiting/pr) + 1 closed
-        assert_eq!(signals.len(), 4);
+        // 4 resolved (spawned/waiting/pr/completed) + 1 closed
+        assert_eq!(signals.len(), 5);
         assert!(signals.iter().all(|s| s.title.contains("closed")));
     }
 

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1593,9 +1593,18 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                     &record,
                                                 ) {
                                                     Ok(engine_result) => {
-                                                        for (worker_id, message) in &engine_result.worker_messages {
-                                                            info!("[task-engine] forwarding to worker {}: {}", worker_id, message);
-                                                            // swarm send will be wired up when swarm integration is ready
+                                                        for (worker_id, message) in engine_result.worker_messages {
+                                                            info!("[task-engine] forwarding to worker {worker_id}: {message}");
+                                                            let swarm = crate::buzz::coordinator::swarm_client::SwarmClient::new(
+                                                                slot.config.root.clone(),
+                                                            );
+                                                            tokio::spawn(async move {
+                                                                if let Err(e) = swarm.send_message(&worker_id, &message).await {
+                                                                    tracing::warn!(
+                                                                        "[task-engine] failed to forward to worker {worker_id}: {e}"
+                                                                    );
+                                                                }
+                                                            });
                                                         }
                                                         for notification in &engine_result.notifications {
                                                             if let Some(ref server) = socket_server {
@@ -1687,6 +1696,141 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                                 }
                                                             }
                                                         }
+                                            }
+
+                                            // Dispatch reviewer worker when task enters InAiReview
+                                            if is_new && update.source == "swarm" && update.external_id.starts_with("swarm-pr-") {
+                                                let worker_id = update.external_id.strip_prefix("swarm-pr-").unwrap_or("").to_string();
+                                                if !worker_id.is_empty()
+                                                    && let Ok(task_store) = crate::buzz::task::store::TaskStore::open(slot.store.db_path())
+                                                        && let Ok(Some(task)) = task_store.find_task_by_worker(&slot.name, &worker_id)
+                                                            && task.stage == crate::buzz::task::TaskStage::InAiReview
+                                                            && task.metadata.get("reviewer_worker_id").is_none()
+                                                            && let (Some(pr_number), Some(repo)) = (task.pr_number, &task.repo)
+                                                {
+                                                    // Use the short repo name (e.g. "apiari" from "ApiariTools/apiari")
+                                                    let short_repo = repo
+                                                        .split('/')
+                                                        .next_back()
+                                                        .unwrap_or(repo.as_str())
+                                                        .to_string();
+                                                    let swarm = crate::buzz::coordinator::swarm_client::SwarmClient::new(
+                                                        slot.config.root.clone(),
+                                                    );
+                                                    let task_id = task.id.clone();
+                                                    let task_title = task.title.clone();
+                                                    let mut meta = task.metadata.clone();
+                                                    let db_path = slot.store.db_path().to_path_buf();
+                                                    tokio::spawn(async move {
+                                                        match swarm.create_reviewer_worker(&short_repo, pr_number).await {
+                                                            Ok(reviewer_id) if !reviewer_id.is_empty() => {
+                                                                meta["reviewer_worker_id"] = serde_json::Value::String(reviewer_id.clone());
+                                                                if let Ok(ts) = crate::buzz::task::store::TaskStore::open(&db_path) {
+                                                                    if let Err(e) = ts.update_task_metadata(&task_id, &meta) {
+                                                                        tracing::warn!("[task-engine] failed to store reviewer_worker_id: {e}");
+                                                                    } else {
+                                                                        info!("[task-engine] dispatched reviewer {reviewer_id} for task '{task_title}'");
+                                                                    }
+                                                                }
+                                                            }
+                                                            Ok(_) => {
+                                                                tracing::warn!("[task-engine] reviewer dispatch for '{task_title}' returned empty id");
+                                                            }
+                                                            Err(e) => {
+                                                                tracing::warn!("[task-engine] failed to dispatch reviewer for '{task_title}': {e}");
+                                                            }
+                                                        }
+                                                    });
+                                                }
+                                            }
+
+                                            // Process reviewer worker completion — emit verdict signal
+                                            if is_new && update.source == "swarm" && update.external_id.starts_with("swarm-completed-") {
+                                                let worker_id = update.external_id.strip_prefix("swarm-completed-").unwrap_or("").to_string();
+                                                if !worker_id.is_empty()
+                                                    && let Ok(task_store) = crate::buzz::task::store::TaskStore::open(slot.store.db_path())
+                                                        && let Ok(Some(task)) = task_store.find_task_by_reviewer_worker(&slot.name, &worker_id)
+                                                {
+                                                    // Read verdict from swarm state file while worker is still present
+                                                    let state_path = slot.config.root.join(".swarm").join("state.json");
+                                                    if let Ok(raw) = std::fs::read_to_string(&state_path)
+                                                        && let Ok(state_json) = serde_json::from_str::<serde_json::Value>(&raw)
+                                                    {
+                                                        let worktree = state_json
+                                                            .get("worktrees")
+                                                            .and_then(|wts| wts.as_array())
+                                                            .and_then(|arr| {
+                                                                arr.iter().find(|wt| {
+                                                                    wt.get("id")
+                                                                        .and_then(|id| id.as_str())
+                                                                        == Some(worker_id.as_str())
+                                                                })
+                                                            });
+                                                        let verdict = worktree
+                                                            .and_then(|wt| wt.get("review_verdict"))
+                                                            .and_then(|v| v.as_str())
+                                                            .map(String::from);
+                                                        let comments = worktree
+                                                            .and_then(|wt| wt.get("review_comments"))
+                                                            .and_then(|v| v.as_str())
+                                                            .unwrap_or("")
+                                                            .to_string();
+
+                                                        if let Some(verdict) = verdict
+                                                            && let (Some(pr_number), Some(repo)) = (task.pr_number, &task.repo)
+                                                        {
+                                                            let metadata = serde_json::json!({
+                                                                "verdict": verdict,
+                                                                "comments": comments,
+                                                                "repo": repo,
+                                                                "pr_number": pr_number,
+                                                                "reviewer_worker_id": worker_id,
+                                                            });
+                                                            let verdict_signal = crate::buzz::signal::SignalUpdate::new(
+                                                                "swarm_review_verdict",
+                                                                format!("swarm-review-verdict-{worker_id}"),
+                                                                format!("Review verdict for PR #{pr_number}: {verdict}"),
+                                                                crate::buzz::signal::Severity::Info,
+                                                            )
+                                                            .with_metadata(metadata.to_string());
+
+                                                            match slot.store.upsert_signal(&verdict_signal) {
+                                                                Ok((vid, true)) => {
+                                                                    info!("[task-engine] emitted review verdict '{verdict}' for task '{}'", task.title);
+                                                                    // Process immediately through task engine
+                                                                    if let Ok(Some(vrecord)) = slot.store.get_signal(vid)
+                                                                        && let Ok(ts2) = crate::buzz::task::store::TaskStore::open(slot.store.db_path())
+                                                                    {
+                                                                        match crate::buzz::task::engine::process_signal(&ts2, &slot.name, &vrecord) {
+                                                                            Ok(ve_result) => {
+                                                                                for (wid, msg) in ve_result.worker_messages {
+                                                                                    let swarm = crate::buzz::coordinator::swarm_client::SwarmClient::new(slot.config.root.clone());
+                                                                                    tokio::spawn(async move {
+                                                                                        if let Err(e) = swarm.send_message(&wid, &msg).await {
+                                                                                            tracing::warn!("[task-engine] failed to send review feedback to worker {wid}: {e}");
+                                                                                        }
+                                                                                    });
+                                                                                }
+                                                                                for notification in &ve_result.notifications {
+                                                                                    if let Some(ref server) = socket_server {
+                                                                                        server.broadcast_activity("task", &slot.name, "transition", notification);
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                            Err(e) => {
+                                                                                tracing::warn!("[task-engine] error processing verdict signal: {e}");
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                                Ok((_, false)) => {} // already seen
+                                                                Err(e) => {
+                                                                    tracing::warn!("[task-engine] failed to upsert verdict signal: {e}");
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
                                             }
 
                                             // Handle worker closed — dismiss task if no PR was merged


### PR DESCRIPTION
## Summary

- When a task transitions to `InAiReview` (swarm worker opened a PR), the daemon automatically dispatches a reviewer worker using the `reviewer` profile via the swarm daemon IPC
- The reviewer worker ID is stored in `task.metadata.reviewer_worker_id` to prevent duplicate dispatches
- A new `swarm-completed-{id}` signal is emitted by the SwarmWatcher when a worker enters a terminal phase, allowing the daemon to read the review verdict from the swarm state file while the worker is still present
- When the reviewer completes, the daemon reads `review_verdict` / `review_comments` from `.swarm/state.json` and emits a `swarm_review_verdict` signal
- New rules engine rules process the verdict: `APPROVED` → `MergeReady`, `CHANGES_REQUESTED` → `InProgress` with comments forwarded to the original coding worker
- Worker message forwarding (`ForwardToWorker` actions) is now wired up to `SwarmClient::send_message` (replacing the previous log-only stub)

## Files changed

- `buzz/task/store.rs` — `update_task_metadata`, `find_task_by_reviewer_worker`
- `buzz/task/rules.rs` — `swarm_review_verdict` rules + 5 new tests
- `buzz/coordinator/swarm_client.rs` — `create_reviewer_worker` method (uses `profile: "reviewer"`)
- `buzz/watcher/swarm.rs` — `swarm-completed-{id}` signal on terminal phase transition
- `daemon/mod.rs` — reviewer dispatch, verdict processing, worker message wiring

## Test plan

- [x] `cargo fmt -p apiari` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test -p apiari` — 701 passed, 0 failed
- [x] New rules tests: approved→MergeReady, changes_requested→InProgress, unknown verdict→None, no metadata→None

🤖 Generated with [Claude Code](https://claude.com/claude-code)