### PR TITLE
feat: live worker output stream via daemon IPC

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -190,6 +190,12 @@ pub(super) enum AppUpdate {
         task_id: String,
         events: Vec<crate::buzz::task::ActivityEvent>,
     },
+    /// A single line streamed from a live worker output subscription.
+    WorkerOutputLine {
+        workspace_name: String,
+        worker_id: String,
+        line: OutputLine,
+    },
 }
 
 // ── Worker info from state.json ───────────────────────────
@@ -283,6 +289,59 @@ pub struct TaskDetailState {
     pub pr_number: Option<i64>,
     pub events: Vec<crate::buzz::task::ActivityEvent>,
     pub scroll: usize,
+}
+
+/// Style of a rendered worker output line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputLineKind {
+    Text,
+    Thinking,
+    ToolUse,
+    ToolResult,
+    Separator,
+    Status,
+    Error,
+}
+
+/// A single rendered line in the worker output panel.
+#[derive(Debug, Clone)]
+pub struct OutputLine {
+    pub kind: OutputLineKind,
+    pub text: String,
+}
+
+/// State for the live worker output panel.
+#[derive(Debug, Clone)]
+pub struct WorkerOutputState {
+    pub worker_id: String,
+    pub lines: Vec<OutputLine>,
+    pub scroll: usize,
+    /// When true, new lines auto-scroll to the bottom.
+    pub auto_scroll: bool,
+}
+
+impl WorkerOutputState {
+    pub fn new(worker_id: String) -> Self {
+        Self {
+            worker_id,
+            lines: Vec::new(),
+            scroll: 0,
+            auto_scroll: true,
+        }
+    }
+
+    /// Maximum number of lines to keep in memory.
+    pub const MAX_LINES: usize = 10_000;
+
+    /// Append a line; enforce the cap and auto-scroll if enabled.
+    pub fn push(&mut self, line: OutputLine) {
+        if self.lines.len() >= Self::MAX_LINES {
+            self.lines.drain(0..Self::MAX_LINES / 10);
+            // Adjust scroll so we don't jump
+            self.scroll = self.scroll.saturating_sub(Self::MAX_LINES / 10);
+        }
+        self.lines.push(line);
+    }
 }
 
 /// Build kanban cards from tasks. Task cards take priority over worker/signal cards
@@ -1015,6 +1074,8 @@ pub struct WorkspaceState {
     pub activity_scroll: usize,
     /// Task detail panel state (Some when viewing a task's timeline).
     pub viewing_task: Option<TaskDetailState>,
+    /// Live worker output panel state (Some when streaming a worker's output).
+    pub viewing_worker_output: Option<WorkerOutputState>,
 }
 
 // ── App ───────────────────────────────────────────────────
@@ -1084,6 +1145,8 @@ pub struct App {
     pub spinner_tick: usize,
     pub last_worker_refresh: Instant,
     pub last_signal_refresh: Instant,
+    /// Background task streaming a worker's live output (aborted when output panel closes).
+    pub worker_output_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl App {
@@ -1149,6 +1212,7 @@ impl App {
                     activity_selected: 0,
                     activity_scroll: 0,
                     viewing_task: None,
+                    viewing_worker_output: None,
                 }
             })
             .collect();
@@ -1220,6 +1284,7 @@ impl App {
             spinner_tick: 0,
             last_worker_refresh: Instant::now(),
             last_signal_refresh: Instant::now(),
+            worker_output_task: None,
         };
 
         // Inject first onboarding message into chat
