### PR TITLE
feat: exclude reviewer workers from task creation and kanban

### DIFF
--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1623,10 +1623,14 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                 }
                                             }
 
-                                            // Create task for new swarm workers
+                                            // Create task for new swarm workers (skip reviewer workers)
                                             if is_new && update.source == "swarm" && update.external_id.starts_with("swarm-spawned-") {
                                                 let worker_id = update.external_id.strip_prefix("swarm-spawned-").unwrap_or("").to_string();
-                                                if !worker_id.is_empty()
+                                                let is_reviewer = update.body.as_ref()
+                                                    .and_then(|b| b.lines().nth(1))
+                                                    .map(|l| l.trim_start().starts_with("Review PR"))
+                                                    .unwrap_or(false);
+                                                if !is_reviewer && !worker_id.is_empty()
                                                     && let Ok(task_store) = crate::buzz::task::store::TaskStore::open(slot.store.db_path())
                                                         && let Ok(None) = task_store.find_task_by_worker(&slot.name, &worker_id) {
                                                             let title = update.body.as_ref()

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -337,6 +337,11 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
 
     // ── Workers → cards ──
     for w in &ws.workers {
+        // Reviewer workers are internal to the review process — hide them from the board
+        if w.prompt.starts_with("Review PR") {
+            continue;
+        }
+
         let phase = w.phase.as_deref().unwrap_or("");
 
         let elapsed = w
@@ -4954,6 +4959,24 @@ mod tests {
         let cards = build_kanban_cards(&ws);
         assert_eq!(cards.len(), 1, "dismissed card should be filtered out");
         assert!(!cards[0].id.contains("abc-1234"));
+    }
+
+    #[test]
+    fn test_kanban_reviewer_worker_excluded() {
+        let mut ws = empty_ws();
+        // A reviewer worker has a prompt starting with "Review PR #"
+        let mut reviewer = make_worker("rev-1234", "running", None);
+        reviewer.prompt = "Review PR #42: verify the implementation".to_string();
+        // A regular worker should still appear
+        let regular = make_worker("abc-5678", "running", None);
+        ws.workers = vec![reviewer, regular];
+        let cards = build_kanban_cards(&ws);
+        assert_eq!(
+            cards.len(),
+            1,
+            "reviewer worker should not create a kanban card"
+        );
+        assert_eq!(cards[0].id, "worker:abc-5678");
     }
 
     // ── build_kanban_cards_from_tasks tests ──────────────────


### PR DESCRIPTION
## Summary

- **Daemon**: Skip task creation for `swarm-spawned-*` signals where the worker prompt starts with `"Review PR"` (line 1 of the signal body), preventing reviewer workers from getting their own task entries
- **UI**: Skip reviewer workers in `build_kanban_cards()` by checking if `w.prompt.starts_with("Review PR")`, hiding them from the kanban board
- **Test**: Added `test_kanban_reviewer_worker_excluded` verifying that a reviewer worker does not produce a kanban card while a regular worker alongside it still does

## Test plan

- [x] `cargo fmt -p apiari` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean  
- [x] `cargo test -p apiari` — 702 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)