### PR TITLE
feat: implement complete task lifecycle state machine

### DIFF
--- a/crates/apiari/src/buzz/task/engine.rs
+++ b/crates/apiari/src/buzz/task/engine.rs
@@ -126,7 +126,7 @@ pub fn process_signal(
 }
 
 /// Find a task that matches this signal.
-/// Tries PR matching first, then worker_id matching for branch-ready signals.
+/// Tries PR matching first, then worker_id matching for branch-ready and swarm lifecycle signals.
 fn find_task_for_signal(
     store: &TaskStore,
     workspace: &str,
@@ -159,7 +159,50 @@ fn find_task_for_signal(
         return Ok(Some(task));
     }
 
+    // For swarm worker lifecycle signals, match by worker_id from metadata
+    if matches!(
+        signal.source.as_str(),
+        "swarm_worker_running" | "swarm_worker_closed"
+    ) && let Some(worker_id) = extract_worker_id_from_metadata(signal)
+    {
+        let role = extract_role_from_metadata(signal);
+
+        if role.as_deref() == Some("reviewer") {
+            // Reviewer: look up by reviewer_worker_id in task metadata
+            if let Some(task) = store.find_task_by_reviewer_worker(workspace, &worker_id)? {
+                return Ok(Some(task));
+            }
+        } else {
+            // Regular worker: look up by worker_id
+            if let Some(task) = store.find_task_by_worker(workspace, &worker_id)? {
+                return Ok(Some(task));
+            }
+        }
+    }
+
     Ok(None)
+}
+
+/// Extract the `worker_id` field from signal metadata JSON.
+fn extract_worker_id_from_metadata(signal: &SignalRecord) -> Option<String> {
+    signal
+        .metadata
+        .as_ref()
+        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+        .and_then(|v| {
+            v.get("worker_id")
+                .and_then(|s| s.as_str())
+                .map(String::from)
+        })
+}
+
+/// Extract the `role` field from signal metadata JSON.
+fn extract_role_from_metadata(signal: &SignalRecord) -> Option<String> {
+    signal
+        .metadata
+        .as_ref()
+        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+        .and_then(|v| v.get("role").and_then(|s| s.as_str()).map(String::from))
 }
 
 #[cfg(test)]
