### PR TITLE
feat: load reviewer prompt from .apiari/skills/code-review.md

### DIFF
--- a/.apiari/skills/code-review.md
+++ b/.apiari/skills/code-review.md
@@ -1,0 +1,38 @@
+# Code Review
+
+Review the branch diff thoroughly and output a structured verdict.
+
+## How to Review
+Run `git diff main...<branch-name>` to see the changes.
+Also read the changed files (not just the diff) to understand full context.
+
+## Review Focus
+- **Correctness**: Logic errors, off-by-one errors, incorrect assumptions?
+- **Error handling**: Panics, unwraps, silent failures? Are Result types propagated?
+- **Edge cases**: Empty strings, None values, missing files, concurrent access, malformed input?
+- **Shell injection / security**: Are user strings safely escaped before shell commands or queries?
+- **Data consistency**: New fields have `#[serde(default)]`? Deserialization breaks? Race conditions?
+- **API consistency**: Follows existing patterns and conventions?
+- **Test coverage**: Tests for new behavior? Edge cases and error paths covered, not just happy path?
+- **Resource cleanup**: File handles, connections, spawned tasks properly cleaned up?
+
+## Verdict Rules
+- Correctness issues, shell injection risks, or data consistency problems → CHANGES_REQUESTED
+- Tests only cover happy path, miss obvious edge cases → CHANGES_REQUESTED
+- Code works but minor style issues → APPROVED (mention as comments)
+- When in doubt, request changes. A false positive is better than a missed bug.
+
+## Verdict Format
+Output EXACTLY one of these as your final message:
+
+If the branch looks good:
+```
+REVIEW_VERDICT: APPROVED
+```
+
+If changes are needed:
+```
+REVIEW_VERDICT: CHANGES_REQUESTED
+- [file:line] description of issue
+- [file:line] description of issue
+```

--- a/crates/apiari/src/buzz/coordinator/swarm_client.rs
+++ b/crates/apiari/src/buzz/coordinator/swarm_client.rs
@@ -55,15 +55,32 @@ impl SwarmClient {
         }
     }
 
+    /// Load the code-review skill from `.apiari/skills/code-review.md` if it exists.
+    fn load_review_skill(&self) -> String {
+        let path = self.work_dir.join(".apiari/skills/code-review.md");
+        std::fs::read_to_string(&path).unwrap_or_default()
+    }
+
+    /// Build the reviewer prompt, prepending the skill file if present.
+    fn reviewer_prompt(&self, base: &str) -> String {
+        let skill = self.load_review_skill();
+        if skill.is_empty() {
+            base.to_string()
+        } else {
+            format!("{skill}\n\n---\n\n{base}")
+        }
+    }
+
     /// Create a reviewer worker for a PR. Returns the worktree ID.
     ///
     /// Uses the `reviewer` profile, which instructs the agent to review the diff
     /// and emit a structured verdict (`REVIEW_VERDICT: APPROVED` or
     /// `REVIEW_VERDICT: CHANGES_REQUESTED`).
     pub async fn create_reviewer_worker(&self, repo: &str, pr_number: i64) -> Result<String> {
+        let prompt = self.reviewer_prompt(&format!("Review PR #{pr_number}"));
         let resp = self
             .request(DaemonRequest::CreateWorker {
-                prompt: format!("Review PR #{pr_number}"),
+                prompt,
                 agent: "claude".to_string(),
                 repo: Some(repo.to_string()),
                 start_point: None,
@@ -84,6 +101,42 @@ impl SwarmClient {
                 Ok(id)
             }
             DaemonResponse::Error { message } => bail!("create_reviewer_worker failed: {message}"),
+            other => bail!("unexpected response: {other:?}"),
+        }
+    }
+
+    /// Create a reviewer worker for a branch. Returns the worktree ID.
+    pub async fn create_reviewer_worker_for_branch(
+        &self,
+        repo: &str,
+        branch_name: &str,
+    ) -> Result<String> {
+        let prompt = self.reviewer_prompt(&format!("Review branch {branch_name}"));
+        let resp = self
+            .request(DaemonRequest::CreateWorker {
+                prompt,
+                agent: "claude".to_string(),
+                repo: Some(repo.to_string()),
+                start_point: None,
+                workspace: Some(self.work_dir.clone()),
+                profile: None,
+                task_dir: None,
+                role: Some("reviewer".to_string()),
+                review_pr: None,
+                base_branch: Some("main".to_string()),
+            })
+            .await?;
+
+        match resp {
+            DaemonResponse::Ok { data } => {
+                let id = data
+                    .and_then(|v| v.as_str().map(String::from))
+                    .unwrap_or_default();
+                Ok(id)
+            }
+            DaemonResponse::Error { message } => {
+                bail!("create_reviewer_worker_for_branch failed: {message}")
+            }
             other => bail!("unexpected response: {other:?}"),
         }
     }


### PR DESCRIPTION
## Summary
- Adds `.apiari/skills/code-review.md` as the default reviewer playbook (review focus, verdict rules, output format)
- `SwarmClient::create_reviewer_worker` now loads that file and prepends it to the prompt; falls back gracefully if absent
- Adds `SwarmClient::create_reviewer_worker_for_branch` for branch-based review dispatch with the same skill-loading behavior

## Test plan
- [ ] Verify that when `.apiari/skills/code-review.md` exists the reviewer worker receives the skill content prepended to the base prompt
- [ ] Verify that when the file is absent the prompt is unchanged (same behavior as before)
- [ ] `cargo clippy -p apiari -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)