### PR TITLE
feat: add task detail view when selecting a kanban card

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -185,6 +185,11 @@ pub(super) enum AppUpdate {
     },
     Tasks(Vec<(String, Vec<crate::buzz::task::Task>)>),
     ActivityEvents(Vec<(String, Vec<crate::buzz::task::ActivityEvent>)>),
+    TaskTimeline {
+        workspace: String,
+        task_id: String,
+        events: Vec<crate::buzz::task::ActivityEvent>,
+    },
 }
 
 // ── Worker info from state.json ───────────────────────────
@@ -266,6 +271,18 @@ pub struct KanbanCard {
     pub source: String,
     pub url: Option<String>,
     pub entered_stage_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// State for the task detail panel (shown when pressing Enter on a task kanban card).
+#[derive(Debug, Clone)]
+pub struct TaskDetailState {
+    pub task_id: String,
+    pub task_title: String,
+    pub stage: String,
+    pub worker_id: Option<String>,
+    pub pr_number: Option<i64>,
+    pub events: Vec<crate::buzz::task::ActivityEvent>,
+    pub scroll: usize,
 }
 
 /// Build kanban cards from tasks. Task cards take priority over worker/signal cards
@@ -996,6 +1013,8 @@ pub struct WorkspaceState {
     pub activity_selected: usize,
     /// Scroll offset for the activity feed.
     pub activity_scroll: usize,
+    /// Task detail panel state (Some when viewing a task's timeline).
+    pub viewing_task: Option<TaskDetailState>,
 }
 
 // ── App ───────────────────────────────────────────────────
@@ -1129,6 +1148,7 @@ impl App {
                     activity_events: Vec::new(),
                     activity_selected: 0,
                     activity_scroll: 0,
+                    viewing_task: None,
                 }
             })
             .collect();
