### PR TITLE
fix: CI failures and bot reviews no longer regress task stage to InProgress

### DIFF
--- a/crates/apiari/src/buzz/task/engine.rs
+++ b/crates/apiari/src/buzz/task/engine.rs
@@ -79,7 +79,10 @@ pub fn process_signal(
         return Ok(result);
     }
 
-    // Step 4: Apply transition (if stage actually changes)
+    // Step 4: Apply transition (persists to DB only if stage actually changes)
+    // A rule firing counts as "transitioned" even when from == to, because an
+    // action (ForwardToWorker, Notify) is still performed.
+    result.transitioned = true;
     if proposed.from != proposed.to {
         store.transition_task(
             &task.id,
@@ -94,7 +97,13 @@ pub fn process_signal(
             proposed.to.as_str(),
             proposed.reason,
         );
-        result.transitioned = true;
+    } else {
+        info!(
+            "[task-engine] rule fired for task '{}' (stage={}, reason: {})",
+            task.title,
+            proposed.from.as_str(),
+            proposed.reason,
+        );
     }
 
     // Step 5: Collect side effects
@@ -563,44 +572,35 @@ mod tests {
     }
 
     #[test]
-    fn test_lifecycle_ci_failure_backward_transition() {
+    fn test_lifecycle_ci_failure_stays_in_review_and_forwards() {
+        // CI failure during InAiReview should NOT regress the task to InProgress.
+        // The worker is notified but the task stage stays where it is.
         let store = TaskStore::open_memory().unwrap();
 
         // 1. Create task in InAiReview with PR
         let task = make_task("acme", TaskStage::InAiReview, "org/repo", 200);
         store.create_task(&task).unwrap();
 
-        // 2. Process CI failure → should go to InProgress
+        // 2. Process CI failure → should stay in InAiReview, worker gets a message
         let ci_fail = make_signal(
             "github_ci_failure",
             Some("https://github.com/org/repo/pull/200"),
         );
         let result = process_signal(&store, "acme", &ci_fail).unwrap();
-        assert!(result.transitioned);
-        assert_eq!(result.task.as_ref().unwrap().stage, TaskStage::InProgress);
+        assert!(result.transitioned); // rule fired
+        assert_eq!(result.task.as_ref().unwrap().stage, TaskStage::InAiReview); // no regression
         assert_eq!(result.worker_messages.len(), 1);
 
-        // 3. Process PR push while InProgress → no rule for InProgress+github_pr_push
-        // (the rule only exists for HumanReview+github_pr_push)
+        // 3. Process PR push while still in InAiReview → stays in InAiReview
         let pr_push = make_signal(
             "github_pr_push",
             Some("https://github.com/org/repo/pull/200"),
         );
         let result = process_signal(&store, "acme", &pr_push).unwrap();
-        assert!(!result.transitioned);
-        assert_eq!(result.task.unwrap().stage, TaskStage::InProgress);
+        assert!(result.transitioned); // rule fired (pr_push in InAiReview stays+notifies)
+        assert_eq!(result.task.unwrap().stage, TaskStage::InAiReview);
 
-        // 4. Manually transition back to InAiReview, then CI pass → HumanReview
-        let task_id = task.id.clone();
-        store
-            .transition_task(
-                &task_id,
-                &TaskStage::InProgress,
-                &TaskStage::InAiReview,
-                Some("Worker pushed fix".to_string()),
-            )
-            .unwrap();
-
+        // 4. CI pass → HumanReview
         let ci_pass = make_signal(
             "github_ci_pass",
             Some("https://github.com/org/repo/pull/200"),

--- a/crates/apiari/src/buzz/task/rules.rs
+++ b/crates/apiari/src/buzz/task/rules.rs
@@ -58,13 +58,15 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
         // PrOpened signal carries structured data (pr_url, pr_number) that needs
         // to be written to the task before transitioning.
 
-        // ── In AI Review: CI failed → back to In Progress ──
+        // ── In AI Review: CI failed → stay in AI Review, notify worker ──
+        // InProgress is reserved for when a worker is actively coding.
+        // CI failures during review are notifications — not state regressions.
         (TaskStage::InAiReview, "github_ci_failure") => {
             let pr_ref = extract_pr_ref(signal);
             Some(ProposedTransition {
                 task_id: task.id.clone(),
                 from: TaskStage::InAiReview,
-                to: TaskStage::InProgress,
+                to: TaskStage::InAiReview,
                 reason: format!("CI failed on {}", pr_ref.as_deref().unwrap_or("PR")),
                 approval: Approval::Auto,
                 action: TransitionAction::ForwardToWorker {
@@ -76,7 +78,9 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
             })
         }
 
-        // ── In AI Review: bot review with comments → back to In Progress ──
+        // ── In AI Review: bot review → stay in AI Review, forward to worker if comments ──
+        // InProgress is reserved for when a worker is actively coding.
+        // Bot review comments are forwarded as notifications, not state regressions.
         (TaskStage::InAiReview, "github_bot_review") => {
             let has_comments = bot_review_has_comments(signal);
 
@@ -84,7 +88,7 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
                 Some(ProposedTransition {
                     task_id: task.id.clone(),
                     from: TaskStage::InAiReview,
-                    to: TaskStage::InProgress,
+                    to: TaskStage::InAiReview,
                     reason: "Bot review has comments".to_string(),
                     approval: Approval::Auto,
                     action: TransitionAction::ForwardToWorker {
@@ -148,10 +152,9 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
             },
         }),
 
-        // ── Human Review: bot review with comments → back to In Progress ──
-        // CI can pass (→ HumanReview) before Copilot finishes reviewing. If Copilot
-        // then leaves inline comments, the task must go back to InProgress so the
-        // worker can address them.
+        // ── Human Review: bot review → stay in Human Review, forward to worker if comments ──
+        // InProgress is reserved for when a worker is actively coding.
+        // Bot review comments during human review are forwarded as notifications.
         (TaskStage::HumanReview, "github_bot_review") => {
             let has_comments = bot_review_has_comments(signal);
 
@@ -159,7 +162,7 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
                 Some(ProposedTransition {
                     task_id: task.id.clone(),
                     from: TaskStage::HumanReview,
-                    to: TaskStage::InProgress,
+                    to: TaskStage::HumanReview,
                     reason: "Bot review has comments after reaching human review".to_string(),
                     approval: Approval::Auto,
                     action: TransitionAction::ForwardToWorker {
@@ -186,11 +189,13 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
             }
         }
 
-        // ── Human Review: CI failure → back to In Progress ──
+        // ── Human Review: CI failure → stay in Human Review, notify worker ──
+        // InProgress is reserved for when a worker is actively coding.
+        // CI failures during review are forwarded as notifications, not state regressions.
         (TaskStage::HumanReview, "github_ci_failure") => Some(ProposedTransition {
             task_id: task.id.clone(),
             from: TaskStage::HumanReview,
-            to: TaskStage::InProgress,
+            to: TaskStage::HumanReview,
             reason: "CI failed after reaching human review".to_string(),
             approval: Approval::Auto,
             action: TransitionAction::ForwardToWorker {
@@ -408,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ci_failure_in_ai_review_transitions_to_in_progress() {
+    fn test_ci_failure_in_ai_review_stays_in_ai_review() {
         let task = make_task(TaskStage::InAiReview);
         let signal = make_signal(
             "github_ci_failure",
@@ -416,7 +421,7 @@ mod tests {
         );
         let result = evaluate_signal(&task, &signal).unwrap();
         assert_eq!(result.from, TaskStage::InAiReview);
-        assert_eq!(result.to, TaskStage::InProgress);
+        assert_eq!(result.to, TaskStage::InAiReview);
         assert_eq!(result.approval, Approval::Auto);
         assert!(matches!(
             result.action,
@@ -451,12 +456,16 @@ mod tests {
     }
 
     #[test]
-    fn test_ci_failure_in_human_review_transitions_to_in_progress() {
+    fn test_ci_failure_in_human_review_stays_in_human_review() {
         let task = make_task(TaskStage::HumanReview);
         let signal = make_signal("github_ci_failure", None);
         let result = evaluate_signal(&task, &signal).unwrap();
         assert_eq!(result.from, TaskStage::HumanReview);
-        assert_eq!(result.to, TaskStage::InProgress);
+        assert_eq!(result.to, TaskStage::HumanReview);
+        assert!(matches!(
+            result.action,
+            TransitionAction::ForwardToWorker { .. }
+        ));
     }
 
     #[test]
@@ -579,12 +588,17 @@ mod tests {
     }
 
     #[test]
-    fn test_bot_review_with_comments_transitions_to_in_progress() {
+    fn test_bot_review_with_comments_stays_in_ai_review() {
         let task = make_task(TaskStage::InAiReview);
         let mut signal = make_signal("github_bot_review", None);
         signal.body = Some("Copilot generated comment on line 5".to_string());
         let result = evaluate_signal(&task, &signal).unwrap();
-        assert_eq!(result.to, TaskStage::InProgress);
+        assert_eq!(result.from, TaskStage::InAiReview);
+        assert_eq!(result.to, TaskStage::InAiReview);
+        assert!(matches!(
+            result.action,
+            TransitionAction::ForwardToWorker { .. }
+        ));
     }
 
     #[test]
@@ -599,8 +613,9 @@ mod tests {
     }
 
     #[test]
-    fn test_bot_review_changes_requested_via_metadata_transitions_to_in_progress() {
-        // Verify structured review_state takes precedence over body text matching.
+    fn test_bot_review_changes_requested_via_metadata_stays_in_stage() {
+        // Verify structured review_state takes precedence over body text matching,
+        // and that the task stays in its current stage (no regression to InProgress).
         for stage in [TaskStage::InAiReview, TaskStage::HumanReview] {
             let task = make_task(stage.clone());
             let mut signal = make_signal("github_bot_review", None);
@@ -611,7 +626,12 @@ mod tests {
                     .to_string(),
             );
             let result = evaluate_signal(&task, &signal).unwrap();
-            assert_eq!(result.to, TaskStage::InProgress, "stage={}", stage.as_str());
+            assert_eq!(result.to, stage, "stage={}", stage.as_str());
+            assert!(
+                matches!(result.action, TransitionAction::ForwardToWorker { .. }),
+                "stage={}",
+                stage.as_str()
+            );
         }
     }
 
@@ -634,13 +654,13 @@ mod tests {
     }
 
     #[test]
-    fn test_bot_review_with_comments_in_human_review_transitions_to_in_progress() {
+    fn test_bot_review_with_comments_in_human_review_stays_in_human_review() {
         let task = make_task(TaskStage::HumanReview);
         let mut signal = make_signal("github_bot_review", None);
         signal.body = Some("Copilot generated comment on line 5".to_string());
         let result = evaluate_signal(&task, &signal).unwrap();
         assert_eq!(result.from, TaskStage::HumanReview);
-        assert_eq!(result.to, TaskStage::InProgress);
+        assert_eq!(result.to, TaskStage::HumanReview);
         assert_eq!(result.approval, Approval::Auto);
         assert!(matches!(
             result.action,


### PR DESCRIPTION
## Summary

- **InProgress now means only one thing**: a swarm worker is actively running. CI failures and bot review comments during `InAiReview` or `HumanReview` are forwarded to the worker as notifications, not used to move the task backward.
- Removed the 4 broken `→ InProgress` transitions: `(InAiReview, github_ci_failure)`, `(HumanReview, github_ci_failure)`, `(InAiReview, github_bot_review)` with comments, `(HumanReview, github_bot_review)` with comments.
- The only valid paths to `InProgress` are: worker spawned/active, or `swarm_review_verdict` of `CHANGES_REQUESTED`.

## Test plan

- [ ] All 31 rules tests pass (`cargo test -p apiari buzz::task::rules`)
- [ ] `cargo clippy -p apiari -- -D warnings` clean
- [ ] Renamed 5 test functions to reflect the corrected expected behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)