### PR TITLE
feat: support branch-ready flow for swarm workers

### DIFF
--- a/crates/apiari/src/buzz/task/engine.rs
+++ b/crates/apiari/src/buzz/task/engine.rs
@@ -126,7 +126,7 @@ pub fn process_signal(
 }
 
 /// Find a task that matches this signal.
-/// Tries PR matching first.
+/// Tries PR matching first, then worker_id matching for branch-ready signals.
 fn find_task_for_signal(
     store: &TaskStore,
     workspace: &str,
@@ -135,6 +135,26 @@ fn find_task_for_signal(
     // Try matching by PR
     if let Some((repo, pr_number)) = rules::match_signal_to_task_pr(signal)
         && let Some(task) = store.find_task_by_pr(workspace, &repo, pr_number)?
+    {
+        return Ok(Some(task));
+    }
+
+    // For swarm_branch_ready signals, match by worker_id in metadata
+    if signal.source == "swarm_branch_ready"
+        && let Some(ref meta) = signal.metadata
+        && let Ok(v) = serde_json::from_str::<serde_json::Value>(meta)
+        && let Some(worker_id) = v.get("worker_id").and_then(|w| w.as_str())
+        && let Some(task) = store.find_task_by_worker(workspace, worker_id)?
+    {
+        return Ok(Some(task));
+    }
+
+    // For swarm_review_verdict signals in the branch-first flow (no PR), match by reviewer_worker_id
+    if signal.source == "swarm_review_verdict"
+        && let Some(ref meta) = signal.metadata
+        && let Ok(v) = serde_json::from_str::<serde_json::Value>(meta)
+        && let Some(reviewer_id) = v.get("reviewer_worker_id").and_then(|w| w.as_str())
+        && let Some(task) = store.find_task_by_reviewer_worker(workspace, reviewer_id)?
     {
         return Ok(Some(task));
     }

--- a/crates/apiari/src/buzz/task/rules.rs
+++ b/crates/apiari/src/buzz/task/rules.rs
@@ -137,6 +137,32 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
             })
         }
 
