### PR TITLE
feat: add task lifecycle activity feed with TUI sidebar toggle

### DIFF
--- a/crates/apiari/src/buzz/task/engine.rs
+++ b/crates/apiari/src/buzz/task/engine.rs
@@ -22,6 +22,8 @@ pub struct EngineResult {
     pub notifications: Vec<String>,
     /// Whether a stage transition occurred.
     pub transitioned: bool,
+    /// Stage the task was in BEFORE the transition (None if no stage change, or no task matched).
+    pub from_stage: Option<super::TaskStage>,
 }
 
 /// Process a signal through the task engine.
@@ -40,6 +42,7 @@ pub fn process_signal(
         worker_messages: Vec::new(),
         notifications: Vec::new(),
         transitioned: false,
+        from_stage: None,
     };
 
     // Step 1: Match signal to task
@@ -83,6 +86,7 @@ pub fn process_signal(
     // A rule firing counts as "transitioned" even when from == to, because an
     // action (ForwardToWorker, Notify) is still performed.
     result.transitioned = true;
+    result.from_stage = Some(proposed.from.clone());
     if proposed.from != proposed.to {
         store.transition_task(
             &task.id,

--- a/crates/apiari/src/buzz/task/event_store.rs
+++ b/crates/apiari/src/buzz/task/event_store.rs
@@ -1,0 +1,316 @@
+//! SQLite-backed activity event store.
+//!
+//! Records task lifecycle events and workspace-level activity for the
+//! per-task timeline and workspace activity feed.
+//!
+//! Uses a separate `activity_events` table (not `task_events`) so it can carry
+//! richer fields: workspace, summary, source, and a JSON metadata blob.
+
+use chrono::{DateTime, Utc};
+use color_eyre::eyre::{Result, WrapErr};
+use rusqlite::{Connection, params};
+use std::path::Path;
+
+/// A single activity event in the task lifecycle or workspace feed.
+#[derive(Debug, Clone)]
+pub struct ActivityEvent {
+    pub id: i64,
+    pub workspace: String,
+    pub task_id: Option<String>,
+    /// One of: `stage_change`, `signal`, `worker`, `review`, `pr`, `note`.
+    pub event_type: String,
+    pub summary: String,
+    pub detail: Option<String>,
+    pub source: Option<String>,
+    pub signal_id: Option<i64>,
+    /// JSON blob for structured data (from_stage, to_stage, verdict, etc.).
+    pub metadata: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// SQLite-backed activity event store.
+pub struct ActivityEventStore {
+    conn: Connection,
+}
+
+impl ActivityEventStore {
+    /// Open an activity event store against the given DB file.
+    pub fn open(path: &Path) -> Result<Self> {
+        let conn = Connection::open(path)
+            .wrap_err_with(|| format!("failed to open {}", path.display()))?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        let store = Self { conn };
+        Self::ensure_schema(&store.conn)?;
+        Ok(store)
+    }
+
+    /// Open an in-memory store (for testing).
+    pub fn open_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        let store = Self { conn };
+        Self::ensure_schema(&store.conn)?;
+        Ok(store)
+    }
+
+    /// Create the `activity_events` table if it doesn't exist.
+    ///
+    /// Called from `TaskStore::ensure_schema` so the table is always present
+    /// on the shared database connection.
+    pub fn ensure_schema(conn: &Connection) -> Result<()> {
+        conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS activity_events (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                workspace   TEXT NOT NULL,
+                task_id     TEXT,
+                event_type  TEXT NOT NULL,
+                summary     TEXT NOT NULL,
+                detail      TEXT,
+                source      TEXT,
+                signal_id   INTEGER,
+                metadata    TEXT,
+                created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_activity_events_task
+                ON activity_events(workspace, task_id, created_at);
+            CREATE INDEX IF NOT EXISTS idx_activity_events_workspace
+                ON activity_events(workspace, created_at);
+            ",
+        )
+        .wrap_err("failed to create activity_events table")?;
+        Ok(())
+    }
+
+    /// Log an activity event.
+    #[allow(clippy::too_many_arguments)]
+    pub fn log_event(
+        &self,
+        workspace: &str,
+        task_id: Option<&str>,
+        event_type: &str,
+        summary: &str,
+        detail: Option<&str>,
+        source: Option<&str>,
+        signal_id: Option<i64>,
+        metadata: Option<&str>,
+    ) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "INSERT INTO activity_events
+             (workspace, task_id, event_type, summary, detail, source, signal_id, metadata, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                workspace, task_id, event_type, summary, detail, source, signal_id, metadata, now
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Get all events for a specific task (chronological, oldest first).
+    pub fn get_task_timeline(&self, workspace: &str, task_id: &str) -> Result<Vec<ActivityEvent>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, workspace, task_id, event_type, summary, detail, source, signal_id, metadata, created_at
+             FROM activity_events
+             WHERE workspace = ?1 AND task_id = ?2
+             ORDER BY created_at ASC",
+        )?;
+        let events = stmt
+            .query_map(params![workspace, task_id], row_to_activity_event)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .wrap_err("failed to query task timeline")?;
+        Ok(events)
+    }
+
+    /// Get workspace-wide activity feed (newest first).
+    pub fn get_activity_feed(
+        &self,
+        workspace: &str,
+        limit: u32,
+        offset: u32,
+    ) -> Result<Vec<ActivityEvent>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, workspace, task_id, event_type, summary, detail, source, signal_id, metadata, created_at
+             FROM activity_events
+             WHERE workspace = ?1
+             ORDER BY created_at DESC
+             LIMIT ?2 OFFSET ?3",
+        )?;
+        let events = stmt
+            .query_map(params![workspace, limit, offset], row_to_activity_event)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .wrap_err("failed to query activity feed")?;
+        Ok(events)
+    }
+
+    /// Delete events older than `retention_days` days for a workspace.
+    pub fn prune(&self, workspace: &str, retention_days: u32) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM activity_events
+             WHERE workspace = ?1
+               AND created_at < datetime('now', ?2)",
+            params![workspace, format!("-{retention_days} days")],
+        )?;
+        Ok(())
+    }
+}
+
+fn row_to_activity_event(row: &rusqlite::Row<'_>) -> rusqlite::Result<ActivityEvent> {
+    let created_at: String = row.get(9)?;
+    Ok(ActivityEvent {
+        id: row.get(0)?,
+        workspace: row.get(1)?,
+        task_id: row.get(2)?,
+        event_type: row.get(3)?,
+        summary: row.get(4)?,
+        detail: row.get(5)?,
+        source: row.get(6)?,
+        signal_id: row.get(7)?,
+        metadata: row.get(8)?,
+        created_at: created_at
+            .parse::<DateTime<Utc>>()
+            .unwrap_or_else(|_| Utc::now()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_and_get_activity_feed() {
+        let store = ActivityEventStore::open_memory().unwrap();
+        store
+            .log_event(
+                "acme",
+                Some("task-1"),
+                "stage_change",
+                "Triage → In Progress",
+                None,
+                Some("swarm"),
+                None,
+                Some(r#"{"from":"Triage","to":"In Progress"}"#),
+            )
+            .unwrap();
+        store
+            .log_event(
+                "acme",
+                None,
+                "signal",
+                "New sentry error",
+                None,
+                Some("sentry"),
+                Some(42),
+                None,
+            )
+            .unwrap();
+
+        let feed = store.get_activity_feed("acme", 50, 0).unwrap();
+        assert_eq!(feed.len(), 2);
+        // newest first
+        assert_eq!(feed[0].summary, "New sentry error");
+        assert_eq!(feed[1].summary, "Triage → In Progress");
+    }
+
+    #[test]
+    fn test_get_task_timeline() {
+        let store = ActivityEventStore::open_memory().unwrap();
+        store
+            .log_event(
+                "acme",
+                Some("task-1"),
+                "stage_change",
+                "Triage → In Progress",
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        store
+            .log_event(
+                "acme",
+                Some("task-1"),
+                "worker",
+                "Reviewer dispatched",
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        store
+            .log_event(
+                "acme",
+                Some("task-2"),
+                "signal",
+                "Other task event",
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let timeline = store.get_task_timeline("acme", "task-1").unwrap();
+        assert_eq!(timeline.len(), 2);
+        assert_eq!(timeline[0].event_type, "stage_change");
+        assert_eq!(timeline[1].event_type, "worker");
+    }
+
+    #[test]
+    fn test_prune() {
+        let store = ActivityEventStore::open_memory().unwrap();
+        // Insert an old event directly with a past timestamp
+        store
+            .conn
+            .execute(
+                "INSERT INTO activity_events (workspace, event_type, summary, created_at)
+                 VALUES ('acme', 'note', 'Old event', datetime('now', '-31 days'))",
+                [],
+            )
+            .unwrap();
+        store
+            .log_event("acme", None, "note", "Recent event", None, None, None, None)
+            .unwrap();
+
+        store.prune("acme", 30).unwrap();
+
+        let feed = store.get_activity_feed("acme", 50, 0).unwrap();
+        assert_eq!(feed.len(), 1);
+        assert_eq!(feed[0].summary, "Recent event");
+    }
+
+    #[test]
+    fn test_workspace_isolation() {
+        let store = ActivityEventStore::open_memory().unwrap();
+        store
+            .log_event(
+                "ws-a",
+                None,
+                "note",
+                "Workspace A event",
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        store
+            .log_event(
+                "ws-b",
+                None,
+                "note",
+                "Workspace B event",
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let feed_a = store.get_activity_feed("ws-a", 50, 0).unwrap();
+        assert_eq!(feed_a.len(), 1);
+        assert_eq!(feed_a[0].summary, "Workspace A event");
+    }
+}

--- a/crates/apiari/src/buzz/task/mod.rs
+++ b/crates/apiari/src/buzz/task/mod.rs
@@ -4,8 +4,11 @@
 //! data types; `store` provides the SQLite-backed persistence layer.
 
 pub mod engine;
+pub mod event_store;
 pub mod rules;
 pub mod store;
+
+pub use event_store::{ActivityEvent, ActivityEventStore};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/crates/apiari/src/buzz/task/store.rs
+++ b/crates/apiari/src/buzz/task/store.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use color_eyre::eyre::{Result, WrapErr, eyre};
 use rusqlite::{Connection, params};
 
+use super::event_store::ActivityEventStore;
 use super::{Task, TaskEvent, TaskStage};
 
 /// SQLite task store.
@@ -74,6 +75,9 @@ impl TaskStore {
             ",
         )
         .wrap_err("failed to create task tables")?;
+
+        // Ensure activity_events table is present on the same connection.
+        ActivityEventStore::ensure_schema(conn)?;
 
         // Migrate old 'Merge Ready' stage values to 'Human Review' (runs only when needed)
         let needs_migration: bool = conn

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -1354,6 +1354,7 @@ max_session_turns = 0
             daemon_endpoints: vec![],
             shells: ShellsConfig::default(),
             schedule: None,
+            activity: ActivityConfig::default(),
         };
         assert_eq!(resolve_repos(&config), vec!["Org/Repo"]);
     }
@@ -1381,6 +1382,7 @@ max_session_turns = 0
             daemon_endpoints: vec![],
             shells: ShellsConfig::default(),
             schedule: None,
+            activity: ActivityConfig::default(),
         };
         assert!(resolve_repos(&config).is_empty());
     }
@@ -1412,6 +1414,7 @@ max_session_turns = 0
             daemon_endpoints: vec![],
             shells: ShellsConfig::default(),
             schedule: None,
+            activity: ActivityConfig::default(),
         };
 
         let buzz = to_buzz_config(&ws);
@@ -1670,6 +1673,7 @@ max_session_turns = 0
             daemon_endpoints: vec![],
             shells: ShellsConfig::default(),
             schedule: None,
+            activity: ActivityConfig::default(),
         }
     }
 

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -194,6 +194,26 @@ pub struct Schedule {
     pub active_days: Option<Vec<String>>,
 }
 
+/// Activity feed / event retention configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivityConfig {
+    /// How many days to retain activity events. Default: 30.
+    #[serde(default = "default_retention_days")]
+    pub retention_days: u32,
+}
+
+fn default_retention_days() -> u32 {
+    30
+}
+
+impl Default for ActivityConfig {
+    fn default() -> Self {
+        Self {
+            retention_days: default_retention_days(),
+        }
+    }
+}
+
 /// A fully self-contained workspace configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
@@ -278,6 +298,10 @@ pub struct WorkspaceConfig {
     /// Active-hours schedule — when absent, watchers and signal hooks run 24/7.
     #[serde(default)]
     pub schedule: Option<Schedule>,
+
+    /// Activity feed / event retention configuration.
+    #[serde(default)]
+    pub activity: ActivityConfig,
 }
 
 /// A single daemon TCP endpoint (host + port).

--- a/crates/apiari/src/daemon/doctor.rs
+++ b/crates/apiari/src/daemon/doctor.rs
@@ -249,6 +249,7 @@ mod tests {
             daemon_endpoints: vec![],
             shells: ShellsConfig::default(),
             schedule: None,
+            activity: crate::config::ActivityConfig::default(),
         }
     }
 

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1396,6 +1396,19 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
     let mut idle_timer = tokio::time::interval(std::time::Duration::from_secs(60));
     idle_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+    let mut prune_timer = tokio::time::interval(std::time::Duration::from_secs(24 * 60 * 60));