@@ -1303,6 +1368,7 @@ impl App {
             activity_selected: 0,
             activity_scroll: 0,
             viewing_task: None,
+            viewing_worker_output: None,
         };
 
         let setup = SetupState {
@@ -1364,6 +1430,7 @@ impl App {
             spinner_tick: 0,
             last_worker_refresh: Instant::now(),
             last_signal_refresh: Instant::now(),
+            worker_output_task: None,
         };
 
         app.rebuild_ws_name_index();
@@ -1444,6 +1511,7 @@ impl App {
             activity_selected: 0,
             activity_scroll: 0,
             viewing_task: None,
+            viewing_worker_output: None,
         };
 
         ws_state.chat_history.push(ChatLine::Assistant(
@@ -1652,6 +1720,7 @@ impl App {
             activity_selected: 0,
             activity_scroll: 0,
             viewing_task: None,
+            viewing_worker_output: None,
         };
 
         if is_add {
@@ -3296,6 +3365,29 @@ impl App {
         self.needs_redraw = true;
     }
 
+    /// Append a line to the live worker output panel for the given workspace/worker.
+    pub(super) fn apply_worker_output_line(
+        &mut self,
+        workspace_name: &str,
+        worker_id: &str,
+        line: OutputLine,
+    ) {
+        if let Some(ws) = self
+            .workspaces
+            .iter_mut()
+            .find(|ws| ws.name == workspace_name)
+            && let Some(ref mut out) = ws.viewing_worker_output
+            && out.worker_id == worker_id
+        {
+            out.push(line);
+            if out.auto_scroll {
+                let total = out.lines.len();
+                out.scroll = total.saturating_sub(1);
+            }
+            self.needs_redraw = true;
+        }
+    }
+
     /// Open the task detail panel for the currently selected kanban card.
     ///
     /// Returns `Some((workspace_name, task_id))` if a task card was selected,
@@ -4821,6 +4913,7 @@ mod tests {
             activity_selected: 0,
             activity_scroll: 0,
             viewing_task: None,
+            viewing_worker_output: None,
         };
         app.workspaces = vec![ws];
         app.setup = None;
@@ -5083,6 +5176,7 @@ mod tests {
             activity_selected: 0,
             activity_scroll: 0,
             viewing_task: None,
+            viewing_worker_output: None,
         }
     }
 

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -3061,6 +3061,7 @@ mod tests {
             activity_selected: 0,
             activity_scroll: 0,
             viewing_task: None,
+            viewing_worker_output: None,
         };
         let ws_name = ws.name.clone();
         App {
@@ -3110,6 +3111,7 @@ mod tests {
             shell_input_active: false,
             shell_input: String::new(),
             kanban_allocated_height: std::cell::Cell::new(0),
+            worker_output_task: None,
         }
     }
 

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -114,6 +114,11 @@ enum KeyAction {
         workspace: String,
         task_id: String,
     },
+    OpenWorkerOutput {
+        workspace_name: String,
+        worker_id: String,
+        workspace_root: std::path::PathBuf,
+    },
     Redraw,
 }
 
@@ -489,6 +494,41 @@ async fn event_loop(
                             continue;
                         }
 
+                        // Open worker output: initialize state and spawn subscription task
+                        if let KeyAction::OpenWorkerOutput {
+                            ref workspace_name,
+                            ref worker_id,
+                            ref workspace_root,
+                        } = action
+                        {
+                            if let Some(ws) = app
+                                .workspaces
+                                .iter_mut()
+                                .find(|ws| ws.name == *workspace_name)
+                            {
+                                ws.viewing_worker_output = Some(
+                                    app::WorkerOutputState::new(worker_id.clone()),
+                                );
+                            }
+                            // Abort any previous subscription task
+                            if let Some(handle) = app.worker_output_task.take() {
+                                handle.abort();
+                            }
+                            let wid = worker_id.clone();
+                            let ws_name = workspace_name.clone();
+                            let root = workspace_root.clone();
+                            let tx = update_tx.clone();
+                            app.worker_output_task = Some(tokio::spawn(async move {
+                                if let Err(e) =
+                                    worker_output_stream_task(wid, ws_name, root, tx).await
+                                {
+                                    tracing::warn!("worker output stream ended: {e}");
+                                }
+                            }));
+                            app.needs_redraw = true;
+                            continue;
+                        }
+
                         if let Some(true) = handle_action(&mut app, action, user_tx).await {
                             break;
                         }
@@ -687,6 +727,9 @@ async fn event_loop(
                             app.remote_host = remote_host;
                         }
                         app.needs_redraw = true;
+                    }
+                    AppUpdate::WorkerOutputLine { workspace_name, worker_id, line } => {
+                        app.apply_worker_output_line(&workspace_name, &worker_id, line);
                     }
                     AppUpdate::WorkerConversation { workspace_name, worker_id, entries } => {
                         if let Some(ws) = app.workspaces.iter_mut().find(|ws| ws.name == workspace_name)
@@ -914,6 +957,72 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
         return handle_dashboard_chat_key(app, key);
     }
 
+    // Worker output panel: intercept all navigation while open
+    if app
+        .current_ws()
+        .is_some_and(|ws| ws.viewing_worker_output.is_some())
+    {
+        match key.code {
+            KeyCode::Esc => {
+                // Abort the subscription task
+                if let Some(handle) = app.worker_output_task.take() {
+                    handle.abort();
+                }
+                if let Some(ws) = app.current_ws_mut() {
+                    ws.viewing_worker_output = None;
+                }
+                app.needs_redraw = true;
+                return KeyAction::Redraw;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if let Some(ws) = app.current_ws_mut()
+                    && let Some(ref mut out) = ws.viewing_worker_output
+                {
+                    out.auto_scroll = false;
+                    let max = out.lines.len().saturating_sub(1);
+                    out.scroll = (out.scroll + 1).min(max);
+                }
+                app.needs_redraw = true;
+                return KeyAction::Redraw;
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if let Some(ws) = app.current_ws_mut()
+                    && let Some(ref mut out) = ws.viewing_worker_output
+                {
+                    out.auto_scroll = false;
+                    out.scroll = out.scroll.saturating_sub(1);
+                }
+                app.needs_redraw = true;
+                return KeyAction::Redraw;
+            }
+            KeyCode::Char('G') => {
+                if let Some(ws) = app.current_ws_mut()
+                    && let Some(ref mut out) = ws.viewing_worker_output
+                {
+                    out.auto_scroll = true;
+                    out.scroll = out.lines.len().saturating_sub(1);
+                }
+                app.needs_redraw = true;
+                return KeyAction::Redraw;
+            }
+            KeyCode::Char('f') => {
+                if let Some(ws) = app.current_ws_mut()
+                    && let Some(ref mut out) = ws.viewing_worker_output
+                {
+                    out.auto_scroll = !out.auto_scroll;
+                    if out.auto_scroll {
+                        out.scroll = out.lines.len().saturating_sub(1);
+                    }
+                }
+                app.needs_redraw = true;
+                return KeyAction::Redraw;
+            }
+            _ => {
+                return KeyAction::Redraw;
+            }
+        }
+    }
+
     // Task detail panel: intercept navigation keys while open
     if app.current_ws().is_some_and(|ws| ws.viewing_task.is_some()) {
         match key.code {
@@ -950,6 +1059,24 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
                 });
                 if let Some((workspace, task_id)) = info {
                     return KeyAction::LoadTaskTimeline { workspace, task_id };
+                }
+                return KeyAction::Redraw;
+            }
+            KeyCode::Char('o') => {
+                // Open live worker output for this task's worker
+                let info = app.current_ws().and_then(|ws| {
+                    ws.viewing_task.as_ref().and_then(|d| {
+                        d.worker_id
+                            .as_ref()
+                            .map(|wid| (ws.name.clone(), wid.clone(), ws.config.root.clone()))
+                    })
+                });
+                if let Some((workspace_name, worker_id, workspace_root)) = info {
+                    return KeyAction::OpenWorkerOutput {
+                        workspace_name,
+                        worker_id,
+                        workspace_root,
+                    };
                 }
                 return KeyAction::Redraw;
             }