+        // ── In Progress: branch ready → In AI Review ──
+        // A worker pushed a branch and output BRANCH_READY, triggering this
+        // signal. The task moves to InAiReview so a reviewer worker can be
+        // dispatched. This is the branch-first alternative to PrOpened.
+        (TaskStage::InProgress, "swarm_branch_ready") => {
+            let meta = signal
+                .metadata
+                .as_ref()
+                .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok());
+            let branch_name = meta
+                .as_ref()
+                .and_then(|m| m.get("branch_name").and_then(|v| v.as_str()))
+                .unwrap_or("unknown branch")
+                .to_string();
+            Some(ProposedTransition {
+                task_id: task.id.clone(),
+                from: TaskStage::InProgress,
+                to: TaskStage::InAiReview,
+                reason: format!("Branch ready for review: {branch_name}"),
+                approval: Approval::Auto,
+                action: TransitionAction::Notify {
+                    message: format!("Branch {branch_name} is ready — dispatching AI reviewer"),
+                },
+            })
+        }
+
         // ── In Progress: CI failure (worker is still coding, CI ran on push) ──
         (TaskStage::InProgress, "github_ci_failure") => Some(ProposedTransition {
             task_id: task.id.clone(),
@@ -747,6 +773,45 @@ mod tests {
         let task = make_task(TaskStage::InAiReview);
         let signal = make_signal("swarm_review_verdict", None);
         // No metadata → verdict is "" → no rule matches
+        assert!(evaluate_signal(&task, &signal).is_none());
+    }
+
+    #[test]
+    fn test_branch_ready_in_progress_transitions_to_in_ai_review() {
+        let task = make_task(TaskStage::InProgress);
+        let mut signal = make_signal("swarm_branch_ready", None);
+        signal.metadata = Some(
+            r#"{"worker_id": "w-abc1", "branch_name": "swarm/my-feature", "repo": "/tmp/repo"}"#
+                .to_string(),
+        );
+        let result = evaluate_signal(&task, &signal).unwrap();
+        assert_eq!(result.from, TaskStage::InProgress);
+        assert_eq!(result.to, TaskStage::InAiReview);
+        assert_eq!(result.approval, Approval::Auto);
+        assert!(matches!(result.action, TransitionAction::Notify { .. }));
+        if let TransitionAction::Notify { message } = result.action {
+            assert!(message.contains("swarm/my-feature"));
+        }
+    }
+
+    #[test]
+    fn test_branch_ready_in_progress_no_metadata_still_transitions() {
+        // Signal without metadata should still transition (branch_name defaults to "unknown branch")
+        let task = make_task(TaskStage::InProgress);
+        let signal = make_signal("swarm_branch_ready", None);
+        let result = evaluate_signal(&task, &signal).unwrap();
+        assert_eq!(result.from, TaskStage::InProgress);
+        assert_eq!(result.to, TaskStage::InAiReview);
+    }
+
+    #[test]
+    fn test_branch_ready_in_ai_review_no_rule() {
+        // swarm_branch_ready while already InAiReview should not fire a rule
+        let task = make_task(TaskStage::InAiReview);
+        let mut signal = make_signal("swarm_branch_ready", None);
+        signal.metadata = Some(
+            r#"{"worker_id": "w-abc1", "branch_name": "swarm/my-feature", "repo": ""}"#.to_string(),
+        );
         assert!(evaluate_signal(&task, &signal).is_none());
     }
 

--- a/crates/apiari/src/buzz/watcher/swarm.rs
+++ b/crates/apiari/src/buzz/watcher/swarm.rs
@@ -27,6 +27,7 @@ use crate::buzz::signal::{Severity, SignalStatus, SignalUpdate};
 struct TrackedWorker {
     phase: WorkerPhase,
     has_pr: bool,
+    ready_branch: Option<String>,
 }
 
 /// Watches swarm daemon for worker state changes via socket subscription.
@@ -129,14 +130,56 @@ impl SwarmWatcher {
         }
     }
 
+    /// Read `ready_branch` for each worker from `.swarm/state.json`.
+    /// Returns a map of worker_id → (ready_branch, repo_path).
+    fn read_ready_branches(&self) -> HashMap<String, (String, String)> {
+        let state_path = self.work_dir.join(".swarm").join("state.json");
+        let raw = match std::fs::read_to_string(&state_path) {
+            Ok(s) => s,
+            Err(_) => return HashMap::new(),
+        };
+        let state: serde_json::Value = match serde_json::from_str(&raw) {
+            Ok(v) => v,
+            Err(_) => return HashMap::new(),
+        };
+        let mut map = HashMap::new();
+        if let Some(worktrees) = state.get("worktrees").and_then(|w| w.as_array()) {
+            for wt in worktrees {
+                let id = wt
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if id.is_empty() {
+                    continue;
+                }
+                if let Some(branch) = wt.get("ready_branch").and_then(|v| v.as_str()) {
+                    let repo_path = wt
+                        .get("repo_path")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    map.insert(id, (branch.to_string(), repo_path));
+                }
+            }
+        }
+        map
+    }
+
     /// Diff the full worker list against tracked state.
     fn diff_workers(&mut self, workers: &[WorkerInfo]) -> Vec<SignalUpdate> {
+        let ready_branches = self.read_ready_branches();
         let mut signals = Vec::new();
 
         for w in workers {
             let id = &w.id;
             let prev = self.tracked.get(id);
             let has_pr = w.pr_url.is_some();
+            let ready_branch = ready_branches.get(id.as_str()).map(|(b, _)| b.clone());
+            let repo_path = ready_branches
+                .get(id.as_str())
+                .map(|(_, r)| r.clone())
+                .unwrap_or_default();
 
             if prev.is_none() {
                 // New worktree spawned
@@ -152,6 +195,26 @@ impl SwarmWatcher {
                         w.agent,
                         truncate_prompt(&w.prompt)
                     )),
+                );
+            }
+
+            // Branch ready transition: ready_branch became set and no PR opened yet
+            let had_ready_branch = prev.and_then(|p| p.ready_branch.as_deref()).is_some();
+            if ready_branch.is_some() && !had_ready_branch && !has_pr {
+                let branch_name = ready_branch.as_deref().unwrap_or("");
+                let metadata = serde_json::json!({
+                    "worker_id": id,
+                    "branch_name": branch_name,
+                    "repo": repo_path,
+                });
+                signals.push(
+                    SignalUpdate::new(
+                        "swarm_branch_ready",
+                        format!("swarm-branch-ready-{id}"),
+                        format!("Branch ready for review: {branch_name}"),
+                        Severity::Info,
+                    )
+                    .with_metadata(metadata.to_string()),
                 );
             }
 
@@ -208,6 +271,7 @@ impl SwarmWatcher {
                 TrackedWorker {
                     phase: w.phase.clone(),
                     has_pr,
+                    ready_branch: ready_branch.clone(),
                 },
             );
         }
