### PR TITLE
docs: clean up CLAUDE.md to remove process/workflow instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,19 @@
 # Apiari
 
 ## Rules
-1. You are working in a git worktree on a `swarm/*` branch. Never commit to main.
+1. You are working in a git worktree on a `swarm/*` branch — never commit to, push to, or merge into `main`.
 2. Only modify files within this repository.
 3. Do not run `cargo install` or modify system state.
-4. Stay on your `swarm/*` branch — NEVER push to or merge into `main`.
 
 ## Crate Structure
 There is one crate in this repo: `crates/apiari`. The `hive` crate no longer exists. Do NOT create or modify anything in a `crates/hive/` directory.
 
-- `src/buzz/` — watchers, coordinator, signals, config, tasks
-- `src/daemon/` — daemon entry point, socket server, multi-workspace routing
-- `src/ui/` — ratatui TUI (kanban, chat, triage sidebar)
-- `src/config.rs` — workspace config parsing
-- `src/validate_bash.rs` — bash audit hook
+Key locations within `crates/apiari/src/`:
+- `buzz/` — watchers, coordinator, signals, config, tasks
+- `daemon/` — daemon entry point, socket server, multi-workspace routing
+- `ui/` — ratatui TUI (kanban, chat, triage sidebar)
+- `config.rs` — workspace config parsing
+- `validate_bash.rs` — bash audit hook
 
 ## Pre-Commit Checks
 Before every commit, run **both** of these and fix any issues:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,42 +1,21 @@
-# Worker Profile
+# Apiari
 
 ## Rules
 1. You are working in a git worktree on a `swarm/*` branch. Never commit to main.
 2. Only modify files within this repository.
-3. When done, create a PR with `gh pr create --reviewer @copilot`.
-4. Do not run `cargo install` or modify system state.
-5. Plan and execute in one go — do not pause for confirmation.
-
-## Scope Discipline
-- ONLY make changes described in the task. Do not refactor, reorganize, or improve unrelated code.
-- If `.task/TASK.md` has an **Anti-Goals** section, treat every item as a hard constraint — do NOT do those things.
-- If `.task/PLAN.md` exists, follow its steps exactly. Do not add extra steps.
-- Do not modify files outside the plan unless strictly required to complete a planned step.
-- A focused PR that does one thing well is better than a large PR that "also fixes" other things.
-- When in doubt about whether something is in scope, it isn't. Leave it alone.
-
-## Task Artifacts
-If a `.task/` directory exists, read ALL files before writing any code:
-- `.task/TASK.md` — Task definition with scope, acceptance criteria, and anti-goals
-- `.task/CONTEXT.md` — Relevant codebase files and patterns
-- `.task/PLAN.md` — Step-by-step implementation plan (follow exactly)
-- `.task/PROGRESS.md` — Update this as you complete each step
-
-**Do NOT commit `.task/` to git.** These are pipeline artifacts, not source code.
+3. Do not run `cargo install` or modify system state.
+4. Stay on your `swarm/*` branch — NEVER push to or merge into `main`.
 
 ## Crate Structure
 There is one crate in this repo: `crates/apiari`. The `hive` crate no longer exists. Do NOT create or modify anything in a `crates/hive/` directory.
 
-- All TUI code is in `crates/apiari/src/ui/`
-- All daemon code is in `crates/apiari/src/daemon/`
+- `src/buzz/` — watchers, coordinator, signals, config, tasks
+- `src/daemon/` — daemon entry point, socket server, multi-workspace routing
+- `src/ui/` — ratatui TUI (kanban, chat, triage sidebar)
+- `src/config.rs` — workspace config parsing
+- `src/validate_bash.rs` — bash audit hook
 
 ## Pre-Commit Checks
 Before every commit, run **both** of these and fix any issues:
 - `cargo fmt -p apiari`
-- `cargo clippy --workspace -- -D warnings`
-
-## Git Workflow
-- Stay on your `swarm/*` branch
-- NEVER push to or merge into `main`
-- Commit early and often
-- Push your branch and open a PR when done
+- `cargo clippy -p apiari -- -D warnings`


### PR DESCRIPTION
## Summary
- Removes `Scope Discipline` section (process guidance belonging in worker prompts)
- Removes `Task Artifacts` section (pipeline artifact instructions)
- Removes process rules: PR creation, commit cadence, confirmation pause
- Removes `Git Workflow` section (redundant with remaining guardrails)
- Expands `Crate Structure` with `src/` subdirectory breakdown
- Fixes clippy command from `--workspace` to `-p apiari`

## Test plan
- [ ] `cargo fmt -p apiari` passes
- [ ] `cargo clippy -p apiari -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)