@@ -1282,6 +1302,7 @@ impl App {
             activity_events: Vec::new(),
             activity_selected: 0,
             activity_scroll: 0,
+            viewing_task: None,
         };
 
         let setup = SetupState {
@@ -1422,6 +1443,7 @@ impl App {
             activity_events: Vec::new(),
             activity_selected: 0,
             activity_scroll: 0,
+            viewing_task: None,
         };
 
         ws_state.chat_history.push(ChatLine::Assistant(
@@ -1629,6 +1651,7 @@ impl App {
             activity_events: Vec::new(),
             activity_selected: 0,
             activity_scroll: 0,
+            viewing_task: None,
         };
 
         if is_add {
@@ -3257,6 +3280,64 @@ impl App {
         self.needs_redraw = true;
     }
 
+    /// Apply a task timeline update to the detail panel.
+    pub(super) fn apply_task_timeline_update(
+        &mut self,
+        workspace: &str,
+        task_id: &str,
+        events: Vec<crate::buzz::task::ActivityEvent>,
+    ) {
+        if let Some(ws) = self.workspaces.iter_mut().find(|ws| ws.name == workspace)
+            && let Some(ref mut detail) = ws.viewing_task
+            && detail.task_id == task_id
+        {
+            detail.events = events;
+        }
+        self.needs_redraw = true;
+    }
+
+    /// Open the task detail panel for the currently selected kanban card.
+    ///
+    /// Returns `Some((workspace_name, task_id))` if a task card was selected,
+    /// so the caller can spawn a background timeline load.
+    pub fn open_task_detail_for_selected(&mut self) -> Option<(String, String)> {
+        let allocated_h = self.kanban_allocated_height.get();
+        let ws = self.current_ws_mut()?;
+        let (stage, idx) = ws.kanban_selected?;
+        let visible = ws_kanban_visible_count(ws, stage, allocated_h);
+        if idx >= visible {
+            return None;
+        }
+        let card = ws
+            .kanban_cards
+            .iter()
+            .filter(|c| c.stage == stage)
+            .nth(idx)?;
+        let task_id = card.id.strip_prefix("task:")?.to_string();
+        let title = card.title.clone();
+
+        // Look up full task for extra metadata
+        let task = ws.tasks.iter().find(|t| t.id == task_id);
+        let worker_id = task.and_then(|t| t.worker_id.clone());
+        let pr_number = task.and_then(|t| t.pr_number);
+        let stage_str = task
+            .map(|t| t.stage.as_str().to_string())
+            .unwrap_or_default();
+        let workspace_name = ws.name.clone();
+
+        ws.viewing_task = Some(TaskDetailState {
+            task_id: task_id.clone(),
+            task_title: title,
+            stage: stage_str,
+            worker_id,
+            pr_number,
+            events: Vec::new(),
+            scroll: 0,
+        });
+        self.needs_redraw = true;
+        Some((workspace_name, task_id))
+    }
+
     /// Apply extras data from background refresh.
     pub(super) fn apply_extras_update(
         &mut self,
@@ -4739,6 +4820,7 @@ mod tests {
             activity_events: Vec::new(),
             activity_selected: 0,
             activity_scroll: 0,
+            viewing_task: None,
         };
         app.workspaces = vec![ws];
         app.setup = None;
@@ -5000,6 +5082,7 @@ mod tests {
             activity_events: Vec::new(),
             activity_selected: 0,
             activity_scroll: 0,
+            viewing_task: None,
         }
     }
 

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -2791,6 +2791,7 @@ mod tests {
             activity_events: Vec::new(),
             activity_selected: 0,
             activity_scroll: 0,
+            viewing_task: None,
         };
         let ws_name = ws.name.clone();
         App {

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -110,6 +110,10 @@ enum KeyAction {
     SetupComplete,
     AddWorkspace,
     OpenSettings,
+    LoadTaskTimeline {
+        workspace: String,
+        task_id: String,
+    },
     Redraw,
 }
 
@@ -458,6 +462,33 @@ async fn event_loop(
                             continue;
                         }
 
+                        // Task detail: load timeline in background
+                        if let KeyAction::LoadTaskTimeline {
+                            ref workspace,
+                            ref task_id,
+                        } = action
+                        {
+                            let ws_name = workspace.clone();
+                            let t_id = task_id.clone();
+                            let db = crate::config::db_path();
+                            let tx = update_tx.clone();
+                            tokio::task::spawn_blocking(move || {
+                                if let Ok(store) =
+                                    crate::buzz::task::ActivityEventStore::open(&db)
+                                    && let Ok(events) =
+                                        store.get_task_timeline(&ws_name, &t_id)
+                                {
+                                    let _ = tx.blocking_send(AppUpdate::TaskTimeline {
+                                        workspace: ws_name,
+                                        task_id: t_id,
+                                        events,
+                                    });
+                                }
+                            });
+                            app.needs_redraw = true;
+                            continue;
+                        }
+
                         if let Some(true) = handle_action(&mut app, action, user_tx).await {
                             break;
                         }
@@ -578,6 +609,31 @@ async fn event_loop(
                     }
                     AppUpdate::ActivityEvents(data) => {
                         app.apply_activity_update(data);
+                        // Auto-refresh task timeline if the detail panel is open
+                        if let Some(ws) = app.current_ws()
+                            && let Some(ref detail) = ws.viewing_task
+                        {
+                            let ws_name = ws.name.clone();
+                            let task_id = detail.task_id.clone();
+                            let db = crate::config::db_path();
+                            let tx = update_tx.clone();
+                            tokio::task::spawn_blocking(move || {
+                                if let Ok(store) =
+                                    crate::buzz::task::ActivityEventStore::open(&db)
+                                    && let Ok(events) =
+                                        store.get_task_timeline(&ws_name, &task_id)
+                                {
+                                    let _ = tx.blocking_send(AppUpdate::TaskTimeline {
+                                        workspace: ws_name,
+                                        task_id,
+                                        events,
+                                    });
+                                }
+                            });
+                        }
+                    }
+                    AppUpdate::TaskTimeline { workspace, task_id, events } => {
+                        app.apply_task_timeline_update(&workspace, &task_id, events);
                     }
                     AppUpdate::ShellWindows(data) => {
                         for (name, windows) in &data {
@@ -858,6 +914,49 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
         return handle_dashboard_chat_key(app, key);
     }
 
+    // Task detail panel: intercept navigation keys while open
+    if app.current_ws().is_some_and(|ws| ws.viewing_task.is_some()) {
+        match key.code {
+            KeyCode::Esc => {
+                if let Some(ws) = app.current_ws_mut() {
+                    ws.viewing_task = None;
+                }
+                app.needs_redraw = true;
+                return KeyAction::Redraw;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if let Some(ws) = app.current_ws_mut()
+                    && let Some(ref mut d) = ws.viewing_task
+                {
+                    d.scroll = d.scroll.saturating_add(1);
+                }
+                app.needs_redraw = true;
+                return KeyAction::Redraw;
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if let Some(ws) = app.current_ws_mut()
+                    && let Some(ref mut d) = ws.viewing_task
+                {
+                    d.scroll = d.scroll.saturating_sub(1);
+                }
+                app.needs_redraw = true;
+                return KeyAction::Redraw;
+            }
+            KeyCode::Char('r') => {
+                let info = app.current_ws().and_then(|ws| {
+                    ws.viewing_task
+                        .as_ref()
+                        .map(|d| (ws.name.clone(), d.task_id.clone()))
+                });
+                if let Some((workspace, task_id)) = info {
+                    return KeyAction::LoadTaskTimeline { workspace, task_id };
+                }
+                return KeyAction::Redraw;
+            }
+            _ => {} // other keys fall through to normal handling
+        }
+    }
+
     // When a panel is zoomed full-screen, Tab cycles to the next panel (stays zoomed)
     if app.zoomed_panel.is_some() {
         match key.code {
@@ -956,6 +1055,27 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
                 return KeyAction::Redraw;
             }
             KeyCode::Enter => {
+                // For task cards: open the detail panel.
+                // For other cards: inject context into chat (legacy behavior).
+                if let Some((workspace, task_id)) = app.open_task_detail_for_selected() {
+                    return KeyAction::LoadTaskTimeline { workspace, task_id };
+                }
+                let maybe_msg = app.kanban_action_selected();
+                if let Some(msg) = maybe_msg {
+                    let msg_len = msg.len();
+                    if let Some(ws) = app.current_ws_mut() {
+                        ws.input = msg;
+                        ws.cursor_pos = msg_len;
+                        ws.has_unread_response = false;
+                    }
+                    app.focused_panel = Panel::Chat;
+                    app.chat_focused = true;
+                }
+                app.needs_redraw = true;
+                return KeyAction::Redraw;
+            }
+            // 'c' injects context into chat (works for both task and non-task cards)
+            KeyCode::Char('c') => {
                 let maybe_msg = app.kanban_action_selected();
                 if let Some(msg) = maybe_msg {
                     let msg_len = msg.len();
@@ -2086,6 +2206,7 @@ async fn handle_action(
         KeyAction::OpenSettings
         | KeyAction::SetupComplete
         | KeyAction::AddWorkspace
+        | KeyAction::LoadTaskTimeline { .. }
         | KeyAction::None
         | KeyAction::Redraw => {}
     }

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -214,16 +214,28 @@ fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
 
     draw_kanban_strip(frame, app, ws, rows[0]);
 
-    // Bottom area: Chat + optional Triage sidebar
-    if ws.triage_sidebar_open {
+    // Bottom area: Task detail / Chat + optional Triage sidebar
+    let bottom = rows[1];
+    if ws.viewing_task.is_some() {
+        if ws.triage_sidebar_open {
+            let cols = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
+                .split(bottom);
+            draw_task_detail_panel(frame, ws, cols[0]);
+            draw_triage_sidebar(frame, ws, cols[1]);
+        } else {
+            draw_task_detail_panel(frame, ws, bottom);
+        }
+    } else if ws.triage_sidebar_open {
         let cols = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
-            .split(rows[1]);
+            .split(bottom);
         draw_chat_panel(frame, app, ws, cols[0]);
         draw_triage_sidebar(frame, ws, cols[1]);
     } else {
-        draw_chat_panel(frame, app, ws, rows[1]);
+        draw_chat_panel(frame, app, ws, bottom);
     }
 
     // Onboarding: dim kanban area if Home panel not revealed
@@ -997,6 +1009,221 @@ fn draw_activity_view(frame: &mut Frame, ws: &app::WorkspaceState, area: Rect) {
             x: inner.x,
             y: more_y,
             width: inner.width,
+            height: 1,
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                format!(" +{more} more"),
+                Style::default()
+                    .fg(theme::STEEL)
+                    .add_modifier(Modifier::DIM),
+            ))),
+            more_area,
+        );
+    }
+}
+
+fn draw_task_detail_panel(frame: &mut Frame, ws: &app::WorkspaceState, area: Rect) {
+    let detail = match ws.viewing_task.as_ref() {
+        Some(d) => d,
+        None => return,
+    };
+
+    let title = format!(
+        " Task: {} ",
+        truncate_to_width(&detail.task_title, (area.width as usize).saturating_sub(12))
+    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_set(border::ROUNDED)
+        .border_style(Style::default().fg(theme::FROST))
+        .style(Style::default().bg(theme::COMB))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(theme::POLLEN)
+                .add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.height < 4 {
+        return;
+    }
+
+    // ── Metadata line ────────────────────────────────────
+    let meta_area = Rect {
+        x: inner.x,
+        y: inner.y,
+        width: inner.width,
+        height: 1,
+    };
+    let mut meta_spans: Vec<Span> = Vec::new();
+    if let Some(ref wid) = detail.worker_id {
+        let short = if wid.len() > 12 {
+            &wid[wid.len() - 8..]
+        } else {
+            wid.as_str()
+        };
+        meta_spans.push(Span::styled(
+            format!(" Worker: {short}"),
+            Style::default().fg(theme::FROST),
+        ));
+    }
+    if let Some(pr) = detail.pr_number {
+        meta_spans.push(Span::styled(
+            format!("  PR: #{pr}"),
+            Style::default().fg(theme::MINT),
+        ));
+    }
+    if !detail.stage.is_empty() {
+        meta_spans.push(Span::styled(
+            format!("  Stage: {}", detail.stage),
+            Style::default().fg(theme::POLLEN),
+        ));
+    }
+    frame.render_widget(Paragraph::new(Line::from(meta_spans)), meta_area);
+
+    // ── Divider ──────────────────────────────────────────
+    let div_area = Rect {
+        x: inner.x,
+        y: inner.y + 1,
+        width: inner.width,
+        height: 1,
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "─".repeat(inner.width as usize),
+            Style::default().fg(theme::STEEL),
+        ))),
+        div_area,
+    );
+
+    // ── Footer hint line ─────────────────────────────────
+    let footer_y = inner.y + inner.height.saturating_sub(1);
+    let footer_area = Rect {
+        x: inner.x,
+        y: footer_y,
+        width: inner.width,
+        height: 1,
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(" [Esc]", theme::key_hint()),
+            Span::styled(" Close  ", theme::key_desc()),
+            Span::styled("[r]", theme::key_hint()),
+            Span::styled(" Refresh  ", theme::key_desc()),
+            Span::styled("[j/k]", theme::key_hint()),
+            Span::styled(" Scroll", theme::key_desc()),
+        ])),
+        footer_area,
+    );
+
+    // ── Events list ──────────────────────────────────────
+    let events_y = inner.y + 2;
+    // Reserve 1 row for footer, 2 for meta+divider
+    let events_h = inner.height.saturating_sub(3);
+    let events_area = Rect {
+        x: inner.x,
+        y: events_y,
+        width: inner.width,
+        height: events_h,
+    };
+
+    let events = &detail.events;
+    if events.is_empty() {
+        let msg = " Loading timeline…";
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                msg,
+                Style::default().fg(theme::SMOKE),
+            ))),
+            events_area,
+        );
+        return;
+    }
+
+    // 2 lines per event: summary line + detail/age line
+    const LINES_PER_EVENT: usize = 2;
+    let visible = (events_area.height as usize / LINES_PER_EVENT).min(events.len());
+    let scroll = detail.scroll.min(events.len().saturating_sub(visible));
+
+    let mut y = 0u16;
+    for event in events.iter().skip(scroll).take(visible) {
+        if y + 1 > events_area.height {
+            break;
+        }
+
+        let (type_icon, type_color) = match event.event_type.as_str() {
+            "stage_change" => ("→", theme::MINT),
+            "signal" => ("●", theme::HONEY),
+            "worker" => ("◆", Color::Rgb(100, 180, 220)),
+            "review" => ("★", Color::Rgb(180, 120, 220)),
+            "pr" => ("◆", Color::Rgb(100, 200, 140)),
+            _ => ("·", theme::SMOKE),
+        };
+
+        let local_time = event.created_at.with_timezone(&chrono::Local);
+        let time_str = local_time.format("%H:%M").to_string();
+
+        let age = chrono::Utc::now().signed_duration_since(event.created_at);
+        let age_str = format_age(&age);
+
+        // Line 1: time  icon  summary
+        let line1_area = Rect {
+            x: events_area.x,
+            y: events_area.y + y,
+            width: events_area.width,
+            height: 1,
+        };
+        let summary_max = (events_area.width as usize).saturating_sub(10);
+        let line1 = Line::from(vec![
+            Span::styled(format!(" {time_str} "), Style::default().fg(theme::SMOKE)),
+            Span::styled(format!("{type_icon} "), Style::default().fg(type_color)),
+            Span::styled(
+                truncate_to_width(&event.summary, summary_max),
+                Style::default().fg(theme::FROST),
+            ),
+        ]);
+        frame.render_widget(Paragraph::new(line1), line1_area);
+
+        // Line 2: detail/source  ·  age
+        if y + 1 < events_area.height {
+            let line2_area = Rect {
+                x: events_area.x,
+                y: events_area.y + y + 1,
+                width: events_area.width,
+                height: 1,
+            };
+            let detail_text = event
+                .detail
+                .as_deref()
+                .or(event.source.as_deref())
+                .unwrap_or("");
+            let age_sfx = format!(" · {age_str}");
+            let detail_max = (events_area.width as usize)
+                .saturating_sub(10 + UnicodeWidthStr::width(age_sfx.as_str()));
+            let line2 = Line::from(vec![
+                Span::raw("        "),
+                Span::styled(
+                    truncate_to_width(detail_text, detail_max),
+                    Style::default().fg(Color::Rgb(140, 135, 125)),
+                ),
+                Span::styled(age_sfx, Style::default().fg(Color::Rgb(80, 77, 70))),
+            ]);
+            frame.render_widget(Paragraph::new(line2), line2_area);
+        }
+
+        y += LINES_PER_EVENT as u16;
+    }
+
+    // "+N more" indicator
+    if events.len() > visible + scroll && visible + scroll < events.len() {
+        let more = events.len() - visible - scroll;
+        let more_area = Rect {
+            x: events_area.x,
+            y: events_area.y + events_area.height.saturating_sub(1),
+            width: events_area.width,
             height: 1,
         };
         frame.render_widget(


### PR DESCRIPTION
## Summary

- Press **Enter** on any task kanban card to open a scrollable **Task Detail Panel** replacing the chat area
- The panel shows the full lifecycle timeline for the task (stage changes, worker spawns, review verdicts, PR opens, signals, notes)
- **'c'** injects context into chat as before (the old Enter behavior); **Esc** closes the panel
- Timeline auto-refreshes every 5 seconds via the existing activity-feed tick
- **'r'** triggers a manual refresh; **j/k** scroll through many events

## Implementation

**`app.rs`**
- New `TaskDetailState` struct: `task_id`, `task_title`, `stage`, `worker_id`, `pr_number`, `events`, `scroll`
- `viewing_task: Option<TaskDetailState>` field on `WorkspaceState`
- `AppUpdate::TaskTimeline` variant for background load results
- `open_task_detail_for_selected()` — finds the selected task card and initialises the panel
- `apply_task_timeline_update()` — updates `events` when background load completes

**`mod.rs`**
- `KeyAction::LoadTaskTimeline { workspace, task_id }` — triggers a `spawn_blocking` timeline query
- Enter on task cards calls `open_task_detail_for_selected()` and returns `LoadTaskTimeline`; 'c' injects chat context
- Task detail key block (before kanban navigation): Esc closes, j/k scroll, r refreshes
- `AppUpdate::ActivityEvents` handler also spawns a timeline refresh when the detail panel is open

**`render.rs`**
- `draw_task_detail_panel()`: metadata header (worker/PR/stage), divider, event list with HH:MM timestamps and event-type icons, key-hint footer
- Dashboard layout uses detail panel in place of chat when `viewing_task.is_some()`

## Test plan

- [ ] Open a workspace with active tasks on the kanban strip
- [ ] Press Enter on a task card — detail panel should open with "Loading timeline…" then populate
- [ ] Verify j/k scroll through many events
- [ ] Verify Esc returns to normal chat layout
- [ ] Verify 'c' still injects context into the chat input for task cards
- [ ] Verify Enter on a non-task card (worker/signal) still injects context (old behavior)
- [ ] Verify timeline refreshes automatically while the panel is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)