@@ -228,6 +292,7 @@ impl SwarmWatcher {
                 "swarm-waiting",
                 "swarm-pr",
                 "swarm-completed",
+                "swarm-branch-ready",
             ] {
                 signals.push(
                     SignalUpdate::new(
@@ -272,12 +337,14 @@ impl Watcher for SwarmWatcher {
 
         if !self.initialized {
             // First poll: record current state, don't emit
+            let ready_branches = self.read_ready_branches();
             for w in &workers {
                 self.tracked.insert(
                     w.id.clone(),
                     TrackedWorker {
                         phase: w.phase.clone(),
                         has_pr: w.pr_url.is_some(),
+                        ready_branch: ready_branches.get(&w.id).map(|(b, _)| b.clone()),
                     },
                 );
             }
@@ -316,6 +383,7 @@ impl Watcher for SwarmWatcher {
                     format!("swarm-waiting-{id}"),
                     format!("swarm-pr-{id}"),
                     format!("swarm-completed-{id}"),
+                    format!("swarm-branch-ready-{id}"),
                 ]
             })
             .collect();
@@ -538,6 +606,7 @@ mod tests {
             TrackedWorker {
                 phase: WorkerPhase::Running,
                 has_pr: false,
+                ready_branch: None,
             },
         );
 
@@ -564,6 +633,7 @@ mod tests {
             TrackedWorker {
                 phase: WorkerPhase::Running,
                 has_pr: false,
+                ready_branch: None,
             },
         );
 
@@ -582,13 +652,14 @@ mod tests {
             TrackedWorker {
                 phase: WorkerPhase::Running,
                 has_pr: false,
+                ready_branch: None,
             },
         );
 
         let workers = vec![]; // w1 is gone
         let signals = watcher.diff_workers(&workers);
-        // 4 resolved (spawned/waiting/pr/completed) + 1 closed
-        assert_eq!(signals.len(), 5);
+        // 5 resolved (spawned/waiting/pr/completed/branch-ready) + 1 closed
+        assert_eq!(signals.len(), 6);
         assert!(signals.iter().all(|s| s.title.contains("closed")));
     }
 
@@ -601,6 +672,7 @@ mod tests {
             TrackedWorker {
                 phase: WorkerPhase::Running,
                 has_pr: false,
+                ready_branch: None,
             },
         );
 
@@ -628,5 +700,57 @@ mod tests {
             review_verdict: None,
             agent_card: None,
         }
+    }
+
+    /// Test that a branch-ready transition emits a swarm_branch_ready signal.
+    #[test]
+    fn test_diff_workers_branch_ready() {
+        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        watcher.initialized = true;
+        watcher.tracked.insert(
+            "w1".to_string(),
+            TrackedWorker {
+                phase: WorkerPhase::Running,
+                has_pr: false,
+                ready_branch: None,
+            },
+        );
+
+        // The watcher reads state.json to get ready_branch — we can't inject that
+        // in a unit test without a real file, so test the signal emission logic by
+        // manually calling diff_workers (which reads ready_branches from state.json,
+        // returning an empty map since /tmp/test/.swarm/state.json doesn't exist).
+        // The transition won't fire without state.json, but we verify the base case.
+        let workers = vec![make_worker("w1", WorkerPhase::Running, None)];
+        let signals = watcher.diff_workers(&workers);
+        // No state.json → no ready_branch → no signal
+        assert!(
+            signals.is_empty(),
+            "no state.json means no branch-ready signal"
+        );
+    }
+
+    /// Test that a second poll with the same ready_branch does not re-emit.
+    #[test]
+    fn test_diff_workers_branch_ready_no_duplicate() {
+        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        watcher.initialized = true;
+        // Already tracked with ready_branch set
+        watcher.tracked.insert(
+            "w1".to_string(),
+            TrackedWorker {
+                phase: WorkerPhase::Running,
+                has_pr: false,
+                ready_branch: Some("swarm/my-feature".to_string()),
+            },
+        );
+
+        let workers = vec![make_worker("w1", WorkerPhase::Running, None)];
+        let signals = watcher.diff_workers(&workers);
+        // ready_branch was already tracked → no re-emission (even without state.json)
+        assert!(
+            signals.is_empty(),
+            "already-tracked ready_branch must not re-emit"
+        );
     }
 }

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1748,6 +1748,73 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                 }
                                             }
 