@@ -1182,6 +1309,20 @@ fn handle_dashboard_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAc
             }
         }
         KeyCode::Char('o') => {
+            // Workers panel: open live output stream for selected worker
+            if app.focused_panel == Panel::Workers
+                && let Some(ws) = app.current_ws()
+                && let Some(worker) = ws.workers.get(app.worker_selection)
+            {
+                let workspace_name = ws.name.clone();
+                let worker_id = worker.id.clone();
+                let workspace_root = ws.config.root.clone();
+                return KeyAction::OpenWorkerOutput {
+                    workspace_name,
+                    worker_id,
+                    workspace_root,
+                };
+            }
             if let Some(url) = app.selected_url() {
                 return KeyAction::OpenUrl(url);
             }
@@ -2207,6 +2348,7 @@ async fn handle_action(
         | KeyAction::SetupComplete
         | KeyAction::AddWorkspace
         | KeyAction::LoadTaskTimeline { .. }
+        | KeyAction::OpenWorkerOutput { .. }
         | KeyAction::None
         | KeyAction::Redraw => {}
     }
@@ -2738,6 +2880,133 @@ fn build_coordinator(workspace_name: &str) -> Option<Coordinator> {
     }));
 
     Some(coordinator)
+}
+
+// ── Worker output stream ─────────────────────────────────
+
+/// Background task that subscribes to a worker's live output via the swarm daemon
+/// and forwards each event as an `AppUpdate::WorkerOutputLine`.
+async fn worker_output_stream_task(
+    worker_id: String,
+    workspace_name: String,
+    workspace_root: std::path::PathBuf,
+    tx: mpsc::Sender<app::AppUpdate>,
+) -> color_eyre::Result<()> {
+    use apiari_swarm::client::{AgentEventWire, DaemonRequest, global_socket_path, socket_path};
+    use tokio::{
+        io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+        net::UnixStream,
+    };
+
+    let local = socket_path(&workspace_root);
+    let global = global_socket_path();
+    let stream = if local.exists() {
+        UnixStream::connect(&local).await
+    } else {
+        UnixStream::connect(&global).await
+    }
+    .map_err(|e| color_eyre::eyre::eyre!("failed to connect to swarm daemon: {e}"))?;
+
+    let (reader, mut writer) = stream.into_split();
+
+    let req = DaemonRequest::Subscribe {
+        worktree_id: Some(worker_id.clone()),
+        workspace: None,
+    };
+    let mut line = serde_json::to_string(&req)?;
+    line.push('\n');
+    writer.write_all(line.as_bytes()).await?;
+
+    let mut reader = BufReader::new(reader);
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        let n = reader.read_line(&mut buf).await?;
+        if n == 0 {
+            break; // daemon closed the connection
+        }
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(buf.trim())
+            && val.get("kind").and_then(|k| k.as_str()) == Some("agent_event")
+            && val
+                .get("worktree_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| id == worker_id)
+            && let Some(event_val) = val.get("event")
+            && let Ok(event) = serde_json::from_value::<AgentEventWire>(event_val.clone())
+        {
+            let output_line = agent_event_to_output_line(event);
+            let _ = tx
+                .send(app::AppUpdate::WorkerOutputLine {
+                    workspace_name: workspace_name.clone(),
+                    worker_id: worker_id.clone(),
+                    line: output_line,
+                })
+                .await;
+        }
+    }
+    Ok(())
+}
+
+/// Convert an `AgentEventWire` to a rendered `OutputLine`.
+fn agent_event_to_output_line(event: apiari_swarm::client::AgentEventWire) -> app::OutputLine {
+    use apiari_swarm::client::AgentEventWire;
+    match event {
+        AgentEventWire::TextDelta { text } => app::OutputLine {
+            kind: app::OutputLineKind::Text,
+            text,
+        },
+        AgentEventWire::ThinkingDelta { text } => app::OutputLine {
+            kind: app::OutputLineKind::Thinking,
+            text,
+        },
+        AgentEventWire::ToolUse { tool, input } => {
+            let truncated = if input.len() > 120 {
+                format!("{}…", &input[..120])
+            } else {
+                input
+            };
+            app::OutputLine {
+                kind: app::OutputLineKind::ToolUse,
+                text: format!("🔧 {tool}: {truncated}"),
+            }
+        }
+        AgentEventWire::ToolResult { output, is_error } => {
+            let truncated = if output.len() > 200 {
+                format!("{}…", &output[..200])
+            } else {
+                output
+            };
+            app::OutputLine {
+                kind: if is_error {
+                    app::OutputLineKind::Error
+                } else {
+                    app::OutputLineKind::ToolResult
+                },
+                text: truncated,
+            }
+        }
+        AgentEventWire::TurnComplete => app::OutputLine {
+            kind: app::OutputLineKind::Separator,
+            text: "─".repeat(40),
+        },
+        AgentEventWire::SessionResult {
+            turns, cost_usd, ..
+        } => {
+            let cost_str = cost_usd.map(|c| format!("  ${:.4}", c)).unwrap_or_default();
+            app::OutputLine {
+                kind: app::OutputLineKind::Status,
+                text: format!("Session complete — {turns} turns{cost_str}"),
+            }
+        }
+        AgentEventWire::SessionWaiting { .. } => app::OutputLine {
+            kind: app::OutputLineKind::Status,
+            text: "⏳ Waiting for input…".to_string(),
+        },
+        AgentEventWire::Error { message } => app::OutputLine {
+            kind: app::OutputLineKind::Error,
+            text: format!("Error: {message}"),
+        },
+    }
 }
 
 #[cfg(test)]

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -214,9 +214,20 @@ fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
 
     draw_kanban_strip(frame, app, ws, rows[0]);
 
