### PR TITLE
fix: strip validate-bash hook from signal follow-through sessions

### DIFF
--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -726,9 +726,15 @@ async fn run_coordinator_task(
                 // per-session overrides stay isolated.
                 if let DispatchBundle::Claude(ref mut opts) = bundle {
                     opts.resume = None;
+                    // Strip the validate-bash PreToolUse hook from follow-through
+                    // sessions. Hook deny decisions are cached by Claude Code and
+                    // can bleed into the user's interactive session if left in.
+                    // Follow-throughs have limited max_turns and don't need bash
+                    // auditing; the hook stays active on the main interactive
+                    // coordinator session only.
+                    opts.settings = None;
 
                     // In observe mode, strip Bash to enforce read-only.
-                    // Autonomous mode keeps Bash — validate-bash hook audits.
                     if authority == crate::config::WorkspaceAuthority::Observe {
                         if !opts.disallowed_tools.iter().any(|t| t == "Bash") {
                             opts.disallowed_tools.push("Bash".to_string());


### PR DESCRIPTION
## Summary
- Signal follow-through sessions inherited the `apiari validate-bash` PreToolUse hook from the shared coordinator's settings
- Claude Code caches hook deny decisions, causing them to bleed into the user's interactive session and intermittently block commands like `gh pr merge`
- Fix: set `opts.settings = None` in the follow-through `DispatchBundle::Claude` block before dispatch, so the hook is stripped from follow-through sessions only

The validate-bash hook remains active on the main interactive coordinator session and the CLI chat coordinator — only the follow-through path is changed.

## Test plan
- [ ] Trigger a signal follow-through (e.g. a hook-matched signal) and verify it runs without the validate-bash PreToolUse hook in the session
- [ ] Verify the main interactive coordinator session still has the validate-bash hook active
- [ ] Confirm `gh pr merge` and similar commands are not intermittently blocked in the interactive session after a follow-through runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)