### PR TITLE
feat: PR list view sources from tasks, kanban o-key opens PR URL

### DIFF
--- a/crates/apiari/src/ui/app.rs
+++ b/crates/apiari/src/ui/app.rs
@@ -2485,6 +2485,18 @@ impl App {
         }
     }
 
+    /// Tasks that have a PR URL set.
+    pub fn tasks_with_prs(&self) -> Vec<&crate::buzz::task::Task> {
+        match self.current_ws() {
+            Some(ws) => ws
+                .tasks
+                .iter()
+                .filter(|t| t.pr_url.as_ref().is_some_and(|u| !u.is_empty()))
+                .collect(),
+            None => Vec::new(),
+        }
+    }
+
     // ── Input editing ─────────────────────────────────────
 
     pub fn insert_char(&mut self, c: char) {
@@ -3665,6 +3677,24 @@ impl App {
 
     /// Get the URL associated with the current selection (for 'o' to open).
     pub fn selected_url(&self) -> Option<String> {
+        // PR list: source URLs from tasks (survives worker closure).
+        if self.view == View::PrList {
+            let tasks = self.tasks_with_prs();
+            return tasks
+                .get(self.pr_list_selection)
+                .and_then(|t| t.pr_url.clone());
+        }
+        // Kanban panel: open the selected card's URL (pr_url preferred over source_url).
+        if self.view == View::Dashboard
+            && self.focused_panel == Panel::Home
+            && let Some(ws) = self.current_ws()
+            && let Some((stage, idx)) = ws.kanban_selected
+        {
+            let card = ws.kanban_cards.iter().filter(|c| c.stage == stage).nth(idx);
+            if let Some(card) = card {
+                return card.url.clone();
+            }
+        }
         if let Some(worker) = self.selected_worker() {
             return worker.pr.as_ref().map(|pr| pr.url.clone());
         }

--- a/crates/apiari/src/ui/mod.rs
+++ b/crates/apiari/src/ui/mod.rs
@@ -2018,7 +2018,7 @@ fn handle_review_list_key(app: &mut App, key: crossterm::event::KeyEvent) -> Key
 // ── PR list keys ─────────────────────────────────────────
 
 fn handle_pr_list_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyAction {
-    let pr_count = app.workers_with_prs().len();
+    let pr_count = app.tasks_with_prs().len();
 
     match key.code {
         KeyCode::Esc => app.back_to_dashboard(),
@@ -2040,13 +2040,7 @@ fn handle_pr_list_key(app: &mut App, key: crossterm::event::KeyEvent) -> KeyActi
             app.pr_list_selection = pr_count.saturating_sub(1);
             app.needs_redraw = true;
         }
-        KeyCode::Enter => {
-            let prs = app.workers_with_prs();
-            if let Some((orig_idx, _)) = prs.get(app.pr_list_selection) {
-                app.enter_worker_detail(*orig_idx);
-            }
-        }
-        KeyCode::Char('o') => {
+        KeyCode::Enter | KeyCode::Char('o') => {
             if let Some(url) = app.selected_url() {
                 return KeyAction::OpenUrl(url);
             }

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -3142,23 +3142,14 @@ fn draw_review_list(frame: &mut Frame, app: &App, area: Rect) {
 // ── PR list (full-screen) ─────────────────────────────
 
 fn draw_pr_list(frame: &mut Frame, app: &App, area: Rect) {
-    let ws = match app.current_ws() {
-        Some(ws) => ws,
-        None => return,
-    };
-    let prs: Vec<(usize, &app::WorkerInfo)> = ws
-        .workers
-        .iter()
-        .enumerate()
-        .filter(|(_, w)| w.pr.is_some())
-        .collect();
+    let tasks = app.tasks_with_prs();
 
     let mut lines: Vec<Line> = Vec::new();
     let width = area.width as usize;
 
     // Header
     lines.push(Line::from(""));
-    let header = format!(" Pull Requests ({}) ", prs.len());
+    let header = format!(" Pull Requests ({}) ", tasks.len());
     let ruler_len = width.saturating_sub(header.len());
     lines.push(Line::from(vec![
         Span::styled(header, theme::subtitle()),
@@ -3166,8 +3157,8 @@ fn draw_pr_list(frame: &mut Frame, app: &App, area: Rect) {
     ]));
     lines.push(Line::from(""));
 
-    for (list_idx, (_, worker)) in prs.iter().enumerate() {
-        let pr = worker.pr.as_ref().unwrap();
+    for (list_idx, task) in tasks.iter().enumerate() {
+        let pr_url = task.pr_url.as_deref().unwrap_or("");
         let is_sel = list_idx == app.pr_list_selection;
         let line_style = if is_sel {
             theme::selected()
@@ -3180,38 +3171,59 @@ fn draw_pr_list(frame: &mut Frame, app: &App, area: Rect) {
             Style::default()
         };
 
-        let state_style = match pr.state.as_str() {
-            "OPEN" => Style::default().fg(theme::MINT),
-            "MERGED" => theme::status_done(),
-            "CLOSED" => theme::error(),
+        let stage_str = task.stage.as_str();
+        let stage_style = match task.stage {
+            crate::buzz::task::TaskStage::HumanReview => Style::default().fg(theme::MINT),
+            crate::buzz::task::TaskStage::Merged => theme::status_done(),
+            crate::buzz::task::TaskStage::Dismissed => theme::error(),
             _ => theme::muted(),
         };
 
-        let title_max = width.saturating_sub(30).max(10);
-        let title = trunc(&pr.title, title_max);
+        let pr_label = task
+            .pr_number
+            .map(|n| format!("#{n}"))
+            .unwrap_or_else(|| "PR".to_string());
+
+        let repo_str = task
+            .repo
+            .as_deref()
+            .unwrap_or("")
+            .split('/')
+            .next_back()
+            .unwrap_or("");
+
+        let title_max = width.saturating_sub(36).max(10);
+        let title = trunc(&task.title, title_max);
 
         lines.push(
             Line::from(vec![
                 Span::styled(if is_sel { " \u{25b6}" } else { "  " }, line_style),
                 Span::styled(
-                    format!(" #{:<5}", pr.number),
+                    format!(" {:<6}", pr_label),
                     Style::default().fg(theme::MINT),
                 ),
-                Span::styled(format!(" {:>6} ", pr.state), state_style),
+                Span::styled(format!(" {:>13} ", stage_str), stage_style),
                 Span::styled(title, line_style),
-                Span::styled(format!("  ({})", worker.id), theme::muted()),
+                Span::styled(
+                    if repo_str.is_empty() {
+                        String::new()
+                    } else {
+                        format!("  ({repo_str})")
+                    },
+                    theme::muted(),
+                ),
             ])
             .style(bg),
         );
         // URL on second line (cmd+clickable in terminals)
         lines.push(Line::from(vec![
             Span::raw("    "),
-            Span::styled(&pr.url, Style::default().fg(theme::FROST)),
+            Span::styled(pr_url, Style::default().fg(theme::FROST)),
         ]));
         lines.push(Line::from(""));
     }
 
-    if prs.is_empty() {
+    if tasks.is_empty() {
         lines.push(Line::from(vec![
             Span::raw("   "),
             Span::styled("No pull requests", theme::muted()),


### PR DESCRIPTION
## Summary

- **PR list from tasks**: `p` key PR list now sources entries from `TaskStore` tasks (via `tasks_with_prs()`), so PRs remain visible after workers close. Shows task title, stage, repo, and PR URL for each entry.
- **Enter/o in PR list**: Both keys open the selected task's PR URL in the browser (no worker to drill into once it's closed).
- **Kanban `o` key**: Pressing `o` on a selected kanban card now opens the card's `pr_url` (or `source_url`) in the browser, wired through `selected_url()`.

## Test plan

- [ ] Open the PR list (`p`), verify it shows tasks with `pr_url` set (including those whose workers have already closed)
- [ ] Navigate up/down with `j`/`k`, press `o` or Enter to open the PR URL
- [ ] On the kanban board, select a card with a PR and press `o` — browser should open the PR URL
- [ ] `cargo clippy -p apiari -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)