-    // Bottom area: Task detail / Chat + optional Triage sidebar
+    // Bottom area: Worker output / Task detail / Chat + optional Triage sidebar
     let bottom = rows[1];
-    if ws.viewing_task.is_some() {
+    if ws.viewing_worker_output.is_some() {
+        if ws.triage_sidebar_open {
+            let cols = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
+                .split(bottom);
+            draw_worker_output_panel(frame, ws, cols[0]);
+            draw_triage_sidebar(frame, ws, cols[1]);
+        } else {
+            draw_worker_output_panel(frame, ws, bottom);
+        }
+    } else if ws.viewing_task.is_some() {
         if ws.triage_sidebar_open {
             let cols = Layout::default()
                 .direction(Direction::Horizontal)
@@ -3975,6 +3986,110 @@ fn format_tokens(n: u64) -> String {
         format!("{:.1}k", n as f64 / 1_000.0)
     } else {
         n.to_string()
+    }
+}
+
+// ── Worker output panel ──────────────────────────────────
+
+pub fn draw_worker_output_panel(frame: &mut Frame, ws: &app::WorkspaceState, area: Rect) {
+    let out = match ws.viewing_worker_output.as_ref() {
+        Some(o) => o,
+        None => return,
+    };
+
+    let follow_indicator = if out.auto_scroll { " [follow]" } else { "" };
+    let title = format!(
+        " Output: {} {follow_indicator}",
+        truncate_to_width(&out.worker_id, (area.width as usize).saturating_sub(20))
+    );
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_set(border::ROUNDED)
+        .border_style(Style::default().fg(theme::FROST))
+        .style(Style::default().bg(theme::COMB))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(theme::POLLEN)
+                .add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.height < 3 {
+        return;
+    }
+
+    // Footer hint
+    let footer_y = inner.y + inner.height.saturating_sub(1);
+    let footer_area = Rect {
+        x: inner.x,
+        y: footer_y,
+        width: inner.width,
+        height: 1,
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(" [Esc]", theme::key_hint()),
+            Span::styled(" Close  ", theme::key_desc()),
+            Span::styled("[j/k]", theme::key_hint()),
+            Span::styled(" Scroll  ", theme::key_desc()),
+            Span::styled("[G]", theme::key_hint()),
+            Span::styled(" Bottom  ", theme::key_desc()),
+            Span::styled("[f]", theme::key_hint()),
+            Span::styled(" Follow", theme::key_desc()),
+        ])),
+        footer_area,
+    );
+
+    // Content area (all rows except footer)
+    let content_h = inner.height.saturating_sub(1);
+    let content_area = Rect {
+        x: inner.x,
+        y: inner.y,
+        width: inner.width,
+        height: content_h,
+    };
+
+    if out.lines.is_empty() {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                " Waiting for output…",
+                Style::default().fg(theme::SMOKE),
+            ))),
+            content_area,
+        );
+        return;
+    }
+
+    let visible = content_h as usize;
+    let scroll = out.scroll.min(out.lines.len().saturating_sub(1));
+    let start = scroll.saturating_sub(visible.saturating_sub(1));
+    let start = start.min(out.lines.len().saturating_sub(visible));
+
+    for (i, line) in out.lines.iter().skip(start).take(visible).enumerate() {
+        let row = Rect {
+            x: inner.x,
+            y: inner.y + i as u16,
+            width: inner.width,
+            height: 1,
+        };
+        let (fg, prefix) = match line.kind {
+            app::OutputLineKind::Text => (theme::POLLEN, ""),
+            app::OutputLineKind::Thinking => (theme::SMOKE, "💭 "),
+            app::OutputLineKind::ToolUse => (theme::MINT, ""),
+            app::OutputLineKind::ToolResult => (theme::FROST, "  "),
+            app::OutputLineKind::Separator => (theme::STEEL, ""),
+            app::OutputLineKind::Status => (Color::Rgb(180, 180, 100), ""),
+            app::OutputLineKind::Error => (Color::Rgb(220, 80, 80), "⚠ "),
+        };
+        let text = format!("{prefix}{}", line.text);
+        let truncated = truncate_to_width(&text, inner.width as usize);
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(truncated, Style::default().fg(fg)))),
+            row,
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `WorkerOutputState` to `WorkspaceState` with buffered `OutputLine` list (capped at 10,000), scroll offset, and auto-scroll flag
- Spawn a background task that connects directly to the swarm daemon Unix socket, sends a `Subscribe { worktree_id }` request, and streams `AgentEvent` responses as `AppUpdate::WorkerOutputLine` updates
- Render a scrollable output panel in the dashboard bottom area (replaces chat/task detail area while open), with color-coded lines per event kind