+    prune_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    // Prune old activity events on startup.
+    for slot in &slots {
+        let retention_days = slot.config.activity.retention_days;
+        if let Ok(ae) = crate::buzz::task::ActivityEventStore::open(&db)
+            && let Err(e) = ae.prune(&slot.name, retention_days)
+        {
+            warn!("[{}] failed to prune activity events: {e}", slot.name);
+        }
+    }
+
     let shutdown = tokio::signal::ctrl_c();
     tokio::pin!(shutdown);
 
@@ -1616,6 +1629,44 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                                 );
                                                             }
                                                         }
+                                                        // Log activity events for signal match and stage change.
+                                                        if let Some(ref task) = engine_result.task
+                                                            && let Ok(ae) = crate::buzz::task::ActivityEventStore::open(slot.store.db_path()) {
+                                                                // Log signal event
+                                                                let _ = ae.log_event(
+                                                                    &slot.name,
+                                                                    Some(&task.id),
+                                                                    "signal",
+                                                                    &format!("Signal: {}", record.title),
+                                                                    record.body.as_deref(),
+                                                                    Some(&record.source),
+                                                                    Some(record.id),
+                                                                    None,
+                                                                );
+                                                                // Log stage_change if a transition occurred
+                                                                if engine_result.transitioned
+                                                                    && let Some(ref from) = engine_result.from_stage
+                                                                {
+                                                                    let to = &task.stage;
+                                                                    if from != to {
+                                                                        let meta = serde_json::json!({
+                                                                            "from": from.as_str(),
+                                                                            "to": to.as_str(),
+                                                                            "reason": record.source,
+                                                                        });
+                                                                        let _ = ae.log_event(
+                                                                            &slot.name,
+                                                                            Some(&task.id),
+                                                                            "stage_change",
+                                                                            &format!("{} → {}", from.as_str(), to.as_str()),
+                                                                            None,
+                                                                            Some(&record.source),
+                                                                            Some(record.id),
+                                                                            Some(&meta.to_string()),
+                                                                        );
+                                                                    }
+                                                                }
+                                                            }
                                                     }
                                                     Err(e) => {
                                                         tracing::warn!("[task-engine] error processing signal: {e}");
@@ -1660,6 +1711,34 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                                 tracing::warn!("[task-engine] failed to create task for worker {worker_id}: {e}");
                                                             } else {
                                                                 info!("[task-engine] created task '{}' for worker {worker_id}", task.title);
+                                                                // Log worker spawn and initial stage to activity feed.
+                                                                if let Ok(ae) = crate::buzz::task::ActivityEventStore::open(slot.store.db_path()) {
+                                                                    let meta = serde_json::json!({
+                                                                        "from": serde_json::Value::Null,
+                                                                        "to": "In Progress",
+                                                                        "worker_id": worker_id,
+                                                                    });
+                                                                    let _ = ae.log_event(
+                                                                        &slot.name,
+                                                                        Some(&task.id),
+                                                                        "stage_change",
+                                                                        &format!("Task created: {}", task.title),
+                                                                        None,
+                                                                        Some("swarm"),
+                                                                        None,
+                                                                        Some(&meta.to_string()),
+                                                                    );
+                                                                    let _ = ae.log_event(
+                                                                        &slot.name,
+                                                                        Some(&task.id),
+                                                                        "worker",
+                                                                        &format!("Worker {} spawned", worker_id),
+                                                                        None,
+                                                                        Some("swarm"),
+                                                                        None,
+                                                                        Some(&serde_json::json!({"worker_id": worker_id}).to_string()),
+                                                                    );
+                                                                }
                                                             }
                                                         }
                                             }