+                                            // Dispatch reviewer on branch when task enters InAiReview via branch-ready flow
+                                            if is_new && update.source == "swarm_branch_ready" && update.external_id.starts_with("swarm-branch-ready-") {
+                                                let worker_id = update.external_id.strip_prefix("swarm-branch-ready-").unwrap_or("").to_string();
+                                                if !worker_id.is_empty()
+                                                    && let Ok(task_store) = crate::buzz::task::store::TaskStore::open(slot.store.db_path())
+                                                        && let Ok(Some(task)) = task_store.find_task_by_worker(&slot.name, &worker_id)
+                                                            && task.stage == crate::buzz::task::TaskStage::InAiReview
+                                                            && task.metadata.get("reviewer_worker_id").is_none()
+                                                {
+                                                    // Extract branch_name from signal metadata
+                                                    let branch_name = update.metadata.as_ref()
+                                                        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+                                                        .and_then(|v| v.get("branch_name").and_then(|b| b.as_str()).map(String::from))
+                                                        .unwrap_or_default();
+
+                                                    if !branch_name.is_empty() {
+                                                        // Store ready_branch in task metadata for later PR-open step
+                                                        let mut meta = task.metadata.clone();
+                                                        meta["ready_branch"] = serde_json::Value::String(branch_name.clone());
+                                                        let db_path = slot.store.db_path().to_path_buf();
+                                                        if let Err(e) = task_store.update_task_metadata(&task.id, &meta) {
+                                                            tracing::warn!("[task-engine] failed to store ready_branch in task metadata: {e}");
+                                                        }
+
+                                                        // Derive a short repo name from the signal metadata repo_path
+                                                        // (e.g. "/home/user/project/apiari" → "apiari")
+                                                        let short_repo = update.metadata.as_ref()
+                                                            .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+                                                            .and_then(|v| v.get("repo").and_then(|r| r.as_str()).map(String::from))
+                                                            .unwrap_or_default();
+                                                        let short_repo = short_repo
+                                                            .trim_end_matches('/')
+                                                            .rsplit('/')
+                                                            .next()
+                                                            .unwrap_or(&short_repo)
+                                                            .to_string();
+
+                                                        let swarm = crate::buzz::coordinator::swarm_client::SwarmClient::new(
+                                                            slot.config.root.clone(),
+                                                        );
+                                                        let task_id = task.id.clone();
+                                                        let task_title = task.title.clone();
+                                                        let mut meta2 = meta;
+                                                        tokio::spawn(async move {
+                                                            match swarm.create_reviewer_worker_for_branch(&short_repo, &branch_name).await {
+                                                                Ok(reviewer_id) if !reviewer_id.is_empty() => {
+                                                                    meta2["reviewer_worker_id"] = serde_json::Value::String(reviewer_id.clone());
+                                                                    if let Ok(ts) = crate::buzz::task::store::TaskStore::open(&db_path) {
+                                                                        if let Err(e) = ts.update_task_metadata(&task_id, &meta2) {
+                                                                            tracing::warn!("[task-engine] failed to store reviewer_worker_id: {e}");
+                                                                        } else {
+                                                                            info!("[task-engine] dispatched branch reviewer {reviewer_id} for task '{task_title}'");
+                                                                        }
+                                                                    }
+                                                                }
+                                                                Ok(_) => {
+                                                                    tracing::warn!("[task-engine] branch reviewer dispatch for '{task_title}' returned empty id");
+                                                                }
+                                                                Err(e) => {
+                                                                    tracing::warn!("[task-engine] failed to dispatch branch reviewer for '{task_title}': {e}");
+                                                                }
+                                                            }
+                                                        });
+                                                    }
+                                                }
+                                            }
+
                                             // Process reviewer worker completion — emit verdict signal
                                             if is_new && update.source == "swarm" && update.external_id.starts_with("swarm-completed-") {
                                                 let worker_id = update.external_id.strip_prefix("swarm-completed-").unwrap_or("").to_string();
@@ -1792,20 +1859,41 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                             })
                                                             .unwrap_or_default();
 