@@ -742,5 +785,128 @@ mod tests {
         let result = process_signal(&store, "acme", &signal).unwrap();
         assert!(result.transitioned);
         assert!(result.worker_messages.is_empty()); // no worker to forward to
+    }
+
+    // ── swarm_worker_running rules ──
+
+    fn make_running_signal(worker_id: &str) -> SignalRecord {
+        let mut s = make_signal("swarm_worker_running", None);
+        s.external_id = format!("swarm-worker-running-{worker_id}-1");
+        s.metadata =
+            Some(serde_json::json!({"worker_id": worker_id, "role": "worker"}).to_string());
+        s
+    }
+
+    fn make_closed_signal(worker_id: &str, role: &str) -> SignalRecord {
+        let mut s = make_signal("swarm_worker_closed", None);
+        s.external_id = format!("swarm-worker-closed-{worker_id}");
+        s.metadata = Some(serde_json::json!({"worker_id": worker_id, "role": role}).to_string());
+        s
+    }
+
+    fn create_task_in_stage(
+        store: &TaskStore,
+        workspace: &str,
+        worker_id: &str,
+        stage: TaskStage,
+    ) -> Task {
+        let now = Utc::now();
+        let task = Task {
+            id: Uuid::new_v4().to_string(),
+            workspace: workspace.to_string(),
+            title: format!("Task for {worker_id}"),
+            stage,
+            source: Some("swarm".to_string()),
+            source_url: None,
+            worker_id: Some(worker_id.to_string()),
+            pr_url: None,
+            pr_number: None,
+            repo: None,
+            created_at: now,
+            updated_at: now,
+            resolved_at: None,
+            metadata: serde_json::json!({}),
+        };
+        store.create_task(&task).unwrap();
+        task
+    }
+
+    #[test]
+    fn test_swarm_worker_running_triage_to_in_progress() {
+        let store = TaskStore::open_memory().unwrap();
+        create_task_in_stage(&store, "acme", "w-run1", TaskStage::Triage);
+
+        let signal = make_running_signal("w-run1");
+        let result = process_signal(&store, "acme", &signal).unwrap();
+
+        assert!(result.transitioned);
+        assert_eq!(result.task.unwrap().stage, TaskStage::InProgress);
+    }
+
+    #[test]
+    fn test_swarm_worker_running_human_review_to_in_progress() {
+        let store = TaskStore::open_memory().unwrap();
+        create_task_in_stage(&store, "acme", "w-run2", TaskStage::HumanReview);
+
+        let signal = make_running_signal("w-run2");
+        let result = process_signal(&store, "acme", &signal).unwrap();
+
+        assert!(result.transitioned);
+        assert_eq!(result.task.unwrap().stage, TaskStage::InProgress);
+    }
+
+    #[test]
+    fn test_swarm_worker_running_in_ai_review_to_in_progress() {
+        let store = TaskStore::open_memory().unwrap();
+        create_task_in_stage(&store, "acme", "w-run3", TaskStage::InAiReview);
+
+        let signal = make_running_signal("w-run3");
+        let result = process_signal(&store, "acme", &signal).unwrap();
+
+        assert!(result.transitioned);
+        assert_eq!(result.task.unwrap().stage, TaskStage::InProgress);
+    }
+
+    #[test]
+    fn test_swarm_worker_closed_in_progress_non_reviewer_to_triage() {
+        let store = TaskStore::open_memory().unwrap();
+        create_task_in_stage(&store, "acme", "w-cls-np1", TaskStage::InProgress);
+
+        let signal = make_closed_signal("w-cls-np1", "worker");
+        let result = process_signal(&store, "acme", &signal).unwrap();
+
+        assert!(result.transitioned);
+        assert_eq!(result.task.unwrap().stage, TaskStage::Triage);
+    }
+
+    #[test]
+    fn test_swarm_worker_closed_in_ai_review_reviewer_to_triage() {
+        let store = TaskStore::open_memory().unwrap();
+
+        // Create a task in InAiReview and set reviewer_worker_id in metadata
+        let task = create_task_in_stage(&store, "acme", "w-main1", TaskStage::InAiReview);
+        let meta = serde_json::json!({"reviewer_worker_id": "rev-closed1"});
+        store.update_task_metadata(&task.id, &meta).unwrap();
+
+        let signal = make_closed_signal("rev-closed1", "reviewer");
+        let result = process_signal(&store, "acme", &signal).unwrap();
+
+        assert!(result.transitioned);
+        assert_eq!(result.task.unwrap().stage, TaskStage::Triage);
+    }
+
+    #[test]
+    fn test_swarm_worker_closed_in_progress_reviewer_no_match() {
+        // A reviewer closing while task is InProgress should NOT transition
+        let store = TaskStore::open_memory().unwrap();
+        let task = create_task_in_stage(&store, "acme", "w-main2", TaskStage::InProgress);
+        let meta = serde_json::json!({"reviewer_worker_id": "rev-np1"});
+        store.update_task_metadata(&task.id, &meta).unwrap();
+
+        let signal = make_closed_signal("rev-np1", "reviewer");
+        let result = process_signal(&store, "acme", &signal).unwrap();
+
+        // Rule doesn't fire: (InProgress, swarm_worker_closed, role=reviewer) → no match
+        assert!(!result.transitioned);
     }
 }

--- a/crates/apiari/src/buzz/task/rules.rs
+++ b/crates/apiari/src/buzz/task/rules.rs
@@ -304,6 +304,68 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
             },
         }),
 
