### PR TITLE
feat: add rustfmt/clippy config, git hooks, and fmt CI step

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,7 +2,7 @@
 set -e
 
 # Run cargo fmt check
-if ! cargo fmt --check 2>/dev/null; then
+if ! cargo fmt --all --check 2>/dev/null; then
     echo "❌ cargo fmt failed. Run 'cargo fmt' to fix."
     exit 1
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,11 +3,12 @@ set -e
 
 # Run cargo fmt check
 if ! cargo fmt --check 2>/dev/null; then
-    echo cargo fmt failed
+    echo "❌ cargo fmt failed. Run 'cargo fmt' to fix."
     exit 1
 fi
 
-if ! cargo clippy -- -D warnings 2>/dev/null; then
-    echo clippy has warnings
+# Run clippy
+if ! cargo clippy --workspace -- -D warnings 2>/dev/null; then
+    echo "❌ clippy has warnings. Fix them before committing."
     exit 1
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+      - name: Format
+        run: cargo fmt --workspace --check
       - name: Check
         run: cargo check --workspace
       - name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Format
-        run: cargo fmt --workspace --check
+        run: cargo fmt --all --check
       - name: Check
         run: cargo check --workspace
       - name: Clippy

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,3 @@
 max_width = 100
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
## Summary

- **rustfmt.toml**: Add `imports_granularity = "Crate"` and `group_imports = "StdExternalCrate"` (nightly-only, harmlessly ignored on stable)
- **.githooks/pre-commit**: Fix clippy invocation to use `--workspace` flag; improve error messages with emoji indicators
- **.github/workflows/ci.yml**: Add `cargo fmt --workspace --check` Format step before the existing Check step

## Notes

The reviewer→task linking bug (writing `reviewer_worker_id` to task metadata after dispatching a reviewer) was already fully implemented in the daemon — both PR-flow and branch-ready-flow paths already call `update_task_metadata()` to persist the ID. No changes were needed there.

## Test plan
- [ ] CI passes with Format step
- [ ] `cargo fmt --check` exits 0
- [ ] `cargo clippy --workspace -- -D warnings` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)