### PR TITLE
feat: bump apiari-swarm to 0.1.6, fix reviewer worker dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "a2a-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e05f443013a7902f12a237ae3b876014a9b2e8a44ed03b83e62dab5e6fabc2"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,10 +212,11 @@ dependencies = [
 
 [[package]]
 name = "apiari-swarm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c198715656ed61adf8c207673ebc0ffe48a8461a7311a4d27e83fe215b2925"
+checksum = "3b4debdba2b0640bbe58ae123722900e6205a902ab93e45e75b278fe7bc40ded"
 dependencies = [
+ "a2a-types",
  "apiari-claude-sdk",
  "apiari-codex-sdk",
  "apiari-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ apiari-claude-sdk = "0.1.0"
 apiari-codex-sdk = "0.1.0"
 apiari-gemini-sdk = "0.1.0"
 chrono-tz = "0.9"
-apiari-swarm = { version = "0.1.5", default-features = false, features = ["client"] }
+apiari-swarm = { version = "0.1.6", default-features = false, features = ["client"] }

--- a/crates/apiari/src/buzz/coordinator/swarm_client.rs
+++ b/crates/apiari/src/buzz/coordinator/swarm_client.rs
@@ -36,6 +36,9 @@ impl SwarmClient {
                 workspace: Some(self.work_dir.clone()),
                 profile: None,
                 task_dir: None,
+                role: None,
+                review_pr: None,
+                base_branch: None,
             })
             .await?;
 
@@ -65,8 +68,11 @@ impl SwarmClient {
                 repo: Some(repo.to_string()),
                 start_point: None,
                 workspace: Some(self.work_dir.clone()),
-                profile: Some("reviewer".to_string()),
+                profile: None,
                 task_dir: None,
+                role: Some("reviewer".to_string()),
+                review_pr: Some(pr_number as u64),
+                base_branch: Some("main".to_string()),
             })
             .await?;
 

--- a/crates/apiari/src/buzz/watcher/swarm.rs
+++ b/crates/apiari/src/buzz/watcher/swarm.rs
@@ -624,6 +624,9 @@ mod tests {
             pr_state: pr_url.map(|_| "OPEN".to_string()),
             restart_count: 0,
             created_at: None,
+            role: None,
+            review_verdict: None,
+            agent_card: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Bump `apiari-swarm` dependency from `0.1.5` to `0.1.6`
- Fix `create_reviewer_worker` to pass `role`, `review_pr`, and `base_branch` fields (new in 0.1.6) instead of `profile: Some("reviewer")`, so the swarm daemon actually activates reviewer behavior
- Add the three new `CreateWorker` fields as `None` to the regular `create_worker` call site
- Add new `WorkerInfo` fields (`role`, `review_verdict`, `agent_card`) to the test helper in `buzz/watcher/swarm.rs`

## Test plan
- [x] `cargo fmt -p apiari` — no changes
- [x] `cargo clippy -p apiari -- -D warnings` — clean
- [x] `cargo test -p apiari` — 701 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)