+        // ── Worker running → InProgress ──
+        // A non-reviewer worker transitioned to Running phase. Move the task to InProgress
+        // regardless of which stage it was in (e.g. Triage after worker closed+re-spawned,
+        // HumanReview after human sends rebase message, InAiReview after reviewer returns changes).
+        (
+            TaskStage::Triage | TaskStage::HumanReview | TaskStage::InAiReview,
+            "swarm_worker_running",
+        ) => Some(ProposedTransition {
+            task_id: task.id.clone(),
+            from: task.stage.clone(),
+            to: TaskStage::InProgress,
+            reason: "Worker resumed running".to_string(),
+            approval: Approval::Auto,
+            action: TransitionAction::Notify {
+                message: format!(
+                    "Worker is running — task moved to InProgress (was {})",
+                    task.stage.as_str()
+                ),
+            },
+        }),
+
+        // ── Worker closed without completing → Triage ──
+        // Non-reviewer worker disappeared while task was InProgress — needs attention.
+        (TaskStage::InProgress, "swarm_worker_closed") => {
+            let role = extract_metadata_str(signal, "role");
+            if role.as_deref() != Some("reviewer") {
+                Some(ProposedTransition {
+                    task_id: task.id.clone(),
+                    from: TaskStage::InProgress,
+                    to: TaskStage::Triage,
+                    reason: "Worker closed without completing".to_string(),
+                    approval: Approval::Auto,
+                    action: TransitionAction::Notify {
+                        message: "Worker closed unexpectedly — task needs attention".to_string(),
+                    },
+                })
+            } else {
+                None
+            }
+        }
+
+        // ── Reviewer closed without verdict → Triage ──
+        // Reviewer worker disappeared while task was InAiReview — needs attention.
+        (TaskStage::InAiReview, "swarm_worker_closed") => {
+            let role = extract_metadata_str(signal, "role");
+            if role.as_deref() == Some("reviewer") {
+                Some(ProposedTransition {
+                    task_id: task.id.clone(),
+                    from: TaskStage::InAiReview,
+                    to: TaskStage::Triage,
+                    reason: "Reviewer closed without verdict".to_string(),
+                    approval: Approval::Auto,
+                    action: TransitionAction::Notify {
+                        message: "AI reviewer closed without a verdict — task needs attention"
+                            .to_string(),
+                    },
+                })
+            } else {
+                None
+            }
+        }
+
         // ── Merged PR signal on any active task ──
         (stage, "github_merged_pr") if !stage.is_terminal() => Some(ProposedTransition {
             task_id: task.id.clone(),
@@ -318,6 +380,15 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
 
         _ => None,
     }
+}
+
+/// Extract a string field from signal metadata JSON.
+fn extract_metadata_str(signal: &SignalRecord, key: &str) -> Option<String> {
+    signal
+        .metadata
+        .as_ref()
+        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+        .and_then(|v| v.get(key).and_then(|s| s.as_str()).map(String::from))
 }
 
 /// Returns true if a bot review signal has actionable comments that require