-                                                        if let Some(verdict) = verdict
-                                                            && let (Some(pr_number), Some(repo)) = (task.pr_number, &task.repo)
-                                                        {
-                                                            let metadata = serde_json::json!({
-                                                                "verdict": verdict,
-                                                                "comments": comments,
-                                                                "repo": repo,
-                                                                "pr_number": pr_number,
-                                                                "reviewer_worker_id": worker_id,
-                                                            });
+                                                        if let Some(verdict) = verdict {
+                                                            // Build metadata and title for PR flow or branch-first flow
+                                                            let is_branch_flow = task.pr_number.is_none();
+                                                            let (metadata, signal_title) = if let (Some(pr_number), Some(repo)) = (task.pr_number, task.repo.as_deref()) {
+                                                                // Old PR flow
+                                                                (
+                                                                    serde_json::json!({
+                                                                        "verdict": verdict,
+                                                                        "comments": comments,
+                                                                        "repo": repo,
+                                                                        "pr_number": pr_number,
+                                                                        "reviewer_worker_id": worker_id,
+                                                                    }),
+                                                                    format!("Review verdict for PR #{pr_number}: {verdict}"),
+                                                                )
+                                                            } else {
+                                                                // Branch-first flow: no PR yet
+                                                                let ready_branch = task.metadata
+                                                                    .get("ready_branch")
+                                                                    .and_then(|v| v.as_str())
+                                                                    .unwrap_or("unknown");
+                                                                (
+                                                                    serde_json::json!({
+                                                                        "verdict": verdict,
+                                                                        "comments": comments,
+                                                                        "reviewer_worker_id": worker_id,
+                                                                        "ready_branch": ready_branch,
+                                                                    }),
+                                                                    format!("Review verdict for branch {ready_branch}: {verdict}"),
+                                                                )
+                                                            };
                                                             let verdict_signal = crate::buzz::signal::SignalUpdate::new(
                                                                 "swarm_review_verdict",
                                                                 format!("swarm-review-verdict-{worker_id}"),
-                                                                format!("Review verdict for PR #{pr_number}: {verdict}"),
+                                                                signal_title,
                                                                 crate::buzz::signal::Severity::Info,
                                                             )
                                                             .with_metadata(metadata.to_string());
@@ -1831,6 +1919,26 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                                                     if let Some(ref server) = socket_server {
                                                                                         server.broadcast_activity("task", &slot.name, "transition", notification);
                                                                                     }
+                                                                                }
+
+                                                                                // Branch-first flow: after approval, tell the original worker to open a PR
+                                                                                if verdict == "APPROVED"
+                                                                                    && is_branch_flow
+                                                                                    && let Some(ref original_worker_id) = task.worker_id
+                                                                                {
+                                                                                    let task_title = task.title.clone();
+                                                                                    let swarm = crate::buzz::coordinator::swarm_client::SwarmClient::new(slot.config.root.clone());
+                                                                                    let wid = original_worker_id.clone();
+                                                                                    tokio::spawn(async move {
+                                                                                        let msg = format!(
+                                                                                            "Your code was approved by the reviewer. Please run: `gh pr create --title '{task_title}' --body 'Approved by AI reviewer'`"
+                                                                                        );
+                                                                                        if let Err(e) = swarm.send_message(&wid, &msg).await {
+                                                                                            tracing::warn!("[task-engine] failed to send PR-open message to worker {wid}: {e}");
+                                                                                        } else {
+                                                                                            info!("[task-engine] told worker {wid} to open PR for task '{task_title}'");
+                                                                                        }
+                                                                                    });
                                                                                 }
                                                                             }
                                                                             Err(e) => {


### PR DESCRIPTION
## Summary

- **SwarmWatcher**: reads `ready_branch` from `.swarm/state.json`, tracks it in `TrackedWorker`, and emits a `swarm_branch_ready` signal (with `worker_id`, `branch_name`, `repo` metadata) when it first appears for a worker that has no PR yet
- **Rules engine**: new `(InProgress, "swarm_branch_ready") → InAiReview` rule; `find_task_for_signal` extended to match `swarm_branch_ready` by `worker_id` and `swarm_review_verdict` by `reviewer_worker_id` (for tasks without a PR)
- **SwarmClient**: `create_reviewer_worker_for_branch(branch_name)` dispatches a reviewer against a branch instead of a PR number
- **Daemon**: handles `swarm-branch-ready-*` signals by storing `ready_branch` in task metadata and dispatching a branch reviewer; when a `swarm_review_verdict: APPROVED` fires on a branch-flow task, sends a `gh pr create` instruction to the original worker

Old workers that open PRs directly are unaffected — the existing `swarm-pr-* → InAiReview` path remains as a fallback.

## Test plan

- [ ] All 740 existing tests pass (`cargo test -p apiari`)
- [ ] New rule tests: `test_branch_ready_in_progress_transitions_to_in_ai_review`, `test_branch_ready_in_progress_no_metadata_still_transitions`, `test_branch_ready_in_ai_review_no_rule`
- [ ] New watcher tests: `test_diff_workers_branch_ready`, `test_diff_workers_branch_ready_no_duplicate`
- [ ] Existing `test_diff_workers_closed` updated: now expects 6 signals (added `swarm-branch-ready` prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)