### PR TITLE
chore: expand .gitignore for Rust/Apiari ecosystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,28 @@
+# Build artifacts
+debug/
+target/
+
+# Cargo
+**/*.rs.bk
 .cargo/config.toml
+
+# Runtime state
+.swarm/
+.task/
+
+# Claude Code
+.claude/worktrees/
+
+# Environment / secrets
+.env
+.env.*
+
+# Editor / OS
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*~
+
+# MSRV
+rust-toolchain


### PR DESCRIPTION
## Summary
- Replaces the minimal `.gitignore` (only had `.cargo/config.toml`) with a comprehensive version for Rust/Apiari projects
- Covers build artifacts, Cargo backups, runtime state (`.swarm/`, `.task/`), Claude Code worktrees, env/secrets, editors/OS, and MSRV toolchain file

## Test plan
- [ ] Verify `.gitignore` entries are correct and no unintended files are tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)