### PR TITLE
chore: apply nightly rustfmt (imports_granularity + group_imports)

### DIFF
--- a/crates/apiari/src/buzz/channel/telegram.rs
+++ b/crates/apiari/src/buzz/channel/telegram.rs
@@ -3,12 +3,13 @@
 //! Uses long-polling via `getUpdates` and sends responses via `sendMessage`.
 //! Chunks messages at 4000 chars and retries without Markdown on parse failure.
 
-use super::{Channel, ChannelEvent, OutboundMessage};
 use async_trait::async_trait;
 use color_eyre::eyre::Result;
 use serde::Deserialize;
 use tokio::sync::mpsc::Sender;
 use tracing::warn;
+
+use super::{Channel, ChannelEvent, OutboundMessage};
 
 const MAX_MESSAGE_LEN: usize = 4000;
 

--- a/crates/apiari/src/buzz/config.rs
+++ b/crates/apiari/src/buzz/config.rs
@@ -2,10 +2,10 @@
 //!
 //! The caller (cli crate) is responsible for loading and providing config.
 
+use std::{collections::HashMap, path::Path};
+
 use color_eyre::eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::path::Path;
 
 /// Top-level buzz configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/apiari/src/buzz/conversation.rs
+++ b/crates/apiari/src/buzz/conversation.rs
@@ -119,8 +119,9 @@ impl<'a> ConversationStore<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rusqlite::Connection;
+
+    use super::*;
 
     fn test_conn() -> Connection {
         let conn = Connection::open_in_memory().unwrap();

--- a/crates/apiari/src/buzz/coordinator/devmode.rs
+++ b/crates/apiari/src/buzz/coordinator/devmode.rs
@@ -8,10 +8,11 @@
 //! This path is intentionally **outside** `~/.config/apiari/` (which is an
 //! allowed Bash write target) so the coordinator cannot self-enable dev-mode.
 
+use std::path::{Path, PathBuf};
+
 use chrono::{DateTime, Duration, Utc};
 use color_eyre::eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
 
 /// Default dev-mode duration: 30 minutes.
 const DEFAULT_DURATION_MINUTES: i64 = 30;

--- a/crates/apiari/src/buzz/coordinator/memory.rs
+++ b/crates/apiari/src/buzz/coordinator/memory.rs
@@ -149,8 +149,9 @@ impl<'a> MemoryStore<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rusqlite::Connection;
+
+    use super::*;
 
     fn test_conn() -> Connection {
         let conn = Connection::open_in_memory().unwrap();

--- a/crates/apiari/src/buzz/coordinator/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/mod.rs
@@ -13,15 +13,12 @@ pub mod swarm_client;
 
 use std::path::PathBuf;
 
+use apiari_claude_sdk::{ClaudeClient, Event, SessionOptions, types::ContentBlock};
 use color_eyre::eyre::Result;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use apiari_claude_sdk::types::ContentBlock;
-use apiari_claude_sdk::{ClaudeClient, Event, SessionOptions};
-
-use crate::buzz::conversation::SessionToken;
-use crate::buzz::signal::store::SignalStore;
+use crate::buzz::{conversation::SessionToken, signal::store::SignalStore};
 
 /// Unified token usage stats across all providers.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -767,12 +764,13 @@ fn truncate_cmd(cmd: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use apiari_claude_sdk::Event;
-    use apiari_claude_sdk::types::{
-        AssistantMessage, AssistantMessageContent, ContentBlock, ResultMessage,
+    use apiari_claude_sdk::{
+        Event,
+        types::{AssistantMessage, AssistantMessageContent, ContentBlock, ResultMessage},
     };
     use serde_json::Map;
+
+    use super::*;
 
     fn make_coordinator() -> Coordinator {
         Coordinator::new("sonnet", 20)

--- a/crates/apiari/src/buzz/coordinator/prompt.rs
+++ b/crates/apiari/src/buzz/coordinator/prompt.rs
@@ -3,8 +3,10 @@
 //! Constructs a system prompt that includes open signals and recent memory,
 //! so the coordinator always knows what's happening.
 
-use crate::buzz::coordinator::memory::{MemoryCategory, MemoryEntry};
-use crate::buzz::signal::SignalRecord;
+use crate::buzz::{
+    coordinator::memory::{MemoryCategory, MemoryEntry},
+    signal::SignalRecord,
+};
 
 /// The default coordinator prompt preamble (identity + role boundaries).
 ///
@@ -221,9 +223,10 @@ pub fn format_signal_summary(signals: &[SignalRecord]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
+
     use super::*;
     use crate::buzz::signal::{Severity, SignalStatus};
-    use chrono::Utc;
 
     fn make_signal(source: &str, title: &str, severity: Severity) -> SignalRecord {
         SignalRecord {

--- a/crates/apiari/src/buzz/coordinator/skills/config.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/config.rs
@@ -267,8 +267,9 @@ pub fn build_config_summary(ctx: &SkillContext) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::path::PathBuf;
+
+    use super::*;
 
     fn full_ctx() -> SkillContext {
         SkillContext {

--- a/crates/apiari/src/buzz/coordinator/skills/mod.rs
+++ b/crates/apiari/src/buzz/coordinator/skills/mod.rs
@@ -23,8 +23,10 @@ mod sentry;
 mod signals;
 mod swarm;
 
-use std::io::BufRead;
-use std::path::{Path, PathBuf};
+use std::{
+    io::BufRead,
+    path::{Path, PathBuf},
+};
 
 use crate::config::{WorkspaceAuthority, WorkspaceCapabilities};
 
@@ -320,8 +322,9 @@ pub fn observe_coordinator_disallowed_tools() -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::path::PathBuf;
+
+    use super::*;
 
     fn test_ctx() -> SkillContext {
         SkillContext {

--- a/crates/apiari/src/buzz/coordinator/swarm_client.rs
+++ b/crates/apiari/src/buzz/coordinator/swarm_client.rs
@@ -5,8 +5,10 @@
 
 use std::path::{Path, PathBuf};
 
-use apiari_swarm::daemon::ipc_client::send_daemon_request;
-use apiari_swarm::daemon::protocol::{DaemonRequest, DaemonResponse, WorkerInfo};
+use apiari_swarm::daemon::{
+    ipc_client::send_daemon_request,
+    protocol::{DaemonRequest, DaemonResponse, WorkerInfo},
+};
 use color_eyre::eyre::{Result, bail};
 
 /// Async client for the swarm daemon.

--- a/crates/apiari/src/buzz/pipeline/batch.rs
+++ b/crates/apiari/src/buzz/pipeline/batch.rs
@@ -61,9 +61,10 @@ impl BatchCollector {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
+
     use super::*;
     use crate::buzz::signal::{Severity, SignalStatus};
-    use chrono::Utc;
 
     fn make_record(source: &str, title: &str) -> SignalRecord {
         SignalRecord {

--- a/crates/apiari/src/buzz/pipeline/format.rs
+++ b/crates/apiari/src/buzz/pipeline/format.rs
@@ -63,9 +63,10 @@ pub fn format_batch_notification(signals: &[SignalRecord]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
+
     use super::*;
     use crate::buzz::signal::SignalStatus;
-    use chrono::Utc;
 
     fn make_record(
         source: &str,

--- a/crates/apiari/src/buzz/pipeline/log.rs
+++ b/crates/apiari/src/buzz/pipeline/log.rs
@@ -1,7 +1,9 @@
 //! Notification log — in-memory dedup tracker.
 
-use std::collections::HashMap;
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 /// Tracks recently sent notifications to prevent duplicates.
 pub struct NotificationLog {

--- a/crates/apiari/src/buzz/pipeline/mod.rs
+++ b/crates/apiari/src/buzz/pipeline/mod.rs
@@ -10,13 +10,15 @@ pub mod rule;
 
 use std::time::Duration;
 
-use crate::buzz::signal::SignalRecord;
 use rule::{PipelineAction, PipelineRule, default_rules};
 use tracing::debug;
 
-use self::batch::BatchCollector;
-use self::format::{format_batch_notification, format_signal_notification};
-use self::log::NotificationLog;
+use self::{
+    batch::BatchCollector,
+    format::{format_batch_notification, format_signal_notification},
+    log::NotificationLog,
+};
+use crate::buzz::signal::SignalRecord;
 
 /// Notification pipeline: process signals through rules, dedup, rate-limit, batch.
 pub struct Pipeline {
@@ -122,10 +124,11 @@ impl Pipeline {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::buzz::signal::{Severity, SignalStatus};
     use chrono::Utc;
     use rule::PipelineRule;
+
+    use super::*;
+    use crate::buzz::signal::{Severity, SignalStatus};
 
     fn make_signal(source: &str, ext_id: &str, title: &str, severity: Severity) -> SignalRecord {
         SignalRecord {

--- a/crates/apiari/src/buzz/signal/store.rs
+++ b/crates/apiari/src/buzz/signal/store.rs
@@ -4,10 +4,11 @@
 //! The store uses WAL mode for concurrent readers.
 //! All queries are scoped to a workspace name.
 
+use std::path::{Path, PathBuf};
+
 use chrono::{DateTime, Utc};
 use color_eyre::eyre::{Result, WrapErr};
 use rusqlite::{Connection, params};
-use std::path::{Path, PathBuf};
 
 use super::{Severity, SignalRecord, SignalStatus, SignalUpdate};
 

--- a/crates/apiari/src/buzz/task/engine.rs
+++ b/crates/apiari/src/buzz/task/engine.rs
@@ -7,8 +7,11 @@
 use color_eyre::Result;
 use tracing::info;
 
-use super::rules::{self, Approval, TransitionAction};
-use super::{Task, store::TaskStore};
+use super::{
+    Task,
+    rules::{self, Approval, TransitionAction},
+    store::TaskStore,
+};
 use crate::buzz::signal::SignalRecord;
 
 /// Result of processing a signal through the task engine.
@@ -211,11 +214,14 @@ fn extract_role_from_metadata(signal: &SignalRecord) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::buzz::signal::{Severity, SignalRecord, SignalStatus};
-    use crate::buzz::task::{Task, TaskStage, store::TaskStore};
     use chrono::Utc;
     use uuid::Uuid;
+
+    use super::*;
+    use crate::buzz::{
+        signal::{Severity, SignalRecord, SignalStatus},
+        task::{Task, TaskStage, store::TaskStore},
+    };
 
     fn make_task(workspace: &str, stage: TaskStage, repo: &str, pr_number: i64) -> Task {
         let now = Utc::now();

--- a/crates/apiari/src/buzz/task/event_store.rs
+++ b/crates/apiari/src/buzz/task/event_store.rs
@@ -6,10 +6,11 @@
 //! Uses a separate `activity_events` table (not `task_events`) so it can carry
 //! richer fields: workspace, summary, source, and a JSON metadata blob.
 
+use std::path::Path;
+
 use chrono::{DateTime, Utc};
 use color_eyre::eyre::{Result, WrapErr};
 use rusqlite::{Connection, params};
-use std::path::Path;
 
 /// A single activity event in the task lifecycle or workspace feed.
 #[derive(Debug, Clone)]

--- a/crates/apiari/src/buzz/task/mod.rs
+++ b/crates/apiari/src/buzz/task/mod.rs
@@ -8,9 +8,8 @@ pub mod event_store;
 pub mod rules;
 pub mod store;
 
-pub use event_store::{ActivityEvent, ActivityEventStore};
-
 use chrono::{DateTime, Utc};
+pub use event_store::{ActivityEvent, ActivityEventStore};
 use serde::{Deserialize, Serialize};
 
 /// The stages a task moves through. These are the default stages.

--- a/crates/apiari/src/buzz/task/rules.rs
+++ b/crates/apiari/src/buzz/task/rules.rs
@@ -465,10 +465,11 @@ fn extract_pr_ref(signal: &SignalRecord) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::buzz::signal::{Severity, SignalRecord, SignalStatus};
     use chrono::Utc;
     use uuid::Uuid;
+
+    use super::*;
+    use crate::buzz::signal::{Severity, SignalRecord, SignalStatus};
 
     fn make_task(stage: TaskStage) -> Task {
         use crate::buzz::task::Task;

--- a/crates/apiari/src/buzz/task/store.rs
+++ b/crates/apiari/src/buzz/task/store.rs
@@ -7,8 +7,7 @@ use chrono::{DateTime, Utc};
 use color_eyre::eyre::{Result, WrapErr, eyre};
 use rusqlite::{Connection, params};
 
-use super::event_store::ActivityEventStore;
-use super::{Task, TaskEvent, TaskStage};
+use super::{Task, TaskEvent, TaskStage, event_store::ActivityEventStore};
 
 /// SQLite task store.
 pub struct TaskStore {
@@ -422,8 +421,9 @@ fn row_to_task_event(row: &rusqlite::Row<'_>) -> rusqlite::Result<TaskEvent> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use uuid::Uuid;
+
+    use super::*;
 
     fn make_task(workspace: &str, title: &str) -> Task {
         let now = Utc::now();

--- a/crates/apiari/src/buzz/watcher/email.rs
+++ b/crates/apiari/src/buzz/watcher/email.rs
@@ -16,9 +16,10 @@ use futures::TryStreamExt;
 use tracing::{info, warn};
 
 use super::Watcher;
-use crate::buzz::config::EmailMailboxConfig;
-use crate::buzz::signal::store::SignalStore;
-use crate::buzz::signal::{Severity, SignalStatus, SignalUpdate};
+use crate::buzz::{
+    config::EmailMailboxConfig,
+    signal::{Severity, SignalStatus, SignalUpdate, store::SignalStore},
+};
 
 /// Parsed email data (decoupled from IMAP for testability).
 #[derive(Debug, Clone)]

--- a/crates/apiari/src/buzz/watcher/github.rs
+++ b/crates/apiari/src/buzz/watcher/github.rs
@@ -3,8 +3,10 @@
 //! Queries open issues, PR review requests, watched labels, and CI status.
 //! Stateless — emits all signals every poll; the DB handles dedup via UNIQUE constraints.
 
-use std::collections::{HashMap, HashSet};
-use std::time::Instant;
+use std::{
+    collections::{HashMap, HashSet},
+    time::Instant,
+};
 
 use async_trait::async_trait;
 use color_eyre::Result;
@@ -12,9 +14,10 @@ use futures::future::join_all;
 use tracing::{info, warn};
 
 use super::Watcher;
-use crate::buzz::config::GithubWatcherConfig;
-use crate::buzz::signal::store::SignalStore;
-use crate::buzz::signal::{Severity, SignalUpdate};
+use crate::buzz::{
+    config::GithubWatcherConfig,
+    signal::{Severity, SignalUpdate, store::SignalStore},
+};
 
 /// Minimum remaining API calls before we skip the poll entirely.
 const RATE_LIMIT_CRITICAL: u32 = 50;

--- a/crates/apiari/src/buzz/watcher/linear.rs
+++ b/crates/apiari/src/buzz/watcher/linear.rs
@@ -7,8 +7,10 @@
 //!
 //! Read-only: no Linear mutation API calls are ever made.
 
-use std::collections::{HashMap, HashSet};
-use std::time::Duration;
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use color_eyre::Result;
@@ -18,9 +20,10 @@ use tracing::{info, warn};
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 use super::Watcher;
-use crate::buzz::config::{LinearReviewQueueEntry, LinearWatcherConfig};
-use crate::buzz::signal::store::SignalStore;
-use crate::buzz::signal::{Severity, SignalUpdate};
+use crate::buzz::{
+    config::{LinearReviewQueueEntry, LinearWatcherConfig},
+    signal::{Severity, SignalUpdate, store::SignalStore},
+};
 
 const SOURCE: &str = "linear_review_queue";
 

--- a/crates/apiari/src/buzz/watcher/mod.rs
+++ b/crates/apiari/src/buzz/watcher/mod.rs
@@ -23,9 +23,10 @@ use async_trait::async_trait;
 use color_eyre::Result;
 use tracing::info;
 
-use crate::buzz::signal::SignalUpdate;
-use crate::buzz::signal::store::SignalStore;
-use crate::config::Schedule;
+use crate::{
+    buzz::signal::{SignalUpdate, store::SignalStore},
+    config::Schedule,
+};
 
 /// A pluggable source that can be polled for new signals.
 #[async_trait]

--- a/crates/apiari/src/buzz/watcher/notion.rs
+++ b/crates/apiari/src/buzz/watcher/notion.rs
@@ -13,9 +13,10 @@ use color_eyre::Result;
 use tracing::{info, warn};
 
 use super::Watcher;
-use crate::buzz::config::NotionWatcherConfig;
-use crate::buzz::signal::store::SignalStore;
-use crate::buzz::signal::{Severity, SignalUpdate};
+use crate::buzz::{
+    config::NotionWatcherConfig,
+    signal::{Severity, SignalUpdate, store::SignalStore},
+};
 
 const NOTION_API_BASE: &str = "https://api.notion.com/v1";
 const NOTION_VERSION: &str = "2022-06-28";

--- a/crates/apiari/src/buzz/watcher/review_queue.rs
+++ b/crates/apiari/src/buzz/watcher/review_queue.rs
@@ -4,8 +4,10 @@
 //! review queue entry. Deduplicates across queries: lowest index (highest
 //! priority) wins. Source: `github_review_queue`.
 
-use std::collections::{HashMap, HashSet};
-use std::time::Duration;
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use color_eyre::Result;
@@ -15,9 +17,10 @@ use tracing::{info, warn};
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 use super::Watcher;
-use crate::buzz::config::{GithubWatcherConfig, ReviewQueueEntry};
-use crate::buzz::signal::store::SignalStore;
-use crate::buzz::signal::{Severity, SignalUpdate};
+use crate::buzz::{
+    config::{GithubWatcherConfig, ReviewQueueEntry},
+    signal::{Severity, SignalUpdate, store::SignalStore},
+};
 
 const SOURCE: &str = "github_review_queue";
 

--- a/crates/apiari/src/buzz/watcher/script.rs
+++ b/crates/apiari/src/buzz/watcher/script.rs
@@ -5,14 +5,14 @@ use std::process::Stdio;
 
 use async_trait::async_trait;
 use color_eyre::Result;
-use tokio::io::AsyncReadExt;
-use tokio::process::Command;
+use tokio::{io::AsyncReadExt, process::Command};
 use tracing::{debug, info, warn};
 
 use super::Watcher;
-use crate::buzz::config::ScriptWatcherConfig;
-use crate::buzz::signal::store::SignalStore;
-use crate::buzz::signal::{Severity, SignalUpdate};
+use crate::buzz::{
+    config::ScriptWatcherConfig,
+    signal::{Severity, SignalUpdate, store::SignalStore},
+};
 
 /// Maximum bytes of stdout/stderr to retain per stream per script execution.
 const MAX_OUTPUT_BYTES: usize = 10 * 1024;

--- a/crates/apiari/src/buzz/watcher/sentry.rs
+++ b/crates/apiari/src/buzz/watcher/sentry.rs
@@ -3,8 +3,7 @@
 //! Uses cross-poll dedup via seen_issues map to avoid re-emitting
 //! stale issues that reorder in Sentry's date-sorted results.
 
-use std::collections::HashMap;
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -16,9 +15,10 @@ use tracing::{info, warn};
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 use super::Watcher;
-use crate::buzz::config::SentryWatcherConfig;
-use crate::buzz::signal::store::SignalStore;
-use crate::buzz::signal::{Severity, SignalUpdate};
+use crate::buzz::{
+    config::SentryWatcherConfig,
+    signal::{Severity, SignalUpdate, store::SignalStore},
+};
 
 /// Per-issue metadata tracked across polls for dedup decisions.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/apiari/src/buzz/watcher/swarm.rs
+++ b/crates/apiari/src/buzz/watcher/swarm.rs
@@ -6,21 +6,28 @@
 //!
 //! Replaces the previous approach of polling `.swarm/state.json` on disk.
 
-use apiari_swarm::WorkerPhase;
-use apiari_swarm::client::{
-    DaemonRequest, DaemonResponse, WorkerInfo, global_socket_path, send_daemon_request, socket_path,
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use apiari_swarm::{
+    WorkerPhase,
+    client::{
+        DaemonRequest, DaemonResponse, WorkerInfo, global_socket_path, send_daemon_request,
+        socket_path,
+    },
 };
 use async_trait::async_trait;
 use color_eyre::Result;
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 use tracing::{info, warn};
 
 use super::Watcher;
-use crate::buzz::signal::store::SignalStore;
-use crate::buzz::signal::{Severity, SignalStatus, SignalUpdate};
+use crate::buzz::signal::{Severity, SignalStatus, SignalUpdate, store::SignalStore};
 
 /// Tracked state for a worktree between polls.
 #[derive(Debug, Clone)]
@@ -520,8 +527,10 @@ async fn connect_and_subscribe(
     work_dir: &Path,
     events: &Mutex<Vec<(String, WorkerPhase)>>,
 ) -> Result<()> {
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-    use tokio::net::UnixStream;
+    use tokio::{
+        io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+        net::UnixStream,
+    };
 
     // Try per-workspace socket first, then global
     let local = socket_path(work_dir);
@@ -565,8 +574,9 @@ async fn connect_and_subscribe(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use apiari_swarm::core::state::{SwarmState, WorkerPhase};
+
+    use super::*;
 
     /// Helper to build a minimal valid WorktreeState JSON object.
     fn wt_json(id: &str, extras: &str) -> String {

--- a/crates/apiari/src/config.rs
+++ b/crates/apiari/src/config.rs
@@ -2,11 +2,14 @@
 //!
 //! Each workspace is a self-contained TOML file at `~/.config/apiari/workspaces/{name}.toml`.
 
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
 use color_eyre::eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::process::Command;
 
 /// Root directory for all apiari config.
 pub fn config_dir() -> PathBuf {
@@ -1132,8 +1135,10 @@ fn default_swarm_agent() -> String {
 pub fn to_pipeline_rules(
     config: &PipelineConfig,
 ) -> Vec<crate::buzz::pipeline::rule::PipelineRule> {
-    use crate::buzz::pipeline::rule::{PipelineAction, PipelineRule};
-    use crate::buzz::signal::Severity;
+    use crate::buzz::{
+        pipeline::rule::{PipelineAction, PipelineRule},
+        signal::Severity,
+    };
 
     config
         .rules

--- a/crates/apiari/src/config_set.rs
+++ b/crates/apiari/src/config_set.rs
@@ -3,8 +3,9 @@
 //! Parses dot-separated key paths (e.g. `telegram.bot_token`), sets the value,
 //! validates the result against `WorkspaceConfig`, and writes it back.
 
-use color_eyre::eyre::{Result, WrapErr, bail};
 use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Result, WrapErr, bail};
 
 /// Find the workspace config file path.
 ///

--- a/crates/apiari/src/config_validate.rs
+++ b/crates/apiari/src/config_validate.rs
@@ -3,8 +3,9 @@
 //! Parses each workspace config and checks it deserializes into `WorkspaceConfig`.
 //! Prints a summary line per workspace and exits non-zero if any fail.
 
-use color_eyre::eyre::{Result, WrapErr};
 use std::path::{Component, Path};
+
+use color_eyre::eyre::{Result, WrapErr};
 
 /// Run validation for one or all workspace configs.
 ///
@@ -93,8 +94,9 @@ fn run_with_dir(workspace: Option<&str>, dir: &Path) -> Result<i32> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::io::Write;
+
+    use super::*;
 
     #[test]
     fn test_validate_valid_config() {

--- a/crates/apiari/src/daemon/doctor.rs
+++ b/crates/apiari/src/daemon/doctor.rs
@@ -3,9 +3,7 @@
 //! Inspects the workspace config and `.apiari/` scaffold, reports issues,
 //! and optionally fixes them with `--fix`.
 
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::Path;
+use std::{fs::OpenOptions, io::Write, path::Path};
 
 use crate::config::{CURRENT_CONFIG_VERSION, WorkspaceConfig};
 

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -7,41 +7,40 @@ pub mod doctor;
 pub mod morning_brief;
 pub mod socket;
 
+use std::{collections::HashMap, sync::Arc};
+
 use color_eyre::eyre::{Result, WrapErr};
-use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
-use crate::git_safety::GitSafetyHooks;
-
-use crate::buzz::channel::telegram::TelegramChannel;
-use crate::buzz::channel::{Channel, ChannelEvent, OutboundMessage};
-use crate::buzz::conversation::ConversationStore;
-use crate::buzz::coordinator::prompt::format_signal_summary;
-use crate::buzz::coordinator::skills::{
-    SkillContext, build_skills_prompt, default_coordinator_disallowed_tools,
-    default_coordinator_tools, observe_coordinator_disallowed_tools, observe_coordinator_tools,
-};
-use crate::buzz::coordinator::{Coordinator, CoordinatorEvent, DispatchBundle};
-use crate::buzz::daemon::config as buzz_daemon_config;
-use crate::buzz::pipeline::Pipeline;
-use crate::buzz::signal::Severity;
-use crate::buzz::signal::store::SignalStore;
-use crate::buzz::watcher::WatcherRegistry;
-use crate::buzz::watcher::email::EmailWatcher;
-use crate::buzz::watcher::github::GithubWatcher;
-use crate::buzz::watcher::linear::LinearWatcher;
-use crate::buzz::watcher::notion::NotionWatcher;
-use crate::buzz::watcher::review_queue::ReviewQueueWatcher;
-use crate::buzz::watcher::script::ScriptWatcher;
-use crate::buzz::watcher::sentry::SentryWatcher;
-use crate::buzz::watcher::swarm::SwarmWatcher;
-
-use crate::config::{
-    self, Workspace, WorkspaceConfig, db_path, log_path, pid_path, to_buzz_config,
-    to_pipeline_rules,
+use crate::{
+    buzz::{
+        channel::{Channel, ChannelEvent, OutboundMessage, telegram::TelegramChannel},
+        conversation::ConversationStore,
+        coordinator::{
+            Coordinator, CoordinatorEvent, DispatchBundle,
+            prompt::format_signal_summary,
+            skills::{
+                SkillContext, build_skills_prompt, default_coordinator_disallowed_tools,
+                default_coordinator_tools, observe_coordinator_disallowed_tools,
+                observe_coordinator_tools,
+            },
+        },
+        daemon::config as buzz_daemon_config,
+        pipeline::Pipeline,
+        signal::{Severity, store::SignalStore},
+        watcher::{
+            WatcherRegistry, email::EmailWatcher, github::GithubWatcher, linear::LinearWatcher,
+            notion::NotionWatcher, review_queue::ReviewQueueWatcher, script::ScriptWatcher,
+            sentry::SentryWatcher, swarm::SwarmWatcher,
+        },
+    },
+    config::{
+        self, Workspace, WorkspaceConfig, db_path, log_path, pid_path, to_buzz_config,
+        to_pipeline_rules,
+    },
+    git_safety::GitSafetyHooks,
 };
 
 /// Why the event loop exited.

--- a/crates/apiari/src/daemon/morning_brief.rs
+++ b/crates/apiari/src/daemon/morning_brief.rs
@@ -4,23 +4,26 @@
 //! and, if so, builds a prompt from open signals + worker state, invokes
 //! a fresh coordinator session, and sends the result via Telegram.
 
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
+use apiari_claude_sdk::SessionOptions;
 use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 use chrono_tz::Tz;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
 
-use apiari_claude_sdk::SessionOptions;
-
-use crate::buzz::channel::telegram::TelegramChannel;
-use crate::buzz::channel::{Channel, OutboundMessage};
-use crate::buzz::coordinator::Coordinator;
-use crate::buzz::signal::{Severity, SignalRecord};
-use crate::config::MorningBriefConfig;
-
 use super::socket;
+use crate::{
+    buzz::{
+        channel::{Channel, OutboundMessage, telegram::TelegramChannel},
+        coordinator::Coordinator,
+        signal::{Severity, SignalRecord},
+    },
+    config::MorningBriefConfig,
+};
 
 // ── Swarm state types (minimal, for reading .swarm/state.json) ──
 
@@ -342,9 +345,10 @@ pub async fn execute_brief(params: BriefParams) {
 
 #[cfg(test)]
 mod tests {
+    use chrono::TimeZone;
+
     use super::*;
     use crate::buzz::signal::{Severity, SignalStatus};
-    use chrono::TimeZone;
 
     fn make_signal(source: &str, title: &str, severity: Severity) -> SignalRecord {
         SignalRecord {

--- a/crates/apiari/src/daemon/socket.rs
+++ b/crates/apiari/src/daemon/socket.rs
@@ -6,12 +6,17 @@
 //! - Per-client `mpsc::unbounded_channel` for unicast (Token/Done/Error for the requesting client)
 //! - `tokio::sync::broadcast` for Activity events pushed to ALL connected clients
 
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
-use tokio::net::{TcpListener, UnixListener};
-use tokio::sync::{broadcast, mpsc};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader},
+    net::{TcpListener, UnixListener},
+    sync::{broadcast, mpsc},
+};
 use tracing::{error, info, warn};
 
 // ── Protocol types ──────────────────────────────────────

--- a/crates/apiari/src/git_safety.rs
+++ b/crates/apiari/src/git_safety.rs
@@ -3,9 +3,11 @@
 //! Takes a snapshot of `git status --porcelain` across all repo subdirectories
 //! in a workspace, and can diff two snapshots to find newly dirty files.
 
-use std::any::Any;
-use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::{
+    any::Any,
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 use crate::buzz::coordinator::SafetyHooks;
 

--- a/crates/apiari/src/main.rs
+++ b/crates/apiari/src/main.rs
@@ -8,9 +8,10 @@ pub mod shells;
 mod ui;
 mod validate_bash;
 
+use std::fs;
+
 use clap::{CommandFactory, Parser, Subcommand};
 use color_eyre::eyre::Result;
-use std::fs;
 use tracing_subscriber::fmt::writer::BoxMakeWriter;
 
 #[derive(Parser)]

--- a/crates/apiari/src/shells/mod.rs
+++ b/crates/apiari/src/shells/mod.rs
@@ -4,8 +4,7 @@
 //! persistent shell windows — created automatically with workers or manually
 //! by the user.
 
-use std::path::Path;
-use std::process::Command;
+use std::{path::Path, process::Command};
 
 /// Information about a single tmux window.
 #[derive(Debug, Clone)]

--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -1,18 +1,20 @@
 //! App state machine for the apiari TUI.
 
-use crate::buzz::coordinator::memory::MemoryStore;
-use crate::buzz::signal::store::SignalStore;
-use crate::buzz::signal::{Severity, SignalRecord};
-use apiari_tui::conversation::ConversationEntry;
+use std::{
+    collections::HashMap,
+    io::{BufRead, Seek, SeekFrom},
+    path::{Path, PathBuf},
+    time::Instant,
+};
+
+use apiari_tui::{conversation::ConversationEntry, scroll::ScrollState};
 use chrono::{DateTime, Datelike, Local, TimeZone, Utc};
 use serde::Deserialize;
-use std::collections::HashMap;
-use std::io::{BufRead, Seek, SeekFrom};
-use std::path::Path;
-use std::time::Instant;
 
-use apiari_tui::scroll::ScrollState;
-use std::path::PathBuf;
+use crate::buzz::{
+    coordinator::memory::MemoryStore,
+    signal::{Severity, SignalRecord, store::SignalStore},
+};
 
 /// A tmux operation to be executed asynchronously after apply_worker_update.
 pub(super) enum PendingShellOp {
@@ -27,8 +29,10 @@ pub(super) enum PendingShellOp {
     },
 }
 
-use crate::buzz::conversation::ConversationStore;
-use crate::config::{self, Workspace};
+use crate::{
+    buzz::conversation::ConversationStore,
+    config::{self, Workspace},
+};
 
 /// Maximum number of chat history messages to load from a previous session.
 const CHAT_HISTORY_LIMIT: usize = 20;
@@ -4132,9 +4136,10 @@ fn is_top_level_watcher(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
+
     use super::*;
     use crate::buzz::signal::{Severity, SignalRecord, SignalStatus};
-    use chrono::Utc;
 
     fn make_signal(source: &str, external_id: &str, metadata: Option<&str>) -> SignalRecord {
         SignalRecord {

--- a/crates/apiari/src/ui/daemon_client.rs
+++ b/crates/apiari/src/ui/daemon_client.rs
@@ -1,12 +1,17 @@
 //! TUI-side daemon client — connects to daemon via Unix socket or TCP.
 
 use std::path::Path;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
-use tokio::net::{TcpStream, UnixStream};
+
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines},
+    net::{TcpStream, UnixStream},
+};
 use tracing::{debug, info};
 
-use crate::config::DaemonEndpoint;
-use crate::daemon::socket::{DaemonRequest, DaemonResponse};
+use crate::{
+    config::DaemonEndpoint,
+    daemon::socket::{DaemonRequest, DaemonResponse},
+};
 
 /// Transport-agnostic line reader + writer.
 enum Transport {

--- a/crates/apiari/src/ui/history.rs
+++ b/crates/apiari/src/ui/history.rs
@@ -1,10 +1,13 @@
 //! Chat history persistence — append-only JSONL in `~/.config/apiari/chat_history/`.
 
+use std::{
+    fs::OpenOptions,
+    io::{BufRead, Write},
+    path::PathBuf,
+};
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::fs::OpenOptions;
-use std::io::{BufRead, Write};
-use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -8,29 +8,35 @@ pub mod render;
 pub mod settings;
 pub mod theme;
 
+use std::{io::stdout, time::Duration};
+
 use app::{App, AppUpdate, Mode, Panel, PendingAction, View, review_signal_target};
 use color_eyre::Result;
-use crossterm::ExecutableCommand;
-use crossterm::event::{Event, EventStream, KeyCode, KeyModifiers};
-use crossterm::terminal::{
-    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+use crossterm::{
+    ExecutableCommand,
+    event::{Event, EventStream, KeyCode, KeyModifiers},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use futures::StreamExt;
 use ratatui::prelude::*;
 use settings::SettingsState;
-use std::io::stdout;
-use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::info;
 
-use crate::buzz::coordinator::skills::{
-    build_skills_prompt, default_coordinator_disallowed_tools, default_coordinator_tools,
+use crate::{
+    buzz::{
+        coordinator::{
+            Coordinator, CoordinatorEvent,
+            skills::{
+                build_skills_prompt, default_coordinator_disallowed_tools,
+                default_coordinator_tools,
+            },
+        },
+        signal::store::SignalStore,
+    },
+    config,
+    git_safety::GitSafetyHooks,
 };
-use crate::buzz::coordinator::{Coordinator, CoordinatorEvent};
-use crate::buzz::signal::store::SignalStore;
-
-use crate::config;
-use crate::git_safety::GitSafetyHooks;
 
 // ── Channel types ────────────────────────────────────────
 
@@ -2615,8 +2621,9 @@ fn build_coordinator(workspace_name: &str) -> Option<Coordinator> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    use super::*;
 
     /// Build a minimal App for key-handling tests (no file I/O).
     fn test_app() -> App {

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -2,18 +2,21 @@
 
 use std::borrow::Cow;
 
-use ratatui::Frame;
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
-use ratatui::symbols::border;
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
-
 use apiari_tui::conversation;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    symbols::border,
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use super::app::{self, App, ChatLine, Mode, Panel, PendingAction, View};
-use super::theme;
+use super::{
+    app::{self, App, ChatLine, Mode, Panel, PendingAction, View},
+    theme,
+};
 
 const SPINNER: &[&str] = &["|", "/", "-", "\\"];
 

--- a/crates/apiari/src/ui/settings.rs
+++ b/crates/apiari/src/ui/settings.rs
@@ -4,10 +4,12 @@
 
 use std::collections::HashMap;
 
-use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
-use ratatui::prelude::*;
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    prelude::*,
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+};
 
 use super::theme;
 use crate::config::{self, WorkspaceConfig};

--- a/crates/apiari/src/validate_bash.rs
+++ b/crates/apiari/src/validate_bash.rs
@@ -10,9 +10,12 @@
 //! per-command denials (tool remains available) rather than hook errors
 //! (which can deregister the tool for the session).
 
-use crate::buzz::coordinator::audit::{self, BashClassification};
-use crate::config;
 use std::io::Read;
+
+use crate::{
+    buzz::coordinator::audit::{self, BashClassification},
+    config,
+};
 
 /// The hook's verdict: either allow (no stdout) or deny (JSON on stdout).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -168,8 +171,9 @@ fn extract_command(input: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::sync::Mutex;
+
+    use super::*;
 
     /// Tests that mutate HOME must hold this lock to avoid interfering with each other.
     /// Note: this only serializes tests within this module. Tests in other modules that


### PR DESCRIPTION
## Summary

- Runs `cargo +nightly fmt` to apply the full rustfmt.toml config including nightly-only settings: `imports_granularity = "Crate"` and `group_imports = "StdExternalCrate"`. Stable fmt/clippy CI still passes.
- Reviewer→task metadata linking (`reviewer_worker_id` written after worker dispatch) was already implemented in the previous PR (#196), so no code changes needed there.

## Test plan

- [ ] CI fmt check passes (stable rustfmt ignores nightly-only settings, so nightly-formatted imports are accepted)
- [ ] CI clippy passes with `-D warnings`
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)