@@ -1697,6 +1776,36 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                                     tracing::warn!("[task-engine] failed to transition task to InAiReview: {e}");
                                                                 } else {
                                                                     info!("[task-engine] task '{}' → In AI Review (PR opened)", task.title);
+                                                                    // Log PR opened + stage change to activity feed.
+                                                                    if let Ok(ae) = crate::buzz::task::ActivityEventStore::open(slot.store.db_path()) {
+                                                                        let pr_label = pr_url.as_deref().unwrap_or("(unknown)");
+                                                                        let meta = serde_json::json!({
+                                                                            "from": "In Progress",
+                                                                            "to": "In AI Review",
+                                                                            "reason": "PR opened",
+                                                                            "pr_url": pr_label,
+                                                                        });
+                                                                        let _ = ae.log_event(
+                                                                            &slot.name,
+                                                                            Some(&task.id),
+                                                                            "pr",
+                                                                            &format!("PR opened: {pr_label}"),
+                                                                            None,
+                                                                            Some("swarm"),
+                                                                            None,
+                                                                            Some(&serde_json::json!({"pr_url": pr_label}).to_string()),
+                                                                        );
+                                                                        let _ = ae.log_event(
+                                                                            &slot.name,
+                                                                            Some(&task.id),
+                                                                            "stage_change",
+                                                                            "In Progress → In AI Review",
+                                                                            None,
+                                                                            Some("swarm"),
+                                                                            None,
+                                                                            Some(&meta.to_string()),
+                                                                        );
+                                                                    }
                                                                 }
                                                             }
                                                         }
