### PR TITLE
feat: auto-close reviewer workers after verdict is processed

### DIFF
--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -2091,6 +2091,17 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                                                         }
                                                                                     });
                                                                                 }
+
+                                                                                // Auto-close the reviewer worker — it has delivered its verdict
+                                                                                let swarm_for_close = crate::buzz::coordinator::swarm_client::SwarmClient::new(slot.config.root.clone());
+                                                                                let reviewer_id_to_close = worker_id.clone();
+                                                                                tokio::spawn(async move {
+                                                                                    if let Err(e) = swarm_for_close.close_worker(&reviewer_id_to_close).await {
+                                                                                        tracing::warn!("failed to auto-close reviewer {reviewer_id_to_close}: {e}");
+                                                                                    } else {
+                                                                                        tracing::info!("auto-closed reviewer worker {reviewer_id_to_close}");
+                                                                                    }
+                                                                                });
                                                                             }
                                                                             Err(e) => {
                                                                                 tracing::warn!("[task-engine] error processing verdict signal: {e}");


### PR DESCRIPTION
## Summary
- After a reviewer worker's verdict is processed through the task engine, automatically send a `close_worker` command to that reviewer
- Handles both PR-flow and branch-ready-flow reviewers (both use the same code path in the `swarm-completed-` handler where `worker_id` is the reviewer's ID)
- Close failures (e.g. worker already gone) are logged as warnings and don't error

## Test plan
- [ ] Trigger a review (PR flow or branch-ready flow) and confirm the reviewer worker is auto-closed after verdict is delivered
- [ ] Verify stale reviewer workers no longer appear in kanban after verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)