@@ -838,6 +909,93 @@ mod tests {
         let task = make_task(TaskStage::InProgress);
         let mut signal = make_signal("github_bot_review", None);
         signal.body = Some("Copilot generated comment on line 5".to_string());
+        assert!(evaluate_signal(&task, &signal).is_none());
+    }
+
+    // ── swarm_worker_running rules ──
+
+    fn make_worker_running_signal(worker_id: &str) -> SignalRecord {
+        let mut s = make_signal("swarm_worker_running", None);
+        s.metadata =
+            Some(serde_json::json!({"worker_id": worker_id, "role": "worker"}).to_string());
+        s
+    }
+
+    fn make_worker_closed_signal(worker_id: &str, role: &str) -> SignalRecord {
+        let mut s = make_signal("swarm_worker_closed", None);
+        s.metadata = Some(serde_json::json!({"worker_id": worker_id, "role": role}).to_string());
+        s
+    }
+
+    #[test]
+    fn test_worker_running_triage_to_in_progress() {
+        let task = make_task(TaskStage::Triage);
+        let signal = make_worker_running_signal("w1");
+        let result = evaluate_signal(&task, &signal).unwrap();
+        assert_eq!(result.from, TaskStage::Triage);
+        assert_eq!(result.to, TaskStage::InProgress);
+        assert_eq!(result.approval, Approval::Auto);
+    }
+
+    #[test]
+    fn test_worker_running_human_review_to_in_progress() {
+        let task = make_task(TaskStage::HumanReview);
+        let signal = make_worker_running_signal("w1");
+        let result = evaluate_signal(&task, &signal).unwrap();
+        assert_eq!(result.from, TaskStage::HumanReview);
+        assert_eq!(result.to, TaskStage::InProgress);
+    }
+
+    #[test]
+    fn test_worker_running_in_ai_review_to_in_progress() {
+        let task = make_task(TaskStage::InAiReview);
+        let signal = make_worker_running_signal("w1");
+        let result = evaluate_signal(&task, &signal).unwrap();
+        assert_eq!(result.from, TaskStage::InAiReview);
+        assert_eq!(result.to, TaskStage::InProgress);
+    }
+
+    #[test]
+    fn test_worker_running_already_in_progress_no_rule() {
+        // Already InProgress — no rule fires
+        let task = make_task(TaskStage::InProgress);
+        let signal = make_worker_running_signal("w1");
+        assert!(evaluate_signal(&task, &signal).is_none());
+    }
+
+    #[test]
+    fn test_worker_closed_in_progress_non_reviewer_to_triage() {
+        let task = make_task(TaskStage::InProgress);
+        let signal = make_worker_closed_signal("w1", "worker");
+        let result = evaluate_signal(&task, &signal).unwrap();
+        assert_eq!(result.from, TaskStage::InProgress);
+        assert_eq!(result.to, TaskStage::Triage);
+        assert_eq!(result.approval, Approval::Auto);
+    }
+
+    #[test]
+    fn test_worker_closed_in_progress_reviewer_no_match() {
+        // Reviewer closing while InProgress should not match
+        let task = make_task(TaskStage::InProgress);
+        let signal = make_worker_closed_signal("rev1", "reviewer");
+        assert!(evaluate_signal(&task, &signal).is_none());
+    }
+
+    #[test]
+    fn test_worker_closed_in_ai_review_reviewer_to_triage() {
+        let task = make_task(TaskStage::InAiReview);
+        let signal = make_worker_closed_signal("rev1", "reviewer");
+        let result = evaluate_signal(&task, &signal).unwrap();
+        assert_eq!(result.from, TaskStage::InAiReview);
+        assert_eq!(result.to, TaskStage::Triage);
+        assert_eq!(result.approval, Approval::Auto);
+    }
+
+    #[test]
+    fn test_worker_closed_in_ai_review_non_reviewer_no_match() {
+        // Non-reviewer closing while InAiReview — no rule fires (worker isn't the reviewer)
+        let task = make_task(TaskStage::InAiReview);
+        let signal = make_worker_closed_signal("w1", "worker");
         assert!(evaluate_signal(&task, &signal).is_none());
     }
 }

--- a/crates/apiari/src/buzz/watcher/swarm.rs
+++ b/crates/apiari/src/buzz/watcher/swarm.rs
@@ -28,6 +28,11 @@ struct TrackedWorker {
     phase: WorkerPhase,
     has_pr: bool,
     ready_branch: Option<String>,
+    /// Role of this worker ("reviewer" or None/other = regular worker).
+    role: Option<String>,
+    /// Count of times this worker has transitioned into Running phase.
+    /// Used to make each Running-transition signal unique (so the task engine fires each time).
+    running_count: u32,
 }
 
 /// Watches swarm daemon for worker state changes via socket subscription.