@@ -1725,6 +1834,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                     let task_title = task.title.clone();
                                                     let mut meta = task.metadata.clone();
                                                     let db_path = slot.store.db_path().to_path_buf();
+                                                    let ws_name_for_review = slot.name.clone();
                                                     tokio::spawn(async move {
                                                         match swarm.create_reviewer_worker(&short_repo, pr_number).await {
                                                             Ok(reviewer_id) if !reviewer_id.is_empty() => {
@@ -1734,6 +1844,18 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                                         tracing::warn!("[task-engine] failed to store reviewer_worker_id: {e}");
                                                                     } else {
                                                                         info!("[task-engine] dispatched reviewer {reviewer_id} for task '{task_title}'");
+                                                                        if let Ok(ae) = crate::buzz::task::ActivityEventStore::open(&db_path) {
+                                                                            let _ = ae.log_event(
+                                                                                &ws_name_for_review,
+                                                                                Some(&task_id),
+                                                                                "worker",
+                                                                                &format!("Reviewer {} dispatched", reviewer_id),
+                                                                                None,
+                                                                                Some("swarm"),
+                                                                                None,
+                                                                                Some(&serde_json::json!({"reviewer_worker_id": reviewer_id}).to_string()),
+                                                                            );
+                                                                        }
                                                                     }
                                                                 }
                                                             }
@@ -1791,6 +1913,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                         let task_id = task.id.clone();
                                                         let task_title = task.title.clone();
                                                         let mut meta2 = meta;
+                                                        let ws_name_branch = slot.name.clone();
                                                         tokio::spawn(async move {
                                                             match swarm.create_reviewer_worker_for_branch(&short_repo, &branch_name).await {
                                                                 Ok(reviewer_id) if !reviewer_id.is_empty() => {
@@ -1800,6 +1923,18 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                                             tracing::warn!("[task-engine] failed to store reviewer_worker_id: {e}");
                                                                         } else {
                                                                             info!("[task-engine] dispatched branch reviewer {reviewer_id} for task '{task_title}'");
+                                                                            if let Ok(ae) = crate::buzz::task::ActivityEventStore::open(&db_path) {
+                                                                                let _ = ae.log_event(
+                                                                                    &ws_name_branch,
+                                                                                    Some(&task_id),
+                                                                                    "worker",
+                                                                                    &format!("Branch reviewer {} dispatched", reviewer_id),
+                                                                                    None,
+                                                                                    Some("swarm"),
+                                                                                    None,
+                                                                                    Some(&serde_json::json!({"reviewer_worker_id": reviewer_id, "branch": branch_name}).to_string()),
+                                                                                );
+                                                                            }
                                                                         }
                                                                     }
                                                                 }
@@ -1901,6 +2036,23 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                             match slot.store.upsert_signal(&verdict_signal) {
                                                                 Ok((vid, true)) => {
                                                                     info!("[task-engine] emitted review verdict '{verdict}' for task '{}'", task.title);
+                                                                    // Log review event to activity feed.
+                                                                    if let Ok(ae) = crate::buzz::task::ActivityEventStore::open(slot.store.db_path()) {
+                                                                        let review_meta = serde_json::json!({
+                                                                            "verdict": verdict,
+                                                                            "reviewer_worker_id": worker_id,
+                                                                        });
+                                                                        let _ = ae.log_event(
+                                                                            &slot.name,
+                                                                            Some(&task.id),
+                                                                            "review",
+                                                                            &format!("Review verdict: {verdict}"),
+                                                                            if comments.is_empty() { None } else { Some(comments.as_str()) },
+                                                                            Some("swarm"),
+                                                                            Some(vid),
+                                                                            Some(&review_meta.to_string()),
+                                                                        );
+                                                                    }
                                                                     // Process immediately through task engine
                                                                     if let Ok(Some(vrecord)) = slot.store.get_signal(vid)
                                                                         && let Ok(ts2) = crate::buzz::task::store::TaskStore::open(slot.store.db_path())
@@ -1964,6 +2116,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                     && let Ok(task_store) = crate::buzz::task::store::TaskStore::open(slot.store.db_path())
                                                         && let Ok(Some(task)) = task_store.find_task_by_worker(&slot.name, &worker_id)
                                                             && !task.stage.is_terminal() && task.pr_url.is_none() {
+                                                                let from_stage = task.stage.clone();
                                                                 if let Err(e) = task_store.transition_task(
                                                                     &task.id,
                                                                     &task.stage,
@@ -1973,6 +2126,23 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                                     tracing::warn!("[task-engine] failed to dismiss task for closed worker: {e}");
                                                                 } else {
                                                                     info!("[task-engine] dismissed task '{}' (worker closed without PR)", task.title);
+                                                                    if let Ok(ae) = crate::buzz::task::ActivityEventStore::open(slot.store.db_path()) {
+                                                                        let meta = serde_json::json!({
+                                                                            "from": from_stage.as_str(),
+                                                                            "to": "Dismissed",
+                                                                            "reason": "Worker closed without PR",
+                                                                        });
+                                                                        let _ = ae.log_event(
+                                                                            &slot.name,
+                                                                            Some(&task.id),
+                                                                            "stage_change",
+                                                                            &format!("{} → Dismissed", from_stage.as_str()),
+                                                                            None,
+                                                                            Some("swarm"),
+                                                                            None,
+                                                                            Some(&meta.to_string()),
+                                                                        );
+                                                                    }
                                                                 }
                                                             }
                                             }
@@ -2657,6 +2827,16 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                             );
                         }
                     });
