### PR TITLE
fix: prevent swarm_worker_running from regressing tasks past InProgress

### DIFF
--- a/crates/apiari/src/buzz/task/engine.rs
+++ b/crates/apiari/src/buzz/task/engine.rs
@@ -854,27 +854,29 @@ mod tests {
     }
 
     #[test]
-    fn test_swarm_worker_running_human_review_to_in_progress() {
+    fn test_swarm_worker_running_human_review_no_regression() {
+        // worker_running must NOT regress a task that is already past InProgress.
         let store = TaskStore::open_memory().unwrap();
         create_task_in_stage(&store, "acme", "w-run2", TaskStage::HumanReview);
 
         let signal = make_running_signal("w-run2");
         let result = process_signal(&store, "acme", &signal).unwrap();
 
-        assert!(result.transitioned);
-        assert_eq!(result.task.unwrap().stage, TaskStage::InProgress);
+        assert!(!result.transitioned);
+        assert_eq!(result.task.unwrap().stage, TaskStage::HumanReview);
     }
 
     #[test]
-    fn test_swarm_worker_running_in_ai_review_to_in_progress() {
+    fn test_swarm_worker_running_in_ai_review_no_regression() {
+        // worker_running must NOT regress a task that is already past InProgress.
         let store = TaskStore::open_memory().unwrap();
         create_task_in_stage(&store, "acme", "w-run3", TaskStage::InAiReview);
 
         let signal = make_running_signal("w-run3");
         let result = process_signal(&store, "acme", &signal).unwrap();
 
-        assert!(result.transitioned);
-        assert_eq!(result.task.unwrap().stage, TaskStage::InProgress);
+        assert!(!result.transitioned);
+        assert_eq!(result.task.unwrap().stage, TaskStage::InAiReview);
     }
 
     #[test]

--- a/crates/apiari/src/buzz/task/mod.rs
+++ b/crates/apiari/src/buzz/task/mod.rs
@@ -62,6 +62,19 @@ impl TaskStage {
     pub fn is_terminal(&self) -> bool {
         matches!(self, Self::Merged | Self::Dismissed)
     }
+
+    /// Numeric ordering of stages (higher = further in the lifecycle).
+    /// Used to prevent signal-driven backward transitions.
+    pub fn stage_order(&self) -> u8 {
+        match self {
+            Self::Triage => 0,
+            Self::InProgress => 1,
+            Self::InAiReview => 2,
+            Self::HumanReview => 3,
+            Self::Merged => 4,
+            Self::Dismissed => 5,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/apiari/src/buzz/task/rules.rs
+++ b/crates/apiari/src/buzz/task/rules.rs
@@ -305,25 +305,27 @@ pub fn evaluate_signal(task: &Task, signal: &SignalRecord) -> Option<ProposedTra
         }),
 
         // ── Worker running → InProgress ──
-        // A non-reviewer worker transitioned to Running phase. Move the task to InProgress
-        // regardless of which stage it was in (e.g. Triage after worker closed+re-spawned,
-        // HumanReview after human sends rebase message, InAiReview after reviewer returns changes).
-        (
-            TaskStage::Triage | TaskStage::HumanReview | TaskStage::InAiReview,
-            "swarm_worker_running",
-        ) => Some(ProposedTransition {
-            task_id: task.id.clone(),
-            from: task.stage.clone(),
-            to: TaskStage::InProgress,
-            reason: "Worker resumed running".to_string(),
-            approval: Approval::Auto,
-            action: TransitionAction::Notify {
-                message: format!(
-                    "Worker is running — task moved to InProgress (was {})",
-                    task.stage.as_str()
-                ),
-            },
-        }),
+        // A non-reviewer worker transitioned to Running phase. Only move the task to
+        // InProgress if it hasn't already advanced past that stage. If the task is in
+        // InAiReview, HumanReview, or Merged, the worker_running signal must NOT regress
+        // it backwards — that is a bug, not an intentional transition.
+        (stage, "swarm_worker_running")
+            if stage.stage_order() < TaskStage::InProgress.stage_order() =>
+        {
+            Some(ProposedTransition {
+                task_id: task.id.clone(),
+                from: task.stage.clone(),
+                to: TaskStage::InProgress,
+                reason: "Worker resumed running".to_string(),
+                approval: Approval::Auto,
+                action: TransitionAction::Notify {
+                    message: format!(
+                        "Worker is running — task moved to InProgress (was {})",
+                        task.stage.as_str()
+                    ),
+                },
+            })
+        }
 
         // ── Worker closed without completing → Triage ──
         // Non-reviewer worker disappeared while task was InProgress — needs attention.
@@ -939,21 +941,29 @@ mod tests {
     }
 
     #[test]
-    fn test_worker_running_human_review_to_in_progress() {
+    fn test_worker_running_human_review_no_regression() {
+        // Task already in HumanReview — worker_running must NOT regress it to InProgress.
         let task = make_task(TaskStage::HumanReview);
         let signal = make_worker_running_signal("w1");
-        let result = evaluate_signal(&task, &signal).unwrap();
-        assert_eq!(result.from, TaskStage::HumanReview);
-        assert_eq!(result.to, TaskStage::InProgress);
+        assert!(evaluate_signal(&task, &signal).is_none());
     }
 
     #[test]
-    fn test_worker_running_in_ai_review_to_in_progress() {
+    fn test_worker_running_in_ai_review_no_regression() {
+        // Task already in InAiReview — worker_running must NOT regress it to InProgress.
         let task = make_task(TaskStage::InAiReview);
         let signal = make_worker_running_signal("w1");
+        assert!(evaluate_signal(&task, &signal).is_none());
+    }
+
+    #[test]
+    fn test_ci_pass_in_ai_review_to_human_review_forward_allowed() {
+        // Forward transition: InAiReview + ci_pass → HumanReview is unaffected by the fix.
+        let task = make_task(TaskStage::InAiReview);
+        let signal = make_signal("github_ci_pass", None);
         let result = evaluate_signal(&task, &signal).unwrap();
         assert_eq!(result.from, TaskStage::InAiReview);
-        assert_eq!(result.to, TaskStage::InProgress);
+        assert_eq!(result.to, TaskStage::HumanReview);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `TaskStage::stage_order()` to establish a canonical numeric ordering of lifecycle stages
- Guards the `swarm_worker_running` transition rule so it only fires when the task is **before** `InProgress` in the ordering (i.e., only `Triage`) — tasks already at `InAiReview`, `HumanReview`, or `Merged` are left untouched
- Updates two tests that previously verified the buggy backward-regression behavior, and adds a forward-transition smoke test

## Root Cause
The match arm for `swarm_worker_running` explicitly listed `HumanReview | InAiReview` as valid source stages and transitioned them to `InProgress`. This caused the regression: `PR opened → InProgress → InAiReview → HumanReview` (correct), then `worker running → HumanReview → InProgress` (wrong).

## Test plan
- [ ] `test_worker_running_human_review_no_regression` — HumanReview + worker_running → None (no transition)
- [ ] `test_worker_running_in_ai_review_no_regression` — InAiReview + worker_running → None (no transition)
- [ ] `test_worker_running_triage_to_in_progress` — Triage + worker_running → InProgress (still works)
- [ ] `test_ci_pass_in_ai_review_to_human_review_forward_allowed` — InAiReview + ci_pass → HumanReview (forward unaffected)
- [ ] All 43 rules tests pass, fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)