@@ -93,11 +98,41 @@ impl SwarmWatcher {
         };
 
         for (id, phase) in events {
-            let prev = self.tracked.get(&id);
+            let prev_phase = self.tracked.get(&id).map(|p| p.phase.clone());
+            let role = self.tracked.get(&id).and_then(|p| p.role.clone());
+
+            // Running transition — emit swarm_worker_running for non-reviewer workers
+            if phase == WorkerPhase::Running
+                && prev_phase
+                    .as_ref()
+                    .is_some_and(|p| *p != WorkerPhase::Running)
+            {
+                let role_str = role.as_deref().unwrap_or("worker");
+                if role_str != "reviewer" {
+                    // Increment running_count first so external_id is unique per transition
+                    if let Some(tracked) = self.tracked.get_mut(&id) {
+                        tracked.running_count += 1;
+                    }
+                    let running_count = self.tracked.get(&id).map_or(1, |p| p.running_count);
+                    let metadata =
+                        serde_json::json!({"worker_id": id, "role": role_str}).to_string();
+                    signals.push(
+                        SignalUpdate::new(
+                            "swarm_worker_running",
+                            format!("swarm-worker-running-{id}-{running_count}"),
+                            format!("Worker running: {id}"),
+                            Severity::Info,
+                        )
+                        .with_metadata(metadata),
+                    );
+                }
+            }
 
             // Waiting transition
             if phase == WorkerPhase::Waiting
-                && prev.is_some_and(|p| p.phase != WorkerPhase::Waiting)
+                && prev_phase
+                    .as_ref()
+                    .is_some_and(|p| *p != WorkerPhase::Waiting)
             {
                 signals.push(
                     SignalUpdate::new(
@@ -111,7 +146,7 @@ impl SwarmWatcher {
             }
 
             // Completed/Failed transition — emit so daemon can read verdict before teardown
-            if phase.is_terminal() && prev.is_some_and(|p| !p.phase.is_terminal()) {
+            if phase.is_terminal() && prev_phase.as_ref().is_some_and(|p| !p.is_terminal()) {
                 signals.push(
                     SignalUpdate::new(
                         "swarm",
@@ -123,7 +158,7 @@ impl SwarmWatcher {
                 );
             }
 
-            // Update tracked phase (preserve has_pr since StateChanged doesn't carry it)
+            // Update tracked phase (preserve has_pr and role since StateChanged doesn't carry them)
             if let Some(tracked) = self.tracked.get_mut(&id) {
                 tracked.phase = phase;
             }
@@ -180,6 +215,7 @@ impl SwarmWatcher {
                 .get(id.as_str())
                 .map(|(_, r)| r.clone())
                 .unwrap_or_default();
+            let role = w.role.as_deref().unwrap_or("worker");
 
             if prev.is_none() {
                 // New worktree spawned
@@ -237,6 +273,26 @@ impl SwarmWatcher {
                 signals.push(signal);
             }
 
+            // Running transition — emit swarm_worker_running for non-reviewer workers
+            // (from ListWorkers, in case subscription missed it)
+            if w.phase == WorkerPhase::Running
+                && prev.is_some_and(|p| p.phase != WorkerPhase::Running)
+                && role != "reviewer"
+            {
+                let prev_running_count = prev.map_or(0, |p| p.running_count);
+                let new_running_count = prev_running_count + 1;
+                let metadata = serde_json::json!({"worker_id": id, "role": role}).to_string();
+                signals.push(
+                    SignalUpdate::new(
+                        "swarm_worker_running",
+                        format!("swarm-worker-running-{id}-{new_running_count}"),
+                        format!("Worker running: {id}"),
+                        Severity::Info,
+                    )
+                    .with_metadata(metadata),
+                );
+            }
+
             // Waiting transition (from ListWorkers, in case subscription missed it)
             if w.phase == WorkerPhase::Waiting
                 && prev.is_some_and(|p| p.phase != WorkerPhase::Waiting)
@@ -265,6 +321,19 @@ impl SwarmWatcher {
                 );
             }
 
+            // Compute new running_count (incremented if transitioning into Running)
+            let new_running_count = {
+                let prev_count = prev.map_or(0, |p| p.running_count);
+                if w.phase == WorkerPhase::Running
+                    && prev.is_some_and(|p| p.phase != WorkerPhase::Running)
+                    && role != "reviewer"
+                {
+                    prev_count + 1
+                } else {
+                    prev_count
+                }
+            };
+
             // Update tracked state
             self.tracked.insert(
                 id.clone(),
@@ -272,6 +341,8 @@ impl SwarmWatcher {
                     phase: w.phase.clone(),
                     has_pr,
                     ready_branch: ready_branch.clone(),
+                    role: w.role.clone(),
+                    running_count: new_running_count,
                 },
             );
         }
@@ -287,6 +358,12 @@ impl SwarmWatcher {
             .collect();
 
         for id in &closed {
+            let role_str = self
+                .tracked
+                .get(id)
+                .and_then(|t| t.role.as_deref())
+                .unwrap_or("worker");
+
             for prefix in &[
                 "swarm-spawned",
                 "swarm-waiting",
@@ -313,6 +390,19 @@ impl SwarmWatcher {
                 )
                 .with_status(SignalStatus::Resolved),
             );
+
+            // Emit active swarm_worker_closed signal for the task engine to process
+            let metadata = serde_json::json!({"worker_id": id, "role": role_str}).to_string();
+            signals.push(
+                SignalUpdate::new(
+                    "swarm_worker_closed",
+                    format!("swarm-worker-closed-{id}"),
+                    format!("Worker closed: {id}"),
+                    Severity::Info,
+                )
+                .with_metadata(metadata),
+            );
+
             self.tracked.remove(id);
         }
 
@@ -345,6 +435,8 @@ impl Watcher for SwarmWatcher {
                         phase: w.phase.clone(),
                         has_pr: w.pr_url.is_some(),
                         ready_branch: ready_branches.get(&w.id).map(|(b, _)| b.clone()),
+                        role: w.role.clone(),
+                        running_count: 0,
                     },
                 );
             }
@@ -607,6 +699,8 @@ mod tests {
                 phase: WorkerPhase::Running,
                 has_pr: false,
                 ready_branch: None,
+                role: None,
+                running_count: 1,
             },
         );
 
@@ -634,6 +728,8 @@ mod tests {
                 phase: WorkerPhase::Running,
                 has_pr: false,
                 ready_branch: None,
+                role: None,
+                running_count: 1,
             },
         );
 
@@ -653,13 +749,15 @@ mod tests {
                 phase: WorkerPhase::Running,
                 has_pr: false,
                 ready_branch: None,
+                role: None,
+                running_count: 1,
             },
         );
 
         let workers = vec![]; // w1 is gone
         let signals = watcher.diff_workers(&workers);
-        // 5 resolved (spawned/waiting/pr/completed/branch-ready) + 1 closed
-        assert_eq!(signals.len(), 6);
+        // 5 resolved (spawned/waiting/pr/completed/branch-ready) + 1 old closed + 1 swarm_worker_closed
+        assert_eq!(signals.len(), 7);
         assert!(signals.iter().all(|s| s.title.contains("closed")));
     }
 
@@ -673,12 +771,104 @@ mod tests {
                 phase: WorkerPhase::Running,
                 has_pr: false,
                 ready_branch: None,
+                role: None,
+                running_count: 1,
             },
         );
 
         let workers = vec![make_worker("w1", WorkerPhase::Running, None)];
         let signals = watcher.diff_workers(&workers);
         assert!(signals.is_empty(), "no transition = no signals");
+    }
+
+    #[test]
+    fn test_diff_workers_running_transition_emits_signal() {
+        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        watcher.initialized = true;
+        watcher.tracked.insert(
+            "w1".to_string(),
+            TrackedWorker {
+                phase: WorkerPhase::Waiting,
+                has_pr: false,
+                ready_branch: None,
+                role: None,
+                running_count: 1,
+            },
+        );
+
+        let workers = vec![make_worker("w1", WorkerPhase::Running, None)];
+        let signals = watcher.diff_workers(&workers);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].source, "swarm_worker_running");
+        assert!(signals[0].title.contains("running"));
+        assert!(
+            signals[0]
+                .metadata
+                .as_deref()
+                .unwrap_or("")
+                .contains("worker_id")
+        );
+    }
+
+    #[test]
+    fn test_diff_workers_running_transition_reviewer_no_signal() {
+        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        watcher.initialized = true;
+        watcher.tracked.insert(
+            "r1".to_string(),
+            TrackedWorker {
+                phase: WorkerPhase::Waiting,
+                has_pr: false,
+                ready_branch: None,
+                role: Some("reviewer".to_string()),
+                running_count: 0,
+            },
+        );
+
+        let mut reviewer = make_worker("r1", WorkerPhase::Running, None);
+        reviewer.role = Some("reviewer".to_string());
+        let signals = watcher.diff_workers(&[reviewer]);
+        assert!(
+            signals.is_empty(),
+            "reviewer running transition should not emit swarm_worker_running"
+        );
+    }
+
+    #[test]
+    fn test_diff_workers_closed_emits_worker_closed_signal() {
+        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        watcher.initialized = true;
+        watcher.tracked.insert(
+            "w1".to_string(),
+            TrackedWorker {
+                phase: WorkerPhase::Running,
+                has_pr: false,
+                ready_branch: None,
+                role: None,
+                running_count: 1,
+            },
+        );
+
+        let workers = vec![]; // w1 is gone
+        let signals = watcher.diff_workers(&workers);
+        let closed_signal = signals
+            .iter()
+            .find(|s| s.source == "swarm_worker_closed")
+            .expect("swarm_worker_closed signal should be emitted");
+        assert!(
+            closed_signal
+                .metadata
+                .as_deref()
+                .unwrap_or("")
+                .contains("worker_id")
+        );
+        assert!(
+            closed_signal
+                .metadata
+                .as_deref()
+                .unwrap_or("")
+                .contains("role")
+        );
     }
 
     /// Helper to build a WorkerInfo for testing.