## Key bindings

| Key | Context | Action |
|-----|---------|--------|
| `o` | Task detail panel (with worker) | Open live output |
| `o` | Workers panel | Open live output for selected worker |
| `Esc` | Output panel | Close panel, cancel subscription |
| `j` / `k` | Output panel | Scroll down / up |
| `G` | Output panel | Jump to bottom + re-enable auto-scroll |
| `f` | Output panel | Toggle follow mode |

## Event rendering

| Event | Style |
|-------|-------|
| `TextDelta` | Normal text (amber) |
| `ThinkingDelta` | Dimmed with 💭 prefix |
| `ToolUse` | Mint with 🔧 prefix, input truncated to 120 chars |
| `ToolResult` | Frost, indented, truncated to 200 chars |
| `TurnComplete` | Separator line |
| `SessionResult` | Status line with turn count and cost |
| `SessionWaiting` | "⏳ Waiting for input…" |
| `Error` | Red with ⚠ prefix |

## Test plan

- [ ] Open TUI with an active worker, navigate to Workers panel, press `o` → output panel opens
- [ ] Press Enter on a task kanban card to open task detail, press `o` → output panel opens if a worker_id is set
- [ ] Verify events stream in real time as the worker runs
- [ ] Press `k` to scroll up → auto-scroll disables; press `G` → jumps to bottom and re-enables follow
- [ ] Press `f` to toggle follow mode
- [ ] Press `Esc` → panel closes, background task is cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)