+                }
+            }
+            _ = prune_timer.tick() => {
+                for slot in &slots {
+                    let retention_days = slot.config.activity.retention_days;
+                    if let Ok(ae) = crate::buzz::task::ActivityEventStore::open(slot.store.db_path())
+                        && let Err(e) = ae.prune(&slot.name, retention_days)
+                    {
+                        warn!("[{}] failed to prune activity events: {e}", slot.name);
+                    }
                 }
             }
         }

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -64,6 +64,15 @@ pub enum Mode {
     Help,
 }
 
+/// Which view is shown in the triage sidebar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidebarView {
+    /// Actionable triage items (signals + tasks in Triage stage).
+    Triage,
+    /// Chronological workspace activity feed.
+    Activity,
+}
+
 /// Where a chat message originated from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MessageSource {
@@ -171,6 +180,7 @@ pub(super) enum AppUpdate {
         preview: String,
     },
     Tasks(Vec<(String, Vec<crate::buzz::task::Task>)>),
+    ActivityEvents(Vec<(String, Vec<crate::buzz::task::ActivityEvent>)>),
 }
 
 // ── Worker info from state.json ───────────────────────────
@@ -511,19 +521,14 @@ pub fn triage_items(ws: &WorkspaceState) -> Vec<TriageItem> {
         }
     }
 
