### PR TITLE
feat: rename TaskStage::MergeReady to HumanReview

### DIFF
--- a/crates/apiari/src/buzz/task/engine.rs
+++ b/crates/apiari/src/buzz/task/engine.rs
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ci_pass_transitions_in_ai_review_to_merge_ready() {
+    fn test_ci_pass_transitions_in_ai_review_to_human_review() {
         let store = TaskStore::open_memory().unwrap();
         let task = make_task("acme", TaskStage::InAiReview, "org/repo", 42);
         store.create_task(&task).unwrap();
@@ -221,7 +221,7 @@ mod tests {
 
         assert!(result.transitioned);
         let updated = result.task.unwrap();
-        assert_eq!(updated.stage, TaskStage::MergeReady);
+        assert_eq!(updated.stage, TaskStage::HumanReview);
         assert!(!result.notifications.is_empty());
         assert!(result.worker_messages.is_empty());
     }
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn test_merged_pr_transitions_any_active_task_to_merged() {
         let store = TaskStore::open_memory().unwrap();
-        let task = make_task("acme", TaskStage::MergeReady, "org/repo", 10);
+        let task = make_task("acme", TaskStage::HumanReview, "org/repo", 10);
         store.create_task(&task).unwrap();
 
         let signal = make_signal(
@@ -535,14 +535,14 @@ mod tests {
         let fetched = store.get_task(&task.id).unwrap().unwrap();
         assert_eq!(fetched.stage, TaskStage::InAiReview);
 
-        // 3. Process CI pass signal → should transition to MergeReady
+        // 3. Process CI pass signal → should transition to HumanReview
         let ci_pass = make_signal(
             "github_ci_pass",
             Some("https://github.com/org/repo/pull/100"),
         );
         let result = process_signal(&store, "acme", &ci_pass).unwrap();
         assert!(result.transitioned);
-        assert_eq!(result.task.as_ref().unwrap().stage, TaskStage::MergeReady);
+        assert_eq!(result.task.as_ref().unwrap().stage, TaskStage::HumanReview);
         assert!(!result.notifications.is_empty());
 
         // 4. Process merged PR signal → should transition to Merged
@@ -558,7 +558,7 @@ mod tests {
 
         // Verify events were logged
         let events = store.get_task_events(&task.id).unwrap();
-        // Events: PR opened (manual), CI pass → MergeReady, merged → Merged
+        // Events: PR opened (manual), CI pass → HumanReview, merged → Merged
         assert!(events.len() >= 3);
     }
 
@@ -581,7 +581,7 @@ mod tests {
         assert_eq!(result.worker_messages.len(), 1);
 
         // 3. Process PR push while InProgress → no rule for InProgress+github_pr_push
-        // (the rule only exists for MergeReady+github_pr_push)
+        // (the rule only exists for HumanReview+github_pr_push)
         let pr_push = make_signal(
             "github_pr_push",
             Some("https://github.com/org/repo/pull/200"),
@@ -590,7 +590,7 @@ mod tests {
         assert!(!result.transitioned);
         assert_eq!(result.task.unwrap().stage, TaskStage::InProgress);
 
-        // 4. Manually transition back to InAiReview, then CI pass → MergeReady
+        // 4. Manually transition back to InAiReview, then CI pass → HumanReview
         let task_id = task.id.clone();
         store
             .transition_task(
@@ -607,7 +607,7 @@ mod tests {
         );
         let result = process_signal(&store, "acme", &ci_pass).unwrap();
         assert!(result.transitioned);
-        assert_eq!(result.task.unwrap().stage, TaskStage::MergeReady);
+        assert_eq!(result.task.unwrap().stage, TaskStage::HumanReview);
     }
 
     #[test]
@@ -631,9 +631,9 @@ mod tests {
         );
         let result = process_signal(&store, "acme", &signal).unwrap();
 
-        // 3. Verify task moved to MergeReady
+        // 3. Verify task moved to HumanReview
         assert!(result.transitioned);
-        assert_eq!(result.task.unwrap().stage, TaskStage::MergeReady);
+        assert_eq!(result.task.unwrap().stage, TaskStage::HumanReview);
 
         // 4. Verify notification was generated
         assert!(!result.notifications.is_empty());

--- a/crates/apiari/src/buzz/task/mod.rs
+++ b/crates/apiari/src/buzz/task/mod.rs
@@ -17,7 +17,7 @@ pub enum TaskStage {
     Triage,
     InProgress,
     InAiReview,
-    MergeReady,
+    HumanReview,
     Merged,
     Dismissed,
 }
@@ -28,7 +28,7 @@ impl TaskStage {
             Self::Triage => "Triage",
             Self::InProgress => "In Progress",
             Self::InAiReview => "In AI Review",
-            Self::MergeReady => "Merge Ready",
+            Self::HumanReview => "Human Review",
             Self::Merged => "Merged",
             Self::Dismissed => "Dismissed",
         }
@@ -39,7 +39,8 @@ impl TaskStage {
             "Triage" => Some(Self::Triage),
             "In Progress" => Some(Self::InProgress),
             "In AI Review" => Some(Self::InAiReview),
-            "Merge Ready" => Some(Self::MergeReady),
+            "Human Review" => Some(Self::HumanReview),
+            "Merge Ready" => Some(Self::HumanReview), // migration: old serialized value
             "Merged" => Some(Self::Merged),
             "Dismissed" => Some(Self::Dismissed),
             _ => None,
@@ -52,7 +53,7 @@ impl TaskStage {
             Self::Triage,
             Self::InProgress,
             Self::InAiReview,
-            Self::MergeReady,
+            Self::HumanReview,
         ]
     }
 

--- a/crates/apiari/src/buzz/task/rules.rs
+++ b/crates/apiari/src/buzz/task/rules.rs
@@ -95,10 +95,10 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
                     },
                 })
             } else {
-                // Clean review — propose move to MergeReady (but only if we could
+                // Clean review — propose move to HumanReview (but only if we could
                 // also verify CI is green, which we can't from a single signal).
                 // For now, just notify. The github_ci_pass rule handles the actual
-                // MergeReady transition.
+                // HumanReview transition.
                 Some(ProposedTransition {
                     task_id: task.id.clone(),
                     from: TaskStage::InAiReview,
@@ -115,18 +115,18 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
             }
         }
 
-        // ── In AI Review: CI passed + reviews clean → Merge Ready ──
+        // ── In AI Review: CI passed + reviews clean → Human Review ──
         (TaskStage::InAiReview, "github_ci_pass") => {
             let pr_ref = extract_pr_ref(signal);
             Some(ProposedTransition {
                 task_id: task.id.clone(),
                 from: TaskStage::InAiReview,
-                to: TaskStage::MergeReady,
+                to: TaskStage::HumanReview,
                 reason: format!("CI passed on {}", pr_ref.as_deref().unwrap_or("PR")),
                 approval: Approval::Auto,
                 action: TransitionAction::Notify {
                     message: format!(
-                        "CI passed on {} — ready for merge review",
+                        "CI passed on {} — ready for human review",
                         pr_ref.as_deref().unwrap_or("PR")
                     ),
                 },
@@ -148,19 +148,19 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
             },
         }),
 
-        // ── Merge Ready: bot review with comments → back to In Progress ──
-        // CI can pass (→ MergeReady) before Copilot finishes reviewing. If Copilot
+        // ── Human Review: bot review with comments → back to In Progress ──
+        // CI can pass (→ HumanReview) before Copilot finishes reviewing. If Copilot
         // then leaves inline comments, the task must go back to InProgress so the
         // worker can address them.
-        (TaskStage::MergeReady, "github_bot_review") => {
+        (TaskStage::HumanReview, "github_bot_review") => {
             let has_comments = bot_review_has_comments(signal);
 
             if has_comments {
                 Some(ProposedTransition {
                     task_id: task.id.clone(),
-                    from: TaskStage::MergeReady,
+                    from: TaskStage::HumanReview,
                     to: TaskStage::InProgress,
-                    reason: "Bot review has comments after reaching Merge Ready".to_string(),
+                    reason: "Bot review has comments after reaching human review".to_string(),
                     approval: Approval::Auto,
                     action: TransitionAction::ForwardToWorker {
                         message: format!(
@@ -172,8 +172,8 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
             } else {
                 Some(ProposedTransition {
                     task_id: task.id.clone(),
-                    from: TaskStage::MergeReady,
-                    to: TaskStage::MergeReady, // no stage change
+                    from: TaskStage::HumanReview,
+                    to: TaskStage::HumanReview, // no stage change
                     reason: "Bot review is clean".to_string(),
                     approval: Approval::Auto,
                     action: TransitionAction::Notify {
@@ -186,27 +186,27 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
             }
         }
 
-        // ── Merge Ready: CI failure → back to In Progress ──
-        (TaskStage::MergeReady, "github_ci_failure") => Some(ProposedTransition {
+        // ── Human Review: CI failure → back to In Progress ──
+        (TaskStage::HumanReview, "github_ci_failure") => Some(ProposedTransition {
             task_id: task.id.clone(),
-            from: TaskStage::MergeReady,
+            from: TaskStage::HumanReview,
             to: TaskStage::InProgress,
-            reason: "CI failed after reaching Merge Ready".to_string(),
+            reason: "CI failed after reaching human review".to_string(),
             approval: Approval::Auto,
             action: TransitionAction::ForwardToWorker {
                 message: format!(
-                    "CI failed after PR was merge-ready. Please fix.\n\nSignal: {}",
+                    "CI failed after PR was in human review. Please fix.\n\nSignal: {}",
                     signal.title
                 ),
             },
         }),
 
-        // ── Merge Ready: new commits pushed → back to In AI Review ──
-        (TaskStage::MergeReady, "github_pr_push") => Some(ProposedTransition {
+        // ── Human Review: new commits pushed → back to In AI Review ──
+        (TaskStage::HumanReview, "github_pr_push") => Some(ProposedTransition {
             task_id: task.id.clone(),
-            from: TaskStage::MergeReady,
+            from: TaskStage::HumanReview,
             to: TaskStage::InAiReview,
-            reason: "New commits pushed after reaching Merge Ready".to_string(),
+            reason: "New commits pushed after reaching human review".to_string(),
             approval: Approval::Auto,
             action: TransitionAction::Notify {
                 message: "New commits pushed — moved back to AI Review".to_string(),
@@ -233,11 +233,11 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
                 "APPROVED" => Some(ProposedTransition {
                     task_id: task.id.clone(),
                     from: TaskStage::InAiReview,
-                    to: TaskStage::MergeReady,
+                    to: TaskStage::HumanReview,
                     reason: "AI reviewer approved PR".to_string(),
                     approval: Approval::Auto,
                     action: TransitionAction::Notify {
-                        message: "AI reviewer approved — PR is ready for merge".to_string(),
+                        message: "AI reviewer approved — PR is ready for human review".to_string(),
                     },
                 }),
                 "CHANGES_REQUESTED" => Some(ProposedTransition {
@@ -425,7 +425,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ci_pass_in_ai_review_transitions_to_merge_ready() {
+    fn test_ci_pass_in_ai_review_transitions_to_human_review() {
         let task = make_task(TaskStage::InAiReview);
         let signal = make_signal(
             "github_ci_pass",
@@ -433,7 +433,7 @@ mod tests {
         );
         let result = evaluate_signal(&task, &signal).unwrap();
         assert_eq!(result.from, TaskStage::InAiReview);
-        assert_eq!(result.to, TaskStage::MergeReady);
+        assert_eq!(result.to, TaskStage::HumanReview);
         assert_eq!(result.approval, Approval::Auto);
     }
 
@@ -451,20 +451,20 @@ mod tests {
     }
 
     #[test]
-    fn test_ci_failure_in_merge_ready_transitions_to_in_progress() {
-        let task = make_task(TaskStage::MergeReady);
+    fn test_ci_failure_in_human_review_transitions_to_in_progress() {
+        let task = make_task(TaskStage::HumanReview);
         let signal = make_signal("github_ci_failure", None);
         let result = evaluate_signal(&task, &signal).unwrap();
-        assert_eq!(result.from, TaskStage::MergeReady);
+        assert_eq!(result.from, TaskStage::HumanReview);
         assert_eq!(result.to, TaskStage::InProgress);
     }
 
     #[test]
-    fn test_pr_push_in_merge_ready_transitions_to_ai_review() {
-        let task = make_task(TaskStage::MergeReady);
+    fn test_pr_push_in_human_review_transitions_to_ai_review() {
+        let task = make_task(TaskStage::HumanReview);
         let signal = make_signal("github_pr_push", None);
         let result = evaluate_signal(&task, &signal).unwrap();
-        assert_eq!(result.from, TaskStage::MergeReady);
+        assert_eq!(result.from, TaskStage::HumanReview);
         assert_eq!(result.to, TaskStage::InAiReview);
     }
 
@@ -483,7 +483,7 @@ mod tests {
             TaskStage::Triage,
             TaskStage::InProgress,
             TaskStage::InAiReview,
-            TaskStage::MergeReady,
+            TaskStage::HumanReview,
         ] {
             let task = make_task(stage.clone());
             let signal = make_signal("github_merged_pr", None);
@@ -601,7 +601,7 @@ mod tests {
     #[test]
     fn test_bot_review_changes_requested_via_metadata_transitions_to_in_progress() {
         // Verify structured review_state takes precedence over body text matching.
-        for stage in [TaskStage::InAiReview, TaskStage::MergeReady] {
+        for stage in [TaskStage::InAiReview, TaskStage::HumanReview] {
             let task = make_task(stage.clone());
             let mut signal = make_signal("github_bot_review", None);
             // No body text matching keywords — relies entirely on metadata.
@@ -620,7 +620,7 @@ mod tests {
         // APPROVED review_state → clean, no transition back to InProgress.
         for (stage, expected_to) in [
             (TaskStage::InAiReview, TaskStage::InAiReview),
-            (TaskStage::MergeReady, TaskStage::MergeReady),
+            (TaskStage::HumanReview, TaskStage::HumanReview),
         ] {
             let task = make_task(stage);
             let mut signal = make_signal("github_bot_review", None);
@@ -634,12 +634,12 @@ mod tests {
     }
 
     #[test]
-    fn test_bot_review_with_comments_in_merge_ready_transitions_to_in_progress() {
-        let task = make_task(TaskStage::MergeReady);
+    fn test_bot_review_with_comments_in_human_review_transitions_to_in_progress() {
+        let task = make_task(TaskStage::HumanReview);
         let mut signal = make_signal("github_bot_review", None);
         signal.body = Some("Copilot generated comment on line 5".to_string());
         let result = evaluate_signal(&task, &signal).unwrap();
-        assert_eq!(result.from, TaskStage::MergeReady);
+        assert_eq!(result.from, TaskStage::HumanReview);
         assert_eq!(result.to, TaskStage::InProgress);
         assert_eq!(result.approval, Approval::Auto);
         assert!(matches!(
@@ -649,18 +649,18 @@ mod tests {
     }
 
     #[test]
-    fn test_bot_review_clean_in_merge_ready_stays() {
-        let task = make_task(TaskStage::MergeReady);
+    fn test_bot_review_clean_in_human_review_stays() {
+        let task = make_task(TaskStage::HumanReview);
         let mut signal = make_signal("github_bot_review", None);
         signal.body = Some("Looks good!".to_string());
         let result = evaluate_signal(&task, &signal).unwrap();
-        assert_eq!(result.from, TaskStage::MergeReady);
-        assert_eq!(result.to, TaskStage::MergeReady);
+        assert_eq!(result.from, TaskStage::HumanReview);
+        assert_eq!(result.to, TaskStage::HumanReview);
         assert!(matches!(result.action, TransitionAction::Notify { .. }));
     }
 
     #[test]
-    fn test_review_verdict_approved_transitions_to_merge_ready() {
+    fn test_review_verdict_approved_transitions_to_human_review() {
         let task = make_task(TaskStage::InAiReview);
         let mut signal = make_signal("swarm_review_verdict", None);
         signal.metadata = Some(
@@ -669,7 +669,7 @@ mod tests {
         );
         let result = evaluate_signal(&task, &signal).unwrap();
         assert_eq!(result.from, TaskStage::InAiReview);
-        assert_eq!(result.to, TaskStage::MergeReady);
+        assert_eq!(result.to, TaskStage::HumanReview);
         assert_eq!(result.approval, Approval::Auto);
         assert!(matches!(result.action, TransitionAction::Notify { .. }));
     }

--- a/crates/apiari/src/buzz/task/store.rs
+++ b/crates/apiari/src/buzz/task/store.rs
@@ -75,9 +75,20 @@ impl TaskStore {
         )
         .wrap_err("failed to create task tables")?;
 
-        // Migrate old 'Merge Ready' stage values to 'Human Review'
-        conn.execute_batch("UPDATE tasks SET stage = 'Human Review' WHERE stage = 'Merge Ready';")
+        // Migrate old 'Merge Ready' stage values to 'Human Review' (runs only when needed)
+        let needs_migration: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM tasks WHERE stage = 'Merge Ready' LIMIT 1)",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
+        if needs_migration {
+            conn.execute_batch(
+                "UPDATE tasks SET stage = 'Human Review' WHERE stage = 'Merge Ready';",
+            )
             .wrap_err("failed to migrate Merge Ready → Human Review")?;
+        }
 
         Ok(())
     }

--- a/crates/apiari/src/buzz/task/store.rs
+++ b/crates/apiari/src/buzz/task/store.rs
@@ -82,7 +82,7 @@ impl TaskStore {
                 [],
                 |row| row.get(0),
             )
-            .unwrap_or(false);
+            .wrap_err("failed to check for Merge Ready migration")?;
         if needs_migration {
             conn.execute_batch(
                 "UPDATE tasks SET stage = 'Human Review' WHERE stage = 'Merge Ready';",

--- a/crates/apiari/src/buzz/task/store.rs
+++ b/crates/apiari/src/buzz/task/store.rs
@@ -73,7 +73,13 @@ impl TaskStore {
             CREATE INDEX IF NOT EXISTS idx_task_events_task_id ON task_events(task_id);
             ",
         )
-        .wrap_err("failed to create task tables")
+        .wrap_err("failed to create task tables")?;
+
+        // Migrate old 'Merge Ready' stage values to 'Human Review'
+        conn.execute_batch("UPDATE tasks SET stage = 'Human Review' WHERE stage = 'Merge Ready';")
+            .wrap_err("failed to migrate Merge Ready → Human Review")?;
+
+        Ok(())
     }
 
     fn init_schema(&self) -> Result<()> {
@@ -676,7 +682,7 @@ mod tests {
         let result = store.transition_task(
             &task.id,
             &TaskStage::InProgress,
-            &TaskStage::MergeReady,
+            &TaskStage::HumanReview,
             None,
         );
         assert!(result.is_err(), "should reject wrong from stage");

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -238,7 +238,7 @@ pub enum WorkerEventKind {
 pub enum KanbanStage {
     InProgress,
     InReview,
-    MergeReady,
+    HumanReview,
 }
 
 #[derive(Debug, Clone)]
@@ -264,14 +264,14 @@ pub fn build_kanban_cards_from_tasks(tasks: &[crate::buzz::task::Task]) -> Vec<K
                 t.stage,
                 crate::buzz::task::TaskStage::InProgress
                     | crate::buzz::task::TaskStage::InAiReview
-                    | crate::buzz::task::TaskStage::MergeReady
+                    | crate::buzz::task::TaskStage::HumanReview
             )
         })
         .map(|t| {
             let stage = match t.stage {
                 crate::buzz::task::TaskStage::InProgress => KanbanStage::InProgress,
                 crate::buzz::task::TaskStage::InAiReview => KanbanStage::InReview,
-                crate::buzz::task::TaskStage::MergeReady => KanbanStage::MergeReady,
+                crate::buzz::task::TaskStage::HumanReview => KanbanStage::HumanReview,
                 _ => unreachable!("filtered above"),
             };
             let icon = match t.source.as_deref() {
@@ -307,7 +307,7 @@ pub fn build_kanban_cards_from_tasks(tasks: &[crate::buzz::task::Task]) -> Vec<K
                         "awaiting review".to_string()
                     }
                 }
-                crate::buzz::task::TaskStage::MergeReady => {
+                crate::buzz::task::TaskStage::HumanReview => {
                     if let Some(pr_num) = t.pr_number {
                         format!("PR #{pr_num} · ready to merge")
                     } else {
@@ -378,7 +378,7 @@ pub fn build_kanban_cards(ws: &WorkspaceState) -> Vec<KanbanCard> {
                 // Waiting worker with a PR → likely needs user attention
                 cards.push(KanbanCard {
                     id: format!("worker:{}", w.id),
-                    stage: KanbanStage::MergeReady,
+                    stage: KanbanStage::HumanReview,
                     icon: "👷".to_string(),
                     title: short_id(&w.id),
                     subtitle: format!("PR #{} · merge?", pr.number),
@@ -1780,7 +1780,7 @@ impl App {
     const KANBAN_STAGES: [KanbanStage; 3] = [
         KanbanStage::InProgress,
         KanbanStage::InReview,
-        KanbanStage::MergeReady,
+        KanbanStage::HumanReview,
     ];
 
     /// Move kanban selection to the next non-empty column (right).
@@ -1917,7 +1917,7 @@ impl App {
             .filter(|c| c.stage == stage)
             .nth(idx)?;
         let msg = match stage {
-            KanbanStage::MergeReady => {
+            KanbanStage::HumanReview => {
                 if card.source == "worker" {
                     // subtitle like "PR #42 · merge?"
                     if let Some(num) = kanban_extract_pr_number(&card.subtitle) {
@@ -4858,7 +4858,7 @@ mod tests {
         )];
         let cards = build_kanban_cards(&ws);
         assert_eq!(cards.len(), 1);
-        assert_eq!(cards[0].stage, KanbanStage::MergeReady);
+        assert_eq!(cards[0].stage, KanbanStage::HumanReview);
         assert!(cards[0].subtitle.contains("merge?"));
     }
 
@@ -5064,17 +5064,17 @@ mod tests {
             make_task_for_test("t1", TaskStage::Triage, None),
             make_task_for_test("t2", TaskStage::InProgress, None),
             make_task_for_test("t3", TaskStage::InAiReview, None),
-            make_task_for_test("t4", TaskStage::MergeReady, None),
+            make_task_for_test("t4", TaskStage::HumanReview, None),
             make_task_for_test("t5", TaskStage::Merged, None),
             make_task_for_test("t6", TaskStage::Dismissed, None),
         ];
         let cards = build_kanban_cards_from_tasks(&tasks);
-        // Only InProgress, InAiReview, MergeReady appear in kanban
+        // Only InProgress, InAiReview, HumanReview appear in kanban
         // Triage, Merged, Dismissed are filtered out
         assert_eq!(cards.len(), 3);
         assert_eq!(cards[0].stage, KanbanStage::InProgress); // InProgress
         assert_eq!(cards[1].stage, KanbanStage::InReview); // InAiReview
-        assert_eq!(cards[2].stage, KanbanStage::MergeReady); // MergeReady
+        assert_eq!(cards[2].stage, KanbanStage::HumanReview); // HumanReview
     }
 
     #[test]

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -3280,7 +3280,7 @@ mod tests {
         push_kanban_card(
             &mut app,
             "card-2",
-            app::KanbanStage::MergeReady,
+            app::KanbanStage::HumanReview,
             "worker",
             "PR #1 · merge?",
         );
@@ -3290,23 +3290,23 @@ mod tests {
 
         assert_eq!(
             app.current_ws().unwrap().kanban_selected,
-            Some((app::KanbanStage::MergeReady, 0)),
+            Some((app::KanbanStage::HumanReview, 0)),
             "right should skip to next non-empty column"
         );
     }
 
     #[test]
-    fn test_kanban_enter_injects_merge_message_for_mergeready_worker() {
+    fn test_kanban_enter_injects_merge_message_for_human_review_worker() {
         let mut app = test_app();
         app.focused_panel = Panel::Home;
         push_kanban_card(
             &mut app,
             "card-1",
-            app::KanbanStage::MergeReady,
+            app::KanbanStage::HumanReview,
             "worker",
             "PR #42 · merge?",
         );
-        app.workspaces[0].kanban_selected = Some((app::KanbanStage::MergeReady, 0));
+        app.workspaces[0].kanban_selected = Some((app::KanbanStage::HumanReview, 0));
 
         handle_dashboard_key(&mut app, key(KeyCode::Enter));
 

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -506,7 +506,7 @@ fn draw_kanban_strip(frame: &mut Frame, app: &App, ws: &app::WorkspaceState, are
     let stages = [
         app::KanbanStage::InProgress,
         app::KanbanStage::InReview,
-        app::KanbanStage::MergeReady,
+        app::KanbanStage::HumanReview,
     ];
 
     let columns: Vec<(app::KanbanStage, Vec<&app::KanbanCard>)> = stages
@@ -591,8 +591,8 @@ fn draw_kanban_column(
                 .fg(theme::POLLEN)
                 .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
         ),
-        app::KanbanStage::MergeReady => (
-            "MERGE READY",
+        app::KanbanStage::HumanReview => (
+            "HUMAN REVIEW",
             Style::default()
                 .fg(theme::HONEY)
                 .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
@@ -625,15 +625,15 @@ fn draw_kanban_column(
     let show_count = cards_fit.min(cards.len());
     let overflow = cards.len().saturating_sub(show_count);
 
-    let is_merge_ready = stage == app::KanbanStage::MergeReady;
-    let card_style = if is_merge_ready {
+    let is_human_review = stage == app::KanbanStage::HumanReview;
+    let card_style = if is_human_review {
         Style::default()
             .fg(theme::HONEY)
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(theme::FROST)
     };
-    let subtitle_style = if is_merge_ready {
+    let subtitle_style = if is_human_review {
         Style::default().fg(theme::HONEY)
     } else {
         Style::default().fg(theme::SMOKE)
@@ -657,14 +657,14 @@ fn draw_kanban_column(
             subtitle_style
         };
 
-        // Line 1: icon + title + action hint for MergeReady
+        // Line 1: icon + title + action hint for HumanReview
         let mut title_spans = vec![
             Span::raw(" "),
             Span::styled(&card.icon, effective_card_style),
             Span::raw(" "),
             Span::styled(&card.title, effective_card_style),
         ];
-        if is_merge_ready {
+        if is_human_review {
             title_spans.push(Span::styled(
                 " \u{2192}",
                 if is_selected {


### PR DESCRIPTION
## Summary

- Renames `TaskStage::MergeReady` → `TaskStage::HumanReview` (serialized as `"Human Review"`)
- Renames `KanbanStage::MergeReady` → `KanbanStage::HumanReview` with column header `"HUMAN REVIEW"`
- Adds SQLite migration in `ensure_schema()`: `UPDATE tasks SET stage = 'Human Review' WHERE stage = 'Merge Ready'`
- Keeps `"Merge Ready"` as accepted alias in `from_str()` for backwards compatibility with any existing rows not yet migrated
- Updates all reason strings, action messages, and test names throughout `rules.rs`, `engine.rs`, `store.rs`, `app.rs`, `render.rs`, `mod.rs`

## Why

`MergeReady` implies "go ahead and merge" which was causing the coordinator to be too aggressive. `HumanReview` correctly frames the stage as "automated checks done, human decides next."

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test -p apiari` — 713 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)