@@ -713,6 +903,8 @@ mod tests {
                 phase: WorkerPhase::Running,
                 has_pr: false,
                 ready_branch: None,
+                role: None,
+                running_count: 1,
             },
         );
 
@@ -742,6 +934,8 @@ mod tests {
                 phase: WorkerPhase::Running,
                 has_pr: false,
                 ready_branch: Some("swarm/my-feature".to_string()),
+                role: None,
+                running_count: 1,
             },
         );
 


### PR DESCRIPTION
## Summary

- **Swarm watcher**: adds `role` + `running_count` to `TrackedWorker`; emits `swarm_worker_running` (per Running transition, unique external_id) and `swarm_worker_closed` (active signal with `{worker_id, role}` metadata) alongside existing cleanup signals
- **Rules engine**: adds transitions for `swarm_worker_running` → InProgress (from Triage, HumanReview, InAiReview) and `swarm_worker_closed` → Triage (non-reviewer in InProgress; reviewer in InAiReview)
- **Signal matching**: `find_task_for_signal` now routes `swarm_worker_running`/`swarm_worker_closed` to tasks by `worker_id` in metadata, using `find_task_by_reviewer_worker` for reviewer role

## Test plan

- [ ] 17 new tests added; all pass (`cargo test -p apiari`)
- [ ] `cargo clippy -p apiari -- -D warnings` clean
- [ ] Verified NO `github_ci_pass`/`github_bot_review` rules change stage (informational only)
- [ ] Verified terminal tasks not affected by worker closed signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)