### PR TITLE
fix: suppress idle nudges for workers with PRs and reviewer workers

### DIFF
--- a/crates/apiari/src/buzz/task/rules.rs
+++ b/crates/apiari/src/buzz/task/rules.rs
@@ -156,6 +156,48 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
             },
         }),
 
+        // ── Merge Ready: bot review with comments → back to In Progress ──
+        // CI can pass (→ MergeReady) before Copilot finishes reviewing. If Copilot
+        // then leaves inline comments, the task must go back to InProgress so the
+        // worker can address them.
+        (TaskStage::MergeReady, "github_bot_review") => {
+            let has_comments = signal
+                .body
+                .as_ref()
+                .map(|b| b.contains("generated") && b.contains("comment"))
+                .unwrap_or(false);
+
+            if has_comments {
+                Some(ProposedTransition {
+                    task_id: task.id.clone(),
+                    from: TaskStage::MergeReady,
+                    to: TaskStage::InProgress,
+                    reason: "Bot review has comments after reaching Merge Ready".to_string(),
+                    approval: Approval::Auto,
+                    action: TransitionAction::ForwardToWorker {
+                        message: format!(
+                            "Copilot reviewed your PR and left comments. Please address them.\n\nReview: {}",
+                            signal.url.as_deref().unwrap_or("")
+                        ),
+                    },
+                })
+            } else {
+                Some(ProposedTransition {
+                    task_id: task.id.clone(),
+                    from: TaskStage::MergeReady,
+                    to: TaskStage::MergeReady, // no stage change
+                    reason: "Bot review is clean".to_string(),
+                    approval: Approval::Auto,
+                    action: TransitionAction::Notify {
+                        message: format!(
+                            "Copilot review looks clean on {}",
+                            extract_pr_ref(signal).as_deref().unwrap_or("PR")
+                        ),
+                    },
+                })
+            }
+        }
+
         // ── Merge Ready: CI failure → back to In Progress ──
         (TaskStage::MergeReady, "github_ci_failure") => Some(ProposedTransition {
             task_id: task.id.clone(),
@@ -544,6 +586,32 @@ mod tests {
         let result = evaluate_signal(&task, &signal).unwrap();
         assert_eq!(result.from, TaskStage::InAiReview);
         assert_eq!(result.to, TaskStage::InAiReview);
+        assert!(matches!(result.action, TransitionAction::Notify { .. }));
+    }
+
+    #[test]
+    fn test_bot_review_with_comments_in_merge_ready_transitions_to_in_progress() {
+        let task = make_task(TaskStage::MergeReady);
+        let mut signal = make_signal("github_bot_review", None);
+        signal.body = Some("Copilot generated comment on line 5".to_string());
+        let result = evaluate_signal(&task, &signal).unwrap();
+        assert_eq!(result.from, TaskStage::MergeReady);
+        assert_eq!(result.to, TaskStage::InProgress);
+        assert_eq!(result.approval, Approval::Auto);
+        assert!(matches!(
+            result.action,
+            TransitionAction::ForwardToWorker { .. }
+        ));
+    }
+
+    #[test]
+    fn test_bot_review_clean_in_merge_ready_stays() {
+        let task = make_task(TaskStage::MergeReady);
+        let mut signal = make_signal("github_bot_review", None);
+        signal.body = Some("Looks good!".to_string());
+        let result = evaluate_signal(&task, &signal).unwrap();
+        assert_eq!(result.from, TaskStage::MergeReady);
+        assert_eq!(result.to, TaskStage::MergeReady);
         assert!(matches!(result.action, TransitionAction::Notify { .. }));
     }
 

--- a/crates/apiari/src/buzz/task/rules.rs
+++ b/crates/apiari/src/buzz/task/rules.rs
@@ -77,16 +77,8 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
         }
 
         // ── In AI Review: bot review with comments → back to In Progress ──
-        // Note: We can't easily determine if comments are actionable here without
-        // LLM judgment. For now, any bot review with body content triggers a
-        // forward to the worker. The worker/coordinator can decide if it's noise.
         (TaskStage::InAiReview, "github_bot_review") => {
-            // Check if the review body suggests there are inline comments
-            let has_comments = signal
-                .body
-                .as_ref()
-                .map(|b| b.contains("generated") && b.contains("comment"))
-                .unwrap_or(false);
+            let has_comments = bot_review_has_comments(signal);
 
             if has_comments {
                 Some(ProposedTransition {
@@ -161,11 +153,7 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
         // then leaves inline comments, the task must go back to InProgress so the
         // worker can address them.
         (TaskStage::MergeReady, "github_bot_review") => {
-            let has_comments = signal
-                .body
-                .as_ref()
-                .map(|b| b.contains("generated") && b.contains("comment"))
-                .unwrap_or(false);
+            let has_comments = bot_review_has_comments(signal);
 
             if has_comments {
                 Some(ProposedTransition {
@@ -299,6 +287,27 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
 
         _ => None,
     }
+}
+
+/// Returns true if a bot review signal has actionable comments that require
+/// the worker to go back to InProgress.
+///
+/// Prefers structured `review_state` from signal metadata (CHANGES_REQUESTED or
+/// COMMENTED). Falls back to body text heuristic for signals that lack metadata.
+fn bot_review_has_comments(signal: &SignalRecord) -> bool {
+    // Prefer structured review_state from metadata.
+    if let Some(ref meta) = signal.metadata
+        && let Ok(v) = serde_json::from_str::<serde_json::Value>(meta)
+        && let Some(state) = v.get("review_state").and_then(|s| s.as_str())
+    {
+        return matches!(state, "CHANGES_REQUESTED" | "COMMENTED");
+    }
+    // Fall back to body text heuristic (Copilot inline comment marker).
+    signal
+        .body
+        .as_ref()
+        .map(|b| b.contains("generated") && b.contains("comment"))
+        .unwrap_or(false)
 }
 
 /// Try to match a signal to an existing task by PR number + repo.
@@ -587,6 +596,41 @@ mod tests {
         assert_eq!(result.from, TaskStage::InAiReview);
         assert_eq!(result.to, TaskStage::InAiReview);
         assert!(matches!(result.action, TransitionAction::Notify { .. }));
+    }
+
+    #[test]
+    fn test_bot_review_changes_requested_via_metadata_transitions_to_in_progress() {
+        // Verify structured review_state takes precedence over body text matching.
+        for stage in [TaskStage::InAiReview, TaskStage::MergeReady] {
+            let task = make_task(stage.clone());
+            let mut signal = make_signal("github_bot_review", None);
+            // No body text matching keywords — relies entirely on metadata.
+            signal.body = Some("Please see my inline suggestions.".to_string());
+            signal.metadata = Some(
+                r#"{"review_state": "CHANGES_REQUESTED", "repo": "org/repo", "pr_number": 42}"#
+                    .to_string(),
+            );
+            let result = evaluate_signal(&task, &signal).unwrap();
+            assert_eq!(result.to, TaskStage::InProgress, "stage={}", stage.as_str());
+        }
+    }
+
+    #[test]
+    fn test_bot_review_approved_via_metadata_stays() {
+        // APPROVED review_state → clean, no transition back to InProgress.
+        for (stage, expected_to) in [
+            (TaskStage::InAiReview, TaskStage::InAiReview),
+            (TaskStage::MergeReady, TaskStage::MergeReady),
+        ] {
+            let task = make_task(stage);
+            let mut signal = make_signal("github_bot_review", None);
+            signal.metadata = Some(
+                r#"{"review_state": "APPROVED", "repo": "org/repo", "pr_number": 42}"#.to_string(),
+            );
+            let result = evaluate_signal(&task, &signal).unwrap();
+            assert_eq!(result.to, expected_to);
+            assert!(matches!(result.action, TransitionAction::Notify { .. }));
+        }
     }
 
     #[test]

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -3287,7 +3287,7 @@ async fn build_idle_nudge_detached(
                     continue;
                 }
                 let id = wt.get("id").and_then(|v| v.as_str()).unwrap_or("?");
-                items.push(format!("Worker {id} is idle (no PR yet)"));
+                items.push(format!("Worker {id} is waiting for input (no PR yet)"));
             }
         }
     }

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -3276,16 +3276,18 @@ async fn build_idle_nudge_detached(
         for wt in worktrees {
             let phase = wt.get("phase").and_then(|v| v.as_str()).unwrap_or("");
             if phase == "waiting" {
+                // Skip reviewer workers — auto-dispatched, not user-actionable
+                let prompt = wt.get("prompt").and_then(|v| v.as_str()).unwrap_or("");
+                if prompt.starts_with("Review PR") {
+                    continue;
+                }
+                // Skip workers that opened a PR — they're done, not stuck
+                let has_pr = wt.get("pr").and_then(|v| v.as_object()).is_some();
+                if has_pr {
+                    continue;
+                }
                 let id = wt.get("id").and_then(|v| v.as_str()).unwrap_or("?");
-                let pr_info = wt
-                    .get("pr")
-                    .and_then(|v| v.as_object())
-                    .and_then(|pr| {
-                        let number = pr.get("number")?.as_u64()?;
-                        Some(format!(" (PR #{number})"))
-                    })
-                    .unwrap_or_default();
-                items.push(format!("Worker {id} is waiting{pr_info}"));
+                items.push(format!("Worker {id} is idle (no PR yet)"));
             }
         }
     }
@@ -3316,7 +3318,7 @@ async fn build_idle_nudge_detached(
                 for line in stdout.lines() {
                     let line = line.trim();
                     if !line.is_empty() {
-                        items.push(format!("PR {line} has CI green — ready to merge?"));
+                        items.push(format!("PR {line} — CI green, mergeable"));
                     }
                 }
             }
@@ -3327,7 +3329,7 @@ async fn build_idle_nudge_detached(
         return None;
     }
 
-    let mut msg = String::from("Hey — a few things waiting on you:\n");
+    let mut msg = String::from("Pending items:\n");
     for item in &items {
         msg.push_str(&format!("• {item}\n"));
     }


### PR DESCRIPTION
## Summary
- Suppress idle nudges for swarm workers that have already opened a PR (they're done, not stuck)
- Suppress idle nudges for reviewer workers (prompt starts with "Review PR")
- Align nudge wording with swarm phase terminology: "waiting for input (no PR yet)", "CI green, mergeable"
- Add `(MergeReady, github_bot_review)` lifecycle rule: transitions back to InProgress when Copilot leaves comments after CI has already passed
- Extract `bot_review_has_comments()` helper shared by InAiReview and MergeReady rules; uses structured `review_state` from signal metadata (falls back to body text heuristic)

## Files changed
- `crates/apiari/src/daemon/mod.rs` — `build_idle_nudge_detached()` only
- `crates/apiari/src/buzz/task/rules.rs` — new MergeReady bot-review rule, shared helper, new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)