-    // Open signals that aren't noise
+    // Open signals — only show actionable sources in triage.
     for sig in &ws.signals {
-        // Skip noise signals
-        let dominated = matches!(
+        // Only allow explicitly actionable signal sources in triage.
+        let actionable = matches!(
             sig.source.as_str(),
-            "github_ci_pass"
-                | "github_bot_review"
-                | "github_merged_pr"
-                | "github_release"
-                | "github_pr_push"
-                | "github_ci_failure"
+            "sentry" | "github_review_queue" | "email" | "linear"
         );
-        if dominated {
+        if !actionable {
             continue;
         }
         let source_label = match sig.source.as_str() {
@@ -873,6 +878,14 @@ pub struct WorkspaceState {
     pub triage_selected: usize,
     /// Scroll offset for the triage sidebar.
     pub triage_scroll: usize,
+    /// Which view is shown in the sidebar (Triage or Activity).
+    pub sidebar_view: SidebarView,
+    /// Activity feed events loaded from SQLite.
+    pub activity_events: Vec<crate::buzz::task::ActivityEvent>,
+    /// Selected index in the activity feed list.
+    pub activity_selected: usize,
+    /// Scroll offset for the activity feed.
+    pub activity_scroll: usize,
 }
 
 // ── App ───────────────────────────────────────────────────
@@ -1002,6 +1015,10 @@ impl App {
                     triage_sidebar_open: true,
                     triage_selected: 0,
                     triage_scroll: 0,
+                    sidebar_view: SidebarView::Triage,
+                    activity_events: Vec::new(),
+                    activity_selected: 0,
+                    activity_scroll: 0,
                 }
             })
             .collect();
@@ -1151,6 +1168,10 @@ impl App {
             triage_sidebar_open: true,
             triage_selected: 0,
             triage_scroll: 0,
+            sidebar_view: SidebarView::Triage,
+            activity_events: Vec::new(),
+            activity_selected: 0,
+            activity_scroll: 0,
         };
 
         let setup = SetupState {
@@ -1287,6 +1308,10 @@ impl App {
             triage_sidebar_open: true,
             triage_selected: 0,
             triage_scroll: 0,
+            sidebar_view: SidebarView::Triage,
+            activity_events: Vec::new(),
+            activity_selected: 0,
+            activity_scroll: 0,
         };
 
         ws_state.chat_history.push(ChatLine::Assistant(
@@ -1490,6 +1515,10 @@ impl App {
             triage_sidebar_open: true,
             triage_selected: 0,
             triage_scroll: 0,
+            sidebar_view: SidebarView::Triage,
+            activity_events: Vec::new(),
+            activity_selected: 0,
+            activity_scroll: 0,
         };
 
         if is_add {
@@ -3105,6 +3134,19 @@ impl App {
         self.needs_redraw = true;
     }
 
+    /// Apply activity feed data from background refresh.
+    pub(super) fn apply_activity_update(
+        &mut self,
+        data: Vec<(String, Vec<crate::buzz::task::ActivityEvent>)>,
+    ) {
+        for (name, events) in data {
+            if let Some(ws) = self.workspaces.iter_mut().find(|ws| ws.name == name) {
+                ws.activity_events = events;
+            }
+        }
+        self.needs_redraw = true;
+    }
+
     /// Apply extras data from background refresh.
     pub(super) fn apply_extras_update(
         &mut self,
@@ -3688,6 +3730,24 @@ pub(super) fn load_all_tasks_blocking(
                 Vec::new()
             };
             (name.clone(), tasks)
+        })
+        .collect()
+}
+
+/// Load activity feed events for all workspaces (blocking SQLite queries).
+pub(super) fn load_all_activity_blocking(
+    db_path: &Path,
+    names: &[String],
+) -> Vec<(String, Vec<crate::buzz::task::ActivityEvent>)> {
+    names
+        .iter()
+        .map(|name| {
+            let events = if let Ok(store) = crate::buzz::task::ActivityEventStore::open(db_path) {
+                store.get_activity_feed(name, 50, 0).unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+            (name.clone(), events)
         })
         .collect()
 }
@@ -4564,6 +4624,10 @@ mod tests {
             triage_sidebar_open: true,
             triage_selected: 0,
             triage_scroll: 0,
+            sidebar_view: SidebarView::Triage,
+            activity_events: Vec::new(),
+            activity_selected: 0,
+            activity_scroll: 0,
         };
         app.workspaces = vec![ws];
         app.setup = None;
@@ -4821,6 +4885,10 @@ mod tests {
             triage_sidebar_open: true,
             triage_selected: 0,
             triage_scroll: 0,
+            sidebar_view: SidebarView::Triage,
+            activity_events: Vec::new(),
+            activity_selected: 0,
+            activity_scroll: 0,
         }
     }
 

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -2659,6 +2659,10 @@ mod tests {
             triage_sidebar_open: true,
             triage_selected: 0,
             triage_scroll: 0,
+            sidebar_view: app::SidebarView::Triage,
+            activity_events: Vec::new(),
+            activity_selected: 0,
+            activity_scroll: 0,
         };
         let ws_name = ws.name.clone();
         App {

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -570,6 +570,9 @@ async fn event_loop(
                     AppUpdate::Tasks(data) => {
                         app.apply_task_update(data);
                     }
+                    AppUpdate::ActivityEvents(data) => {
+                        app.apply_activity_update(data);
+                    }
                     AppUpdate::ShellWindows(data) => {
                         for (name, windows) in &data {
                             if let Some(ws) = app.workspaces.iter_mut().find(|ws| ws.name == *name) {
@@ -970,7 +973,21 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
     }
 
     match key.code {
-        KeyCode::Tab => app.next_panel(),
+        KeyCode::Tab => {
+            // When the triage sidebar is open, Tab toggles between Triage and Activity views.
+            // Otherwise it advances the focused panel.
+            if app.current_ws().is_some_and(|ws| ws.triage_sidebar_open) {
+                if let Some(ws) = app.current_ws_mut() {
+                    ws.sidebar_view = match ws.sidebar_view {
+                        app::SidebarView::Triage => app::SidebarView::Activity,
+                        app::SidebarView::Activity => app::SidebarView::Triage,
+                    };
+                    app.needs_redraw = true;
+                }
+            } else {
+                app.next_panel();
+            }
+        }
         KeyCode::BackTab => app.prev_panel(),
         KeyCode::Char('j') | KeyCode::Down => app.select_next_in_panel(),
         KeyCode::Char('k') | KeyCode::Up => app.select_prev_in_panel(),
@@ -2100,6 +2117,7 @@ async fn background_refresh_task(
     do_shell_refresh(&update_tx, &workspace_infos, &mut tmux_available).await;
     do_signal_refresh(&update_tx, &workspace_infos, &db_path).await;
     do_task_refresh(&update_tx, &workspace_infos, &db_path).await;
+    do_activity_refresh(&update_tx, &workspace_infos, &db_path).await;
     do_extras_refresh(&update_tx, &workspace_infos, &db_path, &pid_path).await;
 
     let mut worker_interval = tokio::time::interval(Duration::from_secs(2));
@@ -2126,6 +2144,7 @@ async fn background_refresh_task(
             _ = signal_interval.tick() => {
                 do_signal_refresh(&update_tx, &workspace_infos, &db_path).await;
                 do_task_refresh(&update_tx, &workspace_infos, &db_path).await;
+                do_activity_refresh(&update_tx, &workspace_infos, &db_path).await;
             }
             _ = extras_interval.tick() => {
                 do_extras_refresh(&update_tx, &workspace_infos, &db_path, &pid_path).await;
@@ -2213,6 +2232,20 @@ async fn do_task_refresh(
         tokio::task::spawn_blocking(move || app::load_all_tasks_blocking(&db, &names)).await
     {
         let _ = tx.send(AppUpdate::Tasks(result)).await;
+    }
+}
+
+async fn do_activity_refresh(
+    tx: &mpsc::Sender<AppUpdate>,
+    infos: &[app::WorkspaceRefreshInfo],
+    db_path: &std::path::Path,
+) {
+    let db = db_path.to_path_buf();
+    let names: Vec<String> = infos.iter().map(|i| i.name.clone()).collect();
+    if let Ok(result) =
+        tokio::task::spawn_blocking(move || app::load_all_activity_blocking(&db, &names)).await
+    {
+        let _ = tx.send(AppUpdate::ActivityEvents(result)).await;
     }
 }
 

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -701,12 +701,21 @@ fn draw_kanban_column(
 }
 
 fn draw_triage_sidebar(frame: &mut Frame, ws: &app::WorkspaceState, area: Rect) {
+    use app::SidebarView;
+
+    match ws.sidebar_view {
+        SidebarView::Triage => draw_triage_view(frame, ws, area),
+        SidebarView::Activity => draw_activity_view(frame, ws, area),
+    }
+}
+
+fn draw_triage_view(frame: &mut Frame, ws: &app::WorkspaceState, area: Rect) {
     use crate::buzz::signal::Severity;
 
     let items = app::triage_items(ws);
 
     let count = items.len();
-    let title = format!(" Triage ({count}) ");
+    let title = format!(" [Triage] ({count}) · Tab=Activity ");
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -839,6 +848,147 @@ fn draw_triage_sidebar(frame: &mut Frame, ws: &app::WorkspaceState, area: Rect) 
     // "+N more" indicator at the bottom
     if items.len() > visible + scroll {
         let more = items.len() - visible - scroll;
+        let more_y = inner.y + inner.height.saturating_sub(1);
+        let more_area = Rect {
+            x: inner.x,
+            y: more_y,
+            width: inner.width,
+            height: 1,
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                format!(" +{more} more"),
+                Style::default()
+                    .fg(theme::STEEL)
+                    .add_modifier(Modifier::DIM),
+            ))),
+            more_area,
+        );
+    }
+}
+
+fn draw_activity_view(frame: &mut Frame, ws: &app::WorkspaceState, area: Rect) {
+    let events = &ws.activity_events;
+    let count = events.len();
+    let title = format!(" [Activity] ({count}) · Tab=Triage ");
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_set(border::ROUNDED)
+        .border_style(Style::default().fg(theme::STEEL))
+        .style(Style::default().bg(theme::COMB))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(theme::FROST)
+                .add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if events.is_empty() {
+        let line = Line::from(Span::styled(
+            " No activity yet",
+            Style::default().fg(theme::SMOKE),
+        ));
+        frame.render_widget(Paragraph::new(vec![line]), inner);
+        return;
+    }
+
+    // 3 lines per event: timestamp+type line, summary line, 1 spacer
+    const LINES_PER_EVENT: usize = 3;
+    let visible = (inner.height as usize / LINES_PER_EVENT).min(events.len());
+    let scroll = ws.activity_scroll.min(events.len().saturating_sub(visible));
+
+    let mut y_offset = 0u16;
+
+    for (i, event) in events.iter().skip(scroll).take(visible).enumerate() {
+        if y_offset + 2 > inner.height {
+            break;
+        }
+
+        let actual_idx = i + scroll;
+        let is_selected = actual_idx == ws.activity_selected;
+        let bar_color = theme::SIDEBAR_COLORS[actual_idx % theme::SIDEBAR_COLORS.len()];
+
+        let row_bg = if is_selected {
+            Style::default().bg(Color::Rgb(58, 50, 42))
+        } else {
+            Style::default().bg(theme::COMB)
+        };
+
+        let age = chrono::Utc::now().signed_duration_since(event.created_at);
+        let age_str = format_age(&age);
+
+        let (type_icon, type_color) = match event.event_type.as_str() {
+            "stage_change" => ("→", theme::MINT),
+            "signal" => ("⚡", theme::HONEY),
+            "worker" => ("⚙", Color::Rgb(100, 180, 220)),
+            "review" => ("🔍", Color::Rgb(180, 120, 220)),
+            "pr" => ("⎇", Color::Rgb(100, 200, 140)),
+            "note" => ("✎", theme::SMOKE),
+            _ => ("·", theme::SMOKE),
+        };
+
+        let selector = if is_selected { "\u{25b8}" } else { " " };
+        let selector_style = if is_selected {
+            theme::selected()
+        } else {
+            theme::muted()
+        };
+        let title_style = if is_selected {
+            Style::default()
+                .fg(theme::HONEY)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme::FROST)
+        };
+
+        // Line 1: ▌ selector icon  age
+        let line1_area = Rect {
+            x: inner.x,
+            y: inner.y + y_offset,
+            width: inner.width,
+            height: 1,
+        };
+        let title_max = (inner.width as usize).saturating_sub(8);
+        let line1 = Line::from(vec![
+            Span::styled("\u{258c}", Style::default().fg(bar_color)),
+            Span::styled(selector, selector_style),
+            Span::styled(format!("{type_icon} "), Style::default().fg(type_color)),
+            Span::styled(truncate_to_width(&event.summary, title_max), title_style),
+        ]);
+        frame.render_widget(Paragraph::new(line1).style(row_bg), line1_area);
+
+        // Line 2: ▌   source · age
+        let line2_area = Rect {
+            x: inner.x,
+            y: inner.y + y_offset + 1,
+            width: inner.width,
+            height: 1,
+        };
+        let source_label = event.source.as_deref().unwrap_or(event.event_type.as_str());
+        let age_suffix = format!(" \u{b7} {age_str}");
+        let label_max = (inner.width as usize)
+            .saturating_sub(3)
+            .saturating_sub(UnicodeWidthStr::width(age_suffix.as_str()));
+        let line2 = Line::from(vec![
+            Span::styled("\u{258c}", Style::default().fg(bar_color)),
+            Span::raw("  "),
+            Span::styled(
+                truncate_to_width(source_label, label_max),
+                Style::default().fg(theme::MINT),
+            ),
+            Span::styled(age_suffix, Style::default().fg(Color::Rgb(80, 77, 70))),
+        ]);
+        frame.render_widget(Paragraph::new(line2).style(row_bg), line2_area);
+
+        y_offset += LINES_PER_EVENT as u16;
+    }
+
+    // "+N more" indicator
+    if events.len() > visible + scroll {
+        let more = events.len() - visible - scroll;
         let more_y = inner.y + inner.height.saturating_sub(1);
         let more_area = Rect {
             x: inner.x,


### PR DESCRIPTION
## Summary
- Adds `ActivityEventStore` (SQLite `activity_events` table) with `log_event`, `get_task_timeline`, `get_activity_feed`, and `prune` methods
- Logs activity events at all key daemon write points: signal match/stage changes, task creation, PR open, reviewer dispatch, verdict arrival, worker dismiss; prunes on startup and daily
- Adds `[activity]` config section (`retention_days`, default 30) and TUI sidebar Activity view toggled with Tab key, with allowlist filtering for Triage view

## Test plan
- [ ] `cargo test -p apiari` — new `ActivityEventStore` unit tests pass (feed, timeline, prune, workspace isolation)
- [ ] Start daemon against a real workspace; confirm `activity_events` table is created in the SQLite DB
- [ ] Trigger a signal match and verify an event row is inserted
- [ ] Open TUI, open triage sidebar (existing key), press Tab — confirm view switches to Activity feed
- [ ] Press Tab again — confirm view switches back to Triage
- [ ] Verify Triage view shows only sentry/github_review_queue/email/linear sources and Triage-stage tasks
- [ ] Wait 24h or manually invoke prune; confirm rows older than `retention_days` are deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)