### PR TITLE
feat: bump ratatui 0.29→0.30 and add OSC 8 hyperlinks to PR/triage views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "color-eyre",
- "crossterm",
+ "crossterm 0.28.1",
  "dirs",
  "futures",
  "libc",
@@ -153,7 +153,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "tracing-subscriber",
- "unicode-width 0.2.0",
+ "unicode-width",
  "uuid",
 ]
 
@@ -243,11 +243,9 @@ dependencies = [
 [[package]]
 name = "apiari-tui"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a56bc2c3cfc69b55b5652040f9c789a03946e942ccc6670794fe436e7de53"
 dependencies = [
  "chrono",
- "crossterm",
+ "crossterm 0.28.1",
  "pulldown-cmark 0.12.2",
  "ratatui",
  "serde",
@@ -425,7 +423,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -462,10 +469,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "blocking"
@@ -487,16 +524,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -522,6 +559,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -590,7 +633,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -634,9 +677,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -672,6 +715,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +748,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -727,12 +788,30 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "futures-core",
  "mio",
  "parking_lot",
  "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -745,6 +824,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -767,7 +866,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -778,8 +877,14 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
@@ -788,6 +893,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -819,7 +956,16 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -851,6 +997,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -903,16 +1058,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -935,6 +1123,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1029,7 +1223,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1062,12 +1256,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1083,13 +1287,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1134,9 +1350,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1144,6 +1358,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1165,6 +1384,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1468,7 +1693,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1495,9 +1720,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1519,6 +1744,23 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -1559,6 +1801,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1828,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,11 +1850,21 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
@@ -1623,6 +1890,21 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1676,6 +1958,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,12 +1996,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1736,7 +2051,7 @@ version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1753,7 +2068,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1779,6 +2094,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "owo-colors"
@@ -1825,16 +2149,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "phf"
@@ -1842,6 +2203,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -1863,6 +2225,19 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1891,7 +2266,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1938,6 +2313,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,7 +2340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1977,7 +2358,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -1990,7 +2371,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -2011,6 +2392,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -2035,23 +2422,87 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
 dependencies = [
- "bitflags",
- "cassowary",
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.0",
  "compact_str",
- "crossterm",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm 0.29.0",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
+ "line-clipping",
+ "ratatui-core",
  "strum",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2060,7 +2511,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2163,7 +2614,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2178,16 +2629,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2196,7 +2656,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2269,7 +2729,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2325,7 +2785,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2360,6 +2820,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2474,24 +2945,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2499,6 +2969,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2528,7 +3009,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2537,7 +3018,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2566,6 +3047,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,7 +3135,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2602,7 +3146,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2622,7 +3166,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -2680,7 +3226,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2780,7 +3326,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2835,7 +3381,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2894,6 +3440,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2913,20 +3471,14 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2976,6 +3528,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
@@ -2998,6 +3551,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "want"
@@ -3074,7 +3636,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3115,7 +3677,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3129,6 +3691,78 @@ checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -3174,7 +3808,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3185,7 +3819,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3228,15 +3862,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -3353,7 +3978,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3369,7 +3994,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3381,7 +4006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -3436,7 +4061,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3457,7 +4082,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3477,7 +4102,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3517,7 +4142,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
+ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 async-trait = "0.1"
 reqwest = { version = "0.12", features = ["json"] }
@@ -35,3 +35,5 @@ chrono-tz = "0.9"
 apiari-swarm = { version = "0.1.6", default-features = false, features = ["client"] }
 a2a-types = "0.1"
 
+[patch.crates-io]
+apiari-tui = { path = "vendor/apiari-tui" }

--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use apiari_tui::conversation;
 use ratatui::{
     Frame,
+    buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     symbols::border,
@@ -19,6 +20,30 @@ use super::{
 };
 
 const SPINNER: &[&str] = &["|", "/", "-", "\\"];
+
+/// Apply OSC 8 terminal hyperlinks to cells in a single-row area.
+///
+/// After a line has been rendered into the buffer normally, this overwrites
+/// each non-space cell symbol with `\x1B]8;;{url}\x07{sym}\x1B]8;;\x07` so
+/// that terminals supporting OSC 8 render the text as a clickable hyperlink.
+/// Cells before `x_skip` (used to skip prefix decorations like bars/icons)
+/// are left untouched.
+fn apply_osc8_hyperlink(buf: &mut Buffer, area: Rect, url: &str, x_skip: u16) {
+    let y = area.y;
+    let x_begin = area.x.saturating_add(x_skip);
+    let x_end = area.x.saturating_add(area.width);
+    for x in x_begin..x_end {
+        if x >= buf.area().x + buf.area().width || y >= buf.area().y + buf.area().height {
+            break;
+        }
+        let sym = buf[(x, y)].symbol().to_string();
+        if sym.chars().all(|c| c == ' ') {
+            continue; // skip whitespace-only cells
+        }
+        let linked = format!("\x1B]8;;{url}\x07{sym}\x1B]8;;\x07");
+        buf[(x, y)].set_symbol(&linked);
+    }
+}
 
 /// Build the display string for the input box with cursor indicator.
 /// Returns the rendered string with `_` at the cursor position.
@@ -827,6 +852,11 @@ fn draw_triage_view(frame: &mut Frame, ws: &app::WorkspaceState, area: Rect) {
             Span::styled(truncate_to_width(&item.title, title_max), title_style),
         ]);
         frame.render_widget(Paragraph::new(line1).style(row_bg), line1_area);
+        // Apply OSC 8 hyperlink to the title text if the item has a URL.
+        // Skip 4 columns: ▌(1) + selector(1) + dot(1) + space(1)
+        if let Some(ref url) = item.url {
+            apply_osc8_hyperlink(frame.buffer_mut(), line1_area, url, 4);
+        }
 
         // Line 2: ▌   source_label · age
         // Reserve width for " · {age}" so the age is never pushed off-screen.
@@ -3235,6 +3265,30 @@ fn draw_pr_list(frame: &mut Frame, app: &App, area: Rect) {
         .scroll((app.content_scroll, 0))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
+
+    // Post-render: apply OSC 8 hyperlinks to the URL line of each PR entry.
+    // Layout: 3 header lines (blank + ruler + blank), then per-PR: title(1) + url(1) + blank(1).
+    // URL line virtual index = 3 + pr_idx * 3 + 1 = 4 + pr_idx * 3.
+    // The URL text starts after 4 spaces of indent.
+    let header_lines: u16 = 3;
+    for (list_idx, (_, worker)) in prs.iter().enumerate() {
+        let pr = worker.pr.as_ref().unwrap();
+        let virtual_line = header_lines + list_idx as u16 * 3 + 1;
+        if virtual_line < app.content_scroll {
+            continue;
+        }
+        let row = virtual_line - app.content_scroll;
+        if row >= area.height {
+            break;
+        }
+        let url_area = Rect {
+            x: area.x,
+            y: area.y + row,
+            width: area.width,
+            height: 1,
+        };
+        apply_osc8_hyperlink(frame.buffer_mut(), url_area, &pr.url, 4);
+    }
 }
 
 // ── Status bar ───────────────────────────────────────────

--- a/vendor/apiari-tui/Cargo.toml
+++ b/vendor/apiari-tui/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "apiari-tui"
+version = "0.2.0"
+edition = "2024"
+description = "Shared TUI design system for Apiari tools — theme, scroll, and common widgets"
+license = "MIT"
+
+[lib]
+name = "apiari_tui"
+path = "src/lib.rs"
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+crossterm = { version = "0.28", features = ["event-stream"] }
+pulldown-cmark = "0.12"
+ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/vendor/apiari-tui/src/conversation.rs
+++ b/vendor/apiari-tui/src/conversation.rs
@@ -1,0 +1,269 @@
+//! Shared conversation types and rendering for agent TUI views.
+//!
+//! Used by both `swarm` (live agent TUI) and `apiari` (worker detail chat view).
+
+use crate::markdown;
+use crate::theme;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+
+/// A rendered conversation entry in the TUI.
+#[derive(Debug, Clone)]
+pub enum ConversationEntry {
+    /// User message.
+    User { text: String, timestamp: String },
+    /// Assistant text block (may be streamed incrementally).
+    AssistantText { text: String, timestamp: String },
+    /// A tool call with its result.
+    ToolCall {
+        tool: String,
+        input: String,
+        output: Option<String>,
+        is_error: bool,
+        collapsed: bool,
+    },
+    /// Assistant message that requires user response.
+    Question { text: String, timestamp: String },
+    /// Status message (e.g. "Session started", "Rate limited").
+    Status { text: String },
+}
+
+/// Render conversation entries into ratatui lines.
+///
+/// This is the shared "turn entries -> Lines" logic used by both swarm's agent TUI
+/// and apiari's worker detail view. Each caller handles scroll + frame rendering.
+///
+/// `focused_tool` is the index of the currently focused ToolCall entry (for
+/// keyboard navigation in swarm's TUI). Pass `None` when focus isn't relevant.
+///
+/// Returns an entry-line map: `Vec<(start_line, line_count)>` per entry,
+/// useful for scroll-to-focus calculations.
+pub fn render_conversation<'a>(
+    lines: &mut Vec<Line<'a>>,
+    entries: &'a [ConversationEntry],
+    focused_tool: Option<usize>,
+    assistant_label: Option<&str>,
+) -> Vec<(u32, u32)> {
+    let label = assistant_label.unwrap_or("Claude");
+    let mut last_shown_ts = String::new();
+    let mut entry_line_map: Vec<(u32, u32)> = Vec::with_capacity(entries.len());
+
+    for (i, entry) in entries.iter().enumerate() {
+        let start = lines.len() as u32;
+        let is_focused = focused_tool == Some(i);
+        match entry {
+            ConversationEntry::User { text, timestamp } => {
+                // Divider before user messages (visual turn boundary)
+                if i > 0 {
+                    lines.push(Line::from(""));
+                    lines.push(Line::from(Span::styled(
+                        format!("  {}", "\u{2500}".repeat(40)),
+                        Style::default().fg(theme::STEEL),
+                    )));
+                }
+                lines.push(Line::from(""));
+                let ts_span = dedup_timestamp(timestamp, &mut last_shown_ts);
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        "  You:",
+                        Style::default()
+                            .fg(theme::HONEY)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    ts_span,
+                ]));
+                for line in text.lines() {
+                    lines.push(Line::from(Span::styled(
+                        format!("  {}", line),
+                        theme::text(),
+                    )));
+                }
+            }
+            ConversationEntry::AssistantText { text, timestamp } => {
+                let in_same_turn = is_continuation_of_assistant_turn(entries, i);
+                if !in_same_turn {
+                    lines.push(Line::from(""));
+                    let ts_span = dedup_timestamp(timestamp, &mut last_shown_ts);
+                    lines.push(Line::from(vec![
+                        Span::styled(
+                            format!("  {label}:"),
+                            Style::default()
+                                .fg(theme::MINT)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                        ts_span,
+                    ]));
+                }
+                lines.extend(markdown::render_markdown(text));
+            }
+            ConversationEntry::ToolCall {
+                tool,
+                input,
+                output,
+                is_error,
+                collapsed,
+            } => {
+                let focus_prefix = if is_focused { "\u{25b6} " } else { "  " };
+                let tool_style_expanded = if is_focused {
+                    Style::default()
+                        .fg(theme::HONEY)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    theme::tool_name()
+                };
+                if *collapsed {
+                    let (icon, icon_style) = if output.is_none() {
+                        ("\u{22ef}", theme::muted())
+                    } else if *is_error {
+                        ("\u{2716}", theme::error())
+                    } else {
+                        ("\u{2714}", Style::default().fg(theme::STEEL))
+                    };
+                    let collapsed_tool_style = if is_focused {
+                        Style::default()
+                            .fg(theme::HONEY)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(theme::STEEL)
+                    };
+                    let preview = input
+                        .lines()
+                        .next()
+                        .unwrap_or("")
+                        .chars()
+                        .take(50)
+                        .collect::<String>();
+                    let ellipsis = if input.lines().next().is_some_and(|l| l.len() > 50) {
+                        "..."
+                    } else {
+                        ""
+                    };
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("{}{} ", focus_prefix, icon), icon_style),
+                        Span::styled(tool.as_str(), collapsed_tool_style),
+                        Span::styled(
+                            format!("  {}{}", preview, ellipsis),
+                            Style::default().fg(theme::STEEL),
+                        ),
+                    ]));
+                } else {
+                    lines.push(Line::from(""));
+                    lines.push(Line::from(vec![
+                        Span::styled(focus_prefix, theme::muted()),
+                        Span::styled(format!(" {} ", tool), tool_style_expanded),
+                        Span::styled(
+                            " \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+                            Style::default().fg(theme::STEEL),
+                        ),
+                    ]));
+                    for line in input.lines().take(5) {
+                        lines.push(Line::from(Span::styled(
+                            format!("  \u{2502} {}", line),
+                            Style::default().fg(theme::SLATE),
+                        )));
+                    }
+                    if input.lines().count() > 5 {
+                        lines.push(Line::from(Span::styled(
+                            format!("  \u{2502} ... ({} more lines)", input.lines().count() - 5),
+                            theme::muted(),
+                        )));
+                    }
+                    if let Some(out) = output {
+                        let out_style = if *is_error {
+                            theme::error()
+                        } else {
+                            theme::muted()
+                        };
+                        lines.push(Line::from(Span::styled(
+                            "  \u{251c}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+                            Style::default().fg(theme::STEEL),
+                        )));
+                        for line in out.lines().take(10) {
+                            lines.push(Line::from(Span::styled(
+                                format!("  \u{2502} {}", line),
+                                out_style,
+                            )));
+                        }
+                        if out.lines().count() > 10 {
+                            lines.push(Line::from(Span::styled(
+                                format!("  \u{2502} ... ({} more lines)", out.lines().count() - 10),
+                                theme::muted(),
+                            )));
+                        }
+                    }
+                    lines.push(Line::from(Span::styled(
+                        "  \u{2514}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+                        Style::default().fg(theme::STEEL),
+                    )));
+                }
+            }
+            ConversationEntry::Question { text, timestamp } => {
+                let in_same_turn = is_continuation_of_assistant_turn(entries, i);
+                if !in_same_turn {
+                    lines.push(Line::from(""));
+                    let ts_span = dedup_timestamp(timestamp, &mut last_shown_ts);
+                    lines.push(Line::from(vec![
+                        Span::styled(
+                            format!("  \u{2753} {label}:"),
+                            Style::default()
+                                .fg(theme::HONEY)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                        ts_span,
+                    ]));
+                } else {
+                    // Even in continuation mode, show a visual marker so
+                    // action-needed messages are always distinguishable.
+                    lines.push(Line::from(Span::styled(
+                        "  \u{2753}",
+                        Style::default()
+                            .fg(theme::HONEY)
+                            .add_modifier(Modifier::BOLD),
+                    )));
+                }
+                lines.extend(markdown::render_markdown(text));
+            }
+            ConversationEntry::Status { text } => {
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    format!("  {}", text),
+                    theme::muted(),
+                )));
+            }
+        }
+        let count = lines.len() as u32 - start;
+        entry_line_map.push((start, count));
+    }
+
+    entry_line_map
+}
+
+/// Check if entry at `idx` is a continuation of an assistant turn (looking past tool calls).
+fn is_continuation_of_assistant_turn(entries: &[ConversationEntry], idx: usize) -> bool {
+    if idx == 0 {
+        return false;
+    }
+    for j in (0..idx).rev() {
+        match &entries[j] {
+            ConversationEntry::AssistantText { .. } | ConversationEntry::Question { .. } => {
+                return true;
+            }
+            ConversationEntry::ToolCall { .. } => continue,
+            _ => return false,
+        }
+    }
+    false
+}
+
+/// Show timestamp only if it differs from the last shown one.
+fn dedup_timestamp<'a>(timestamp: &'a str, last_shown: &mut String) -> Span<'a> {
+    if timestamp == last_shown.as_str() || timestamp.is_empty() {
+        Span::raw("")
+    } else {
+        *last_shown = timestamp.to_string();
+        Span::styled(
+            format!("  {}", timestamp),
+            Style::default().fg(theme::SMOKE),
+        )
+    }
+}

--- a/vendor/apiari-tui/src/events_parser.rs
+++ b/vendor/apiari-tui/src/events_parser.rs
@@ -1,0 +1,344 @@
+//! Parse agent events.jsonl into ConversationEntry items.
+//!
+//! The events file is written by swarm's agent TUI at
+//! `.swarm/agents/{worktree_id}/events.jsonl`.
+
+use crate::conversation::ConversationEntry;
+use chrono::{DateTime, Local, Utc};
+use serde::{Deserialize, Serialize};
+use std::io::BufRead;
+use std::path::Path;
+
+/// Format a UTC timestamp as local time for display.
+fn fmt_ts(ts: &DateTime<Utc>) -> String {
+    ts.with_timezone(&Local).format("%-I:%M %p").to_string()
+}
+
+/// A structured event written to the agent's event log.
+///
+/// This is the canonical type for agent event serialization. Both swarm
+/// (writing) and apiari (reading) use this type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentEvent {
+    /// Session started.
+    Start {
+        timestamp: DateTime<Utc>,
+        prompt: String,
+        model: Option<String>,
+    },
+    /// User sent a follow-up message.
+    UserMessage {
+        timestamp: DateTime<Utc>,
+        text: String,
+    },
+    /// Assistant emitted text.
+    AssistantText {
+        timestamp: DateTime<Utc>,
+        text: String,
+    },
+    /// Assistant requested a tool call.
+    ToolUse {
+        timestamp: DateTime<Utc>,
+        tool: String,
+        input: String,
+    },
+    /// Tool execution completed.
+    ToolResult {
+        timestamp: DateTime<Utc>,
+        tool: String,
+        output: String,
+        is_error: bool,
+    },
+    /// SDK returned a result — session is now idle and resumable.
+    SessionResult {
+        timestamp: DateTime<Utc>,
+        turns: u64,
+        cost_usd: Option<f64>,
+        session_id: Option<String>,
+    },
+    /// Session errored.
+    Error {
+        timestamp: DateTime<Utc>,
+        message: String,
+    },
+}
+
+/// Parse an events.jsonl file into conversation entries.
+///
+/// Reads all events and converts them into a flat list of `ConversationEntry`
+/// items suitable for rendering. Unlike `read_last_session`, this doesn't
+/// require a completed session — it replays whatever events exist.
+///
+/// `SessionResult` events become status lines showing turn count and cost.
+pub fn parse_events(path: &Path) -> Vec<ConversationEntry> {
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+    let reader = std::io::BufReader::new(file);
+    let mut entries: Vec<ConversationEntry> = Vec::new();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event: AgentEvent = match serde_json::from_str(&line) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        match event {
+            AgentEvent::Start {
+                prompt, timestamp, ..
+            } => {
+                entries.push(ConversationEntry::User {
+                    text: prompt,
+                    timestamp: fmt_ts(&timestamp),
+                });
+            }
+            AgentEvent::UserMessage {
+                text, timestamp, ..
+            } => {
+                entries.push(ConversationEntry::User {
+                    text,
+                    timestamp: fmt_ts(&timestamp),
+                });
+            }
+            AgentEvent::AssistantText {
+                text, timestamp, ..
+            } => {
+                // Merge consecutive assistant text chunks into a single entry.
+                // The SDK streams text in small fragments; combining them produces
+                // one coherent message for markdown rendering.
+                if let Some(ConversationEntry::AssistantText {
+                    text: prev_text, ..
+                }) = entries.last_mut()
+                {
+                    prev_text.push_str(&text);
+                } else {
+                    entries.push(ConversationEntry::AssistantText {
+                        text,
+                        timestamp: fmt_ts(&timestamp),
+                    });
+                }
+            }
+            AgentEvent::ToolUse { tool, input, .. } => {
+                entries.push(ConversationEntry::ToolCall {
+                    tool,
+                    input,
+                    output: None,
+                    is_error: false,
+                    collapsed: true,
+                });
+            }
+            AgentEvent::ToolResult {
+                output, is_error, ..
+            } => {
+                // Update the last ToolCall entry with the result
+                if let Some(ConversationEntry::ToolCall {
+                    output: o,
+                    is_error: e,
+                    ..
+                }) = entries.last_mut()
+                {
+                    *o = Some(output);
+                    *e = is_error;
+                }
+            }
+            AgentEvent::SessionResult {
+                turns, cost_usd, ..
+            } => {
+                let cost_str = cost_usd.map(|c| format!(", ${:.2}", c)).unwrap_or_default();
+                entries.push(ConversationEntry::Status {
+                    text: format!("Session complete ({} turns{})", turns, cost_str),
+                });
+            }
+            AgentEvent::Error { message, .. } => {
+                entries.push(ConversationEntry::Status {
+                    text: format!("Error: {}", message),
+                });
+            }
+        }
+    }
+
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_events(events: &[AgentEvent]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        for ev in events {
+            let json = serde_json::to_string(ev).unwrap();
+            writeln!(f, "{}", json).unwrap();
+        }
+        f.flush().unwrap();
+        f
+    }
+
+    fn ts() -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    #[test]
+    fn parse_basic_conversation() {
+        let f = write_events(&[
+            AgentEvent::Start {
+                timestamp: ts(),
+                prompt: "fix the bug".into(),
+                model: Some("opus".into()),
+            },
+            AgentEvent::AssistantText {
+                timestamp: ts(),
+                text: "I'll fix it".into(),
+            },
+            AgentEvent::ToolUse {
+                timestamp: ts(),
+                tool: "Read".into(),
+                input: "src/main.rs".into(),
+            },
+            AgentEvent::ToolResult {
+                timestamp: ts(),
+                tool: "Read".into(),
+                output: "fn main() {}".into(),
+                is_error: false,
+            },
+            AgentEvent::SessionResult {
+                timestamp: ts(),
+                turns: 3,
+                cost_usd: Some(0.05),
+                session_id: Some("s1".into()),
+            },
+        ]);
+
+        let entries = parse_events(f.path());
+        assert_eq!(entries.len(), 4); // User, AssistantText, ToolCall, Status
+
+        assert!(matches!(
+            &entries[0],
+            ConversationEntry::User { text, .. } if text == "fix the bug"
+        ));
+        assert!(matches!(
+            &entries[1],
+            ConversationEntry::AssistantText { text, .. } if text == "I'll fix it"
+        ));
+        assert!(matches!(
+            &entries[2],
+            ConversationEntry::ToolCall { tool, output: Some(out), is_error: false, .. }
+            if tool == "Read" && out == "fn main() {}"
+        ));
+        assert!(matches!(
+            &entries[3],
+            ConversationEntry::Status { text } if text.contains("3 turns") && text.contains("$0.05")
+        ));
+    }
+
+    #[test]
+    fn parse_empty_file() {
+        let f = NamedTempFile::new().unwrap();
+        let entries = parse_events(f.path());
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn parse_nonexistent_file() {
+        let entries = parse_events(Path::new("/nonexistent/events.jsonl"));
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn parse_skips_corrupt_lines() {
+        let mut f = NamedTempFile::new().unwrap();
+        let ev = AgentEvent::Start {
+            timestamp: ts(),
+            prompt: "go".into(),
+            model: None,
+        };
+        writeln!(f, "{}", serde_json::to_string(&ev).unwrap()).unwrap();
+        writeln!(f, "not json").unwrap();
+        writeln!(f).unwrap();
+        let ev2 = AgentEvent::AssistantText {
+            timestamp: ts(),
+            text: "done".into(),
+        };
+        writeln!(f, "{}", serde_json::to_string(&ev2).unwrap()).unwrap();
+        f.flush().unwrap();
+
+        let entries = parse_events(f.path());
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn parse_followup_messages() {
+        let f = write_events(&[
+            AgentEvent::Start {
+                timestamp: ts(),
+                prompt: "initial".into(),
+                model: None,
+            },
+            AgentEvent::AssistantText {
+                timestamp: ts(),
+                text: "done".into(),
+            },
+            AgentEvent::SessionResult {
+                timestamp: ts(),
+                turns: 1,
+                cost_usd: None,
+                session_id: Some("s1".into()),
+            },
+            AgentEvent::UserMessage {
+                timestamp: ts(),
+                text: "follow up".into(),
+            },
+            AgentEvent::AssistantText {
+                timestamp: ts(),
+                text: "follow up answer".into(),
+            },
+            AgentEvent::SessionResult {
+                timestamp: ts(),
+                turns: 3,
+                cost_usd: Some(0.10),
+                session_id: Some("s1".into()),
+            },
+        ]);
+
+        let entries = parse_events(f.path());
+        // User, AssistantText, Status(session1), User, AssistantText, Status(session2)
+        assert_eq!(entries.len(), 6);
+        assert!(matches!(
+            &entries[3],
+            ConversationEntry::User { text, .. } if text == "follow up"
+        ));
+    }
+
+    #[test]
+    fn parse_error_events() {
+        let f = write_events(&[
+            AgentEvent::Start {
+                timestamp: ts(),
+                prompt: "go".into(),
+                model: None,
+            },
+            AgentEvent::Error {
+                timestamp: ts(),
+                message: "rate limited".into(),
+            },
+        ]);
+
+        let entries = parse_events(f.path());
+        assert_eq!(entries.len(), 2);
+        assert!(matches!(
+            &entries[1],
+            ConversationEntry::Status { text } if text == "Error: rate limited"
+        ));
+    }
+}

--- a/vendor/apiari-tui/src/lib.rs
+++ b/vendor/apiari-tui/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod conversation;
+pub mod events_parser;
+pub mod markdown;
+pub mod scroll;
+pub mod theme;

--- a/vendor/apiari-tui/src/markdown.rs
+++ b/vendor/apiari-tui/src/markdown.rs
@@ -1,0 +1,632 @@
+use crate::theme;
+use pulldown_cmark::{Alignment, Event, Options, Parser, Tag, TagEnd};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use std::borrow::Cow;
+
+/// Render markdown text into styled ratatui lines.
+/// Each line is indented with 2 spaces to match the conversation layout.
+pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
+    let cleaned = preprocess_markdown(text);
+    let mut renderer = MarkdownRenderer::new();
+    let opts =
+        Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH | Options::ENABLE_HEADING_ATTRIBUTES;
+    let parser = Parser::new_ext(&cleaned, opts);
+
+    for event in parser {
+        renderer.process(event);
+    }
+    renderer.finish()
+}
+
+/// Pre-process LLM output to fix common formatting issues before markdown parsing.
+///
+/// Handles:
+/// - Inline numbered lists: "text 1. item 2. item" → "text\n1. item\n2. item"
+/// - Run-together sentences: "done.Next" → "done.\n\nNext" (period+capital, no space)
+fn preprocess_markdown(text: &str) -> String {
+    let mut result = String::with_capacity(text.len() + 64);
+    let chars: Vec<char> = text.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        // Detect inline numbered list items: non-newline followed by "N. " where N is 1-9
+        // e.g., "...settings  2. Investigate" → "...settings\n2. Investigate"
+        if i + 3 < len && chars[i].is_ascii_digit() && chars[i + 1] == '.' && chars[i + 2] == ' ' {
+            // Check if preceded by text (not start-of-line)
+            let prev_is_text = i > 0 && chars[i - 1] != '\n';
+            // But only if this looks like a list item (next char after space is uppercase or backtick)
+            let next_is_item = i + 3 < len
+                && (chars[i + 3].is_uppercase()
+                    || chars[i + 3] == '`'
+                    || chars[i + 3] == '*'
+                    || chars[i + 3] == '[');
+            if prev_is_text && next_is_item {
+                result.push('\n');
+            }
+        }
+
+        // Detect run-together sentences: ".Capital" or "!Capital" or "?Capital" with no space
+        if i + 1 < len
+            && (chars[i] == '.' || chars[i] == '!' || chars[i] == '?')
+            && chars[i + 1].is_uppercase()
+        {
+            // Don't trigger on abbreviations like "U.S.A" or ellipsis
+            let is_abbrev = i > 0 && chars[i - 1].is_uppercase();
+            if !is_abbrev {
+                result.push(chars[i]);
+                result.push_str("\n\n");
+                i += 1;
+                continue;
+            }
+        }
+
+        result.push(chars[i]);
+        i += 1;
+    }
+
+    result
+}
+
+const INDENT: &str = "  ";
+const MIN_COL_WIDTH: usize = 3;
+const MAX_COL_WIDTH: usize = 40;
+
+struct MarkdownRenderer {
+    lines: Vec<Line<'static>>,
+    /// Current inline spans being accumulated for a paragraph/heading/list item.
+    spans: Vec<Span<'static>>,
+    /// Style stack for nested inline formatting (bold, italic, code).
+    style_stack: Vec<Style>,
+    /// Current heading level (0 = not in heading).
+    heading_level: u8,
+    /// List nesting: each entry is Some(counter) for ordered, None for unordered.
+    list_stack: Vec<Option<u64>>,
+    /// Whether we're at the start of a list item (need to emit bullet/number).
+    list_item_start: bool,
+    /// Table state.
+    table: Option<TableState>,
+    /// Whether we're inside a code block.
+    in_code_block: bool,
+    /// Code block language label.
+    code_lang: Option<String>,
+    /// Accumulated code block lines.
+    code_lines: Vec<String>,
+    /// Whether we're inside a link — accumulate text, emit styled at end.
+    link_url: Option<String>,
+}
+
+struct TableState {
+    alignments: Vec<Alignment>,
+    header_row: Vec<String>,
+    body_rows: Vec<Vec<String>>,
+    current_row: Vec<String>,
+    current_cell: String,
+    in_header: bool,
+}
+
+impl MarkdownRenderer {
+    fn new() -> Self {
+        Self {
+            lines: Vec::new(),
+            spans: Vec::new(),
+            style_stack: vec![Style::default().fg(theme::FROST)],
+            heading_level: 0,
+            list_stack: Vec::new(),
+            list_item_start: false,
+            table: None,
+            in_code_block: false,
+            code_lang: None,
+            code_lines: Vec::new(),
+            link_url: None,
+        }
+    }
+
+    fn current_style(&self) -> Style {
+        self.style_stack.last().copied().unwrap_or(theme::text())
+    }
+
+    fn list_indent(&self) -> String {
+        let depth = self.list_stack.len().saturating_sub(1);
+        format!("{}{}", INDENT, "  ".repeat(depth))
+    }
+
+    fn process(&mut self, event: Event<'_>) {
+        match event {
+            Event::Start(tag) => self.start_tag(tag),
+            Event::End(tag) => self.end_tag(tag),
+            Event::Text(text) => self.text(&text),
+            Event::Code(code) => self.inline_code(&code),
+            Event::SoftBreak => self.soft_break(),
+            Event::HardBreak => self.hard_break(),
+            Event::Rule => self.rule(),
+            _ => {}
+        }
+    }
+
+    fn start_tag(&mut self, tag: Tag<'_>) {
+        match tag {
+            Tag::Heading { level, .. } => {
+                self.heading_level = level as u8;
+                let style = match level {
+                    pulldown_cmark::HeadingLevel::H1 | pulldown_cmark::HeadingLevel::H2 => {
+                        Style::default()
+                            .fg(theme::HONEY)
+                            .add_modifier(Modifier::BOLD)
+                    }
+                    pulldown_cmark::HeadingLevel::H3 => Style::default()
+                        .fg(theme::FROST)
+                        .add_modifier(Modifier::BOLD),
+                    _ => Style::default().fg(theme::ICE).add_modifier(Modifier::BOLD),
+                };
+                self.style_stack.push(style);
+            }
+            Tag::Paragraph => {}
+            Tag::Emphasis => {
+                let base = self.current_style();
+                self.style_stack.push(base.add_modifier(Modifier::ITALIC));
+            }
+            Tag::Strong => {
+                let base = self.current_style();
+                self.style_stack.push(base.add_modifier(Modifier::BOLD));
+            }
+            Tag::List(start) => {
+                self.list_stack.push(start);
+            }
+            Tag::Item => {
+                self.list_item_start = true;
+            }
+            Tag::CodeBlock(kind) => {
+                self.in_code_block = true;
+                self.code_lines.clear();
+                self.code_lang = match kind {
+                    pulldown_cmark::CodeBlockKind::Fenced(lang) => {
+                        let l = lang.to_string();
+                        if l.is_empty() { None } else { Some(l) }
+                    }
+                    _ => None,
+                };
+            }
+            Tag::Table(alignments) => {
+                self.table = Some(TableState {
+                    alignments,
+                    header_row: Vec::new(),
+                    body_rows: Vec::new(),
+                    current_row: Vec::new(),
+                    current_cell: String::new(),
+                    in_header: false,
+                });
+            }
+            Tag::TableHead => {
+                if let Some(ref mut t) = self.table {
+                    t.in_header = true;
+                    t.current_row.clear();
+                }
+            }
+            Tag::TableRow => {
+                if let Some(ref mut t) = self.table {
+                    t.current_row.clear();
+                }
+            }
+            Tag::TableCell => {
+                if let Some(ref mut t) = self.table {
+                    t.current_cell.clear();
+                }
+            }
+            Tag::Link { dest_url, .. } => {
+                self.link_url = Some(dest_url.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    fn end_tag(&mut self, tag: TagEnd) {
+        match tag {
+            TagEnd::Heading(_) => {
+                self.style_stack.pop();
+                self.lines.push(Line::from(""));
+                self.flush_spans();
+                self.heading_level = 0;
+            }
+            TagEnd::Paragraph => {
+                self.flush_spans();
+                self.lines.push(Line::from(""));
+            }
+            TagEnd::Emphasis | TagEnd::Strong => {
+                self.style_stack.pop();
+            }
+            TagEnd::List(_) => {
+                self.list_stack.pop();
+                if self.list_stack.is_empty() {
+                    self.lines.push(Line::from(""));
+                }
+            }
+            TagEnd::Item => {
+                self.flush_spans();
+            }
+            TagEnd::CodeBlock => {
+                self.in_code_block = false;
+                self.emit_code_block();
+            }
+            TagEnd::Table => {
+                self.emit_table();
+            }
+            TagEnd::TableHead => {
+                if let Some(ref mut t) = self.table {
+                    t.header_row = std::mem::take(&mut t.current_row);
+                    t.in_header = false;
+                }
+            }
+            TagEnd::TableRow => {
+                if let Some(ref mut t) = self.table {
+                    let row = std::mem::take(&mut t.current_row);
+                    t.body_rows.push(row);
+                }
+            }
+            TagEnd::TableCell => {
+                if let Some(ref mut t) = self.table {
+                    let cell = std::mem::take(&mut t.current_cell);
+                    t.current_row.push(cell);
+                }
+            }
+            TagEnd::Link => {
+                if let Some(url) = self.link_url.take()
+                    && !url.is_empty()
+                {
+                    self.spans
+                        .push(Span::styled(format!(" ({})", url), theme::muted()));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn text(&mut self, text: &str) {
+        // Table cell text
+        if let Some(ref mut t) = self.table {
+            t.current_cell.push_str(text);
+            return;
+        }
+
+        // Code block text
+        if self.in_code_block {
+            self.code_lines.extend(text.lines().map(String::from));
+            if text.ends_with('\n') && self.code_lines.last().is_some_and(|l| l.is_empty()) {
+                self.code_lines.pop();
+            }
+            return;
+        }
+
+        // Link text — style as HONEY
+        if self.link_url.is_some() {
+            self.spans.push(Span::styled(
+                text.to_string(),
+                Style::default().fg(theme::HONEY),
+            ));
+            return;
+        }
+
+        // List item start — prepend bullet/number
+        if self.list_item_start {
+            self.list_item_start = false;
+            let indent = self.list_indent();
+            match self.list_stack.last_mut() {
+                Some(Some(n)) => {
+                    let prefix = format!("{}{}. ", indent, n);
+                    *n += 1;
+                    self.spans
+                        .push(Span::styled(prefix, Style::default().fg(theme::HONEY)));
+                }
+                _ => {
+                    let prefix = format!("{}\u{2022} ", indent);
+                    self.spans
+                        .push(Span::styled(prefix, Style::default().fg(theme::HONEY)));
+                }
+            }
+        }
+
+        let style = self.current_style();
+        self.spans.push(Span::styled(text.to_string(), style));
+    }
+
+    fn inline_code(&mut self, code: &str) {
+        // Table cell inline code
+        if let Some(ref mut t) = self.table {
+            t.current_cell.push_str(code);
+            return;
+        }
+
+        self.spans.push(Span::styled(
+            format!("`{}`", code),
+            Style::default().fg(theme::POLLEN),
+        ));
+    }
+
+    fn soft_break(&mut self) {
+        // In standard markdown, a single newline is treated as a space (not a line break).
+        // The Paragraph widget's Wrap handles visual line breaking at the viewport width.
+        let style = self.current_style();
+        self.spans.push(Span::styled(" ", style));
+    }
+
+    fn hard_break(&mut self) {
+        self.flush_spans();
+    }
+
+    fn rule(&mut self) {
+        self.lines.push(Line::from(Span::styled(
+            format!("{}────────────────────────────────────────", INDENT),
+            Style::default().fg(theme::STEEL),
+        )));
+        self.lines.push(Line::from(""));
+    }
+
+    /// Flush accumulated spans into a Line.
+    fn flush_spans(&mut self) {
+        if self.spans.is_empty() {
+            return;
+        }
+        let mut all_spans = vec![Span::raw(INDENT.to_string())];
+        all_spans.append(&mut self.spans);
+        self.lines.push(Line::from(all_spans));
+    }
+
+    fn emit_code_block(&mut self) {
+        let lang_label = self.code_lang.take();
+        let border_style = Style::default().fg(theme::STEEL);
+        let code_style = Style::default().fg(theme::SLATE);
+
+        let top = if let Some(ref lang) = lang_label {
+            format!(
+                "{}\u{250c}\u{2500}\u{2500} {} \u{2500}\u{2500}",
+                INDENT, lang
+            )
+        } else {
+            format!("{}\u{250c}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}", INDENT)
+        };
+        self.lines.push(Line::from(Span::styled(top, border_style)));
+
+        for line in &self.code_lines {
+            self.lines.push(Line::from(vec![
+                Span::styled(format!("{}\u{2502} ", INDENT), border_style),
+                Span::styled(line.to_string(), code_style),
+            ]));
+        }
+
+        self.lines.push(Line::from(Span::styled(
+            format!("{}\u{2514}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}", INDENT),
+            border_style,
+        )));
+        self.lines.push(Line::from(""));
+        self.code_lines.clear();
+    }
+
+    fn emit_table(&mut self) {
+        let table = match self.table.take() {
+            Some(t) => t,
+            None => return,
+        };
+
+        let num_cols = table.alignments.len().max(
+            table
+                .header_row
+                .len()
+                .max(table.body_rows.first().map_or(0, |r| r.len())),
+        );
+        if num_cols == 0 {
+            return;
+        }
+
+        let mut widths: Vec<usize> = vec![MIN_COL_WIDTH; num_cols];
+        for (i, cell) in table.header_row.iter().enumerate() {
+            if i < num_cols {
+                widths[i] = widths[i].max(cell.len()).min(MAX_COL_WIDTH);
+            }
+        }
+        for row in &table.body_rows {
+            for (i, cell) in row.iter().enumerate() {
+                if i < num_cols {
+                    widths[i] = widths[i].max(cell.len()).min(MAX_COL_WIDTH);
+                }
+            }
+        }
+
+        let border_style = Style::default().fg(theme::STEEL);
+        let header_style = Style::default()
+            .fg(theme::FROST)
+            .add_modifier(Modifier::BOLD);
+        let cell_style = Style::default().fg(theme::FROST);
+
+        let top = format!(
+            "{}\u{250c}{}\u{2510}",
+            INDENT,
+            widths
+                .iter()
+                .map(|w| "\u{2500}".repeat(w + 2))
+                .collect::<Vec<_>>()
+                .join("\u{252c}")
+        );
+        self.lines.push(Line::from(Span::styled(top, border_style)));
+
+        if !table.header_row.is_empty() {
+            let mut spans = vec![Span::styled(format!("{}\u{2502}", INDENT), border_style)];
+            for (i, cell) in table.header_row.iter().enumerate() {
+                let w = widths.get(i).copied().unwrap_or(MIN_COL_WIDTH);
+                let content = fit_cell(cell, w, table.alignments.get(i));
+                spans.push(Span::styled(format!(" {} ", content), header_style));
+                spans.push(Span::styled("\u{2502}", border_style));
+            }
+            for i in table.header_row.len()..num_cols {
+                let w = widths.get(i).copied().unwrap_or(MIN_COL_WIDTH);
+                spans.push(Span::styled(" ".repeat(w + 2), header_style));
+                spans.push(Span::styled("\u{2502}", border_style));
+            }
+            self.lines.push(Line::from(spans));
+
+            let sep = format!(
+                "{}\u{251c}{}\u{2524}",
+                INDENT,
+                widths
+                    .iter()
+                    .map(|w| "\u{2500}".repeat(w + 2))
+                    .collect::<Vec<_>>()
+                    .join("\u{253c}")
+            );
+            self.lines.push(Line::from(Span::styled(sep, border_style)));
+        }
+
+        for row in &table.body_rows {
+            let mut spans = vec![Span::styled(format!("{}\u{2502}", INDENT), border_style)];
+            for (i, cell) in row.iter().enumerate() {
+                let w = widths.get(i).copied().unwrap_or(MIN_COL_WIDTH);
+                let content = fit_cell(cell, w, table.alignments.get(i));
+                spans.push(Span::styled(format!(" {} ", content), cell_style));
+                spans.push(Span::styled("\u{2502}", border_style));
+            }
+            for i in row.len()..num_cols {
+                let w = widths.get(i).copied().unwrap_or(MIN_COL_WIDTH);
+                spans.push(Span::styled(" ".repeat(w + 2), cell_style));
+                spans.push(Span::styled("\u{2502}", border_style));
+            }
+            self.lines.push(Line::from(spans));
+        }
+
+        let bot = format!(
+            "{}\u{2514}{}\u{2518}",
+            INDENT,
+            widths
+                .iter()
+                .map(|w| "\u{2500}".repeat(w + 2))
+                .collect::<Vec<_>>()
+                .join("\u{2534}")
+        );
+        self.lines.push(Line::from(Span::styled(bot, border_style)));
+        self.lines.push(Line::from(""));
+    }
+
+    fn finish(mut self) -> Vec<Line<'static>> {
+        self.flush_spans();
+        self.lines
+    }
+}
+
+/// Fit cell content to a fixed width, with alignment support.
+fn fit_cell(text: &str, width: usize, alignment: Option<&Alignment>) -> Cow<'static, str> {
+    let text = text.trim();
+    let len = text.len();
+
+    if len > width {
+        let truncated = if width > 3 {
+            format!("{}...", &text[..width - 3])
+        } else {
+            text[..width].to_string()
+        };
+        return Cow::Owned(truncated);
+    }
+
+    let padding = width - len;
+    match alignment.unwrap_or(&Alignment::None) {
+        Alignment::Right => Cow::Owned(format!("{}{}", " ".repeat(padding), text)),
+        Alignment::Center => {
+            let left = padding / 2;
+            let right = padding - left;
+            Cow::Owned(format!("{}{}{}", " ".repeat(left), text, " ".repeat(right)))
+        }
+        _ => Cow::Owned(format!("{}{}", text, " ".repeat(padding))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text_passthrough() {
+        let lines = render_markdown("Hello world");
+        assert!(!lines.is_empty());
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect();
+        assert!(text.contains("Hello world"));
+    }
+
+    #[test]
+    fn bold_text() {
+        let lines = render_markdown("**bold**");
+        let has_bold = lines.iter().any(|l| {
+            l.spans.iter().any(|s| {
+                s.style.add_modifier.contains(Modifier::BOLD) && s.content.contains("bold")
+            })
+        });
+        assert!(has_bold, "Expected bold styled span");
+    }
+
+    #[test]
+    fn inline_code() {
+        let lines = render_markdown("use `foo` here");
+        let has_code = lines.iter().any(|l| {
+            l.spans
+                .iter()
+                .any(|s| s.style.fg == Some(theme::POLLEN) && s.content.contains("`foo`"))
+        });
+        assert!(has_code, "Expected inline code span with POLLEN color");
+    }
+
+    #[test]
+    fn code_block() {
+        let lines = render_markdown("```rust\nfn main() {}\n```");
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect();
+        assert!(text.contains("rust"), "Expected language label");
+        assert!(text.contains("fn main()"), "Expected code content");
+    }
+
+    #[test]
+    fn heading_h1() {
+        let lines = render_markdown("# Title");
+        let has_honey = lines.iter().any(|l| {
+            l.spans
+                .iter()
+                .any(|s| s.style.fg == Some(theme::HONEY) && s.content.contains("Title"))
+        });
+        assert!(has_honey, "Expected H1 with HONEY color");
+    }
+
+    #[test]
+    fn unordered_list() {
+        let lines = render_markdown("- item one\n- item two");
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect();
+        assert!(text.contains("\u{2022}"), "Expected bullet character");
+        assert!(text.contains("item one"));
+        assert!(text.contains("item two"));
+    }
+
+    #[test]
+    fn fit_cell_truncates() {
+        let result = fit_cell("very long text", 8, None);
+        assert_eq!(result.as_ref(), "very ...");
+    }
+
+    #[test]
+    fn fit_cell_right_align() {
+        let result = fit_cell("hi", 5, Some(&Alignment::Right));
+        assert_eq!(result.as_ref(), "   hi");
+    }
+
+    #[test]
+    fn empty_input() {
+        let lines = render_markdown("");
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect();
+        assert!(text.trim().is_empty());
+    }
+}

--- a/vendor/apiari-tui/src/scroll.rs
+++ b/vendor/apiari-tui/src/scroll.rs
@@ -1,0 +1,152 @@
+//! Visual-line-aware scrollable text rendering.
+//!
+//! Ratatui's `Paragraph::scroll()` counts **visual** lines (post-wrap), but most
+//! callers only know **logical** line counts.  When `Wrap` is enabled, long lines
+//! expand into multiple visual rows, so a naïve `total_logical - viewport` scroll
+//! offset falls short of the true bottom.
+//!
+//! `ScrollState` + `render_scrollable()` solve this by computing visual line
+//! counts the same way ratatui does (`ceil(line_width / viewport_width)`), keeping
+//! auto-scroll pinned to the real bottom.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::text::{Line, Text};
+use ratatui::widgets::{Block, Paragraph, Wrap};
+
+/// Scroll state for a scrollable text region.
+///
+/// `offset == 0` means "pinned to the bottom" (auto-scroll).
+/// Scrolling up increases `offset`; scrolling back to 0 re-enables auto-scroll.
+#[derive(Debug, Clone)]
+pub struct ScrollState {
+    /// Lines scrolled up from the bottom (0 = follow latest content).
+    pub offset: u32,
+    /// Whether we're auto-following new content.
+    pub auto_scroll: bool,
+}
+
+impl Default for ScrollState {
+    fn default() -> Self {
+        Self {
+            offset: 0,
+            auto_scroll: true,
+        }
+    }
+}
+
+impl ScrollState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Scroll up (away from bottom). Disables auto-scroll.
+    pub fn scroll_up(&mut self, amount: u32) {
+        self.offset = self.offset.saturating_add(amount);
+        self.auto_scroll = false;
+    }
+
+    /// Scroll down (toward bottom). Re-enables auto-scroll when reaching offset 0.
+    pub fn scroll_down(&mut self, amount: u32) {
+        self.offset = self.offset.saturating_sub(amount);
+        if self.offset == 0 {
+            self.auto_scroll = true;
+        }
+    }
+
+    /// Jump to bottom and re-enable auto-scroll.
+    pub fn scroll_to_bottom(&mut self) {
+        self.offset = 0;
+        self.auto_scroll = true;
+    }
+}
+
+/// Count total visual lines for `lines` at viewport width `w`.
+fn visual_line_count(lines: &[Line<'_>], w: usize) -> u32 {
+    let mut total: u32 = 0;
+    for line in lines {
+        let lw = line.width();
+        total += (lw.max(1).div_ceil(w)) as u32;
+    }
+    total
+}
+
+/// Render `lines` into `area` with visual-line-aware scrolling.
+///
+/// Handles both auto-scroll (pinned to bottom) and manual scroll modes.
+/// Uses `Wrap { trim: false }` so long lines wrap naturally.
+///
+/// The `block` is rendered first; scrollable content fills its inner area.
+/// Over-scroll is clamped — you can't scroll past the first line.
+pub fn render_scrollable<'a>(
+    frame: &mut Frame,
+    area: Rect,
+    lines: Vec<Line<'a>>,
+    scroll: &ScrollState,
+    block: Block<'a>,
+) {
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
+    let w = inner.width.max(1) as usize;
+    let visible_height = inner.height as u32;
+
+    if scroll.auto_scroll {
+        // Trim to a small tail so our visual-line estimate stays accurate
+        // (drift accumulates over many lines with ratatui's word-wrapping).
+        let keep_lines = (visible_height as usize) * 4 + 50;
+        let display_lines = if lines.len() > keep_lines {
+            &lines[lines.len() - keep_lines..]
+        } else {
+            &lines[..]
+        };
+
+        let tail_visual = visual_line_count(display_lines, w);
+        let scroll_rows = tail_visual.saturating_sub(visible_height);
+
+        let paragraph = Paragraph::new(Text::from(display_lines.to_vec()))
+            .scroll((scroll_rows.min(u16::MAX as u32) as u16, 0))
+            .wrap(Wrap { trim: false });
+        frame.render_widget(paragraph, inner);
+    } else {
+        // Manual scroll: use visual line count, clamp offset.
+        let total_visual = visual_line_count(&lines, w);
+        let max_offset = total_visual.saturating_sub(visible_height);
+        let clamped_offset = scroll.offset.min(max_offset);
+
+        let target_scroll = max_offset.saturating_sub(clamped_offset);
+
+        // For large offsets, drop earlier lines to avoid perf issues.
+        let (display_lines, effective_scroll) = if target_scroll > 500 {
+            let buffer = visible_height.max(100);
+            let drop_target = target_scroll.saturating_sub(buffer);
+            let mut drop_count = 0usize;
+            let mut dropped = 0u32;
+            for line in lines.iter() {
+                let lw = line.width();
+                let vl = (lw.max(1).div_ceil(w)) as u32;
+                if dropped + vl > drop_target {
+                    break;
+                }
+                dropped += vl;
+                drop_count += 1;
+            }
+            let adj = target_scroll - dropped;
+            (
+                Text::from(lines[drop_count..].to_vec()),
+                adj.min(u16::MAX as u32) as u16,
+            )
+        } else {
+            (Text::from(lines), target_scroll as u16)
+        };
+
+        let paragraph = Paragraph::new(display_lines)
+            .scroll((effective_scroll, 0))
+            .wrap(Wrap { trim: false });
+        frame.render_widget(paragraph, inner);
+    }
+}

--- a/vendor/apiari-tui/src/theme.rs
+++ b/vendor/apiari-tui/src/theme.rs
@@ -1,0 +1,171 @@
+#![allow(dead_code)]
+
+use ratatui::style::{Color, Modifier, Style};
+
+// ── Color Palette ──────────────────────────────────────────
+// Warm honey / amber tones for the bee theme.
+// Pops against dark terminal backgrounds.
+
+pub const HONEY: Color = Color::Rgb(255, 183, 77); // warm amber
+pub const GOLD: Color = Color::Rgb(255, 215, 0); // bright gold
+pub const NECTAR: Color = Color::Rgb(255, 138, 61); // deep orange
+pub const POLLEN: Color = Color::Rgb(250, 230, 140); // soft yellow
+pub const WAX: Color = Color::Rgb(60, 56, 48); // dark warm gray
+pub const COMB: Color = Color::Rgb(40, 37, 32); // darker bg
+pub const SMOKE: Color = Color::Rgb(140, 135, 125); // muted text
+pub const ROYAL: Color = Color::Rgb(160, 120, 255); // purple accent
+pub const MINT: Color = Color::Rgb(100, 230, 180); // green/success
+pub const EMBER: Color = Color::Rgb(255, 90, 90); // red/error
+pub const FROST: Color = Color::Rgb(220, 220, 225); // bright text
+pub const SLATE: Color = Color::Rgb(140, 145, 155); // cool gray for headers
+pub const STEEL: Color = Color::Rgb(100, 105, 115); // medium cool gray for borders
+pub const ICE: Color = Color::Rgb(175, 180, 190); // light cool gray for labels
+pub const HEADER_BG: Color = Color::Rgb(65, 60, 52); // section header bar bg (visible against terminal)
+pub const FOCUS_BG: Color = Color::Rgb(55, 47, 37); // warm tint for focused panel headers
+pub const TOOL_FOCUS_BG: Color = Color::Rgb(50, 47, 42); // subtle tint for focused tool entry
+pub const OVERLAY_BG: Color = Color::Rgb(30, 28, 25); // dark overlay background
+
+// ── Styles ─────────────────────────────────────────────────
+
+pub fn title() -> Style {
+    Style::default().fg(HONEY).add_modifier(Modifier::BOLD)
+}
+
+pub fn subtitle() -> Style {
+    Style::default().fg(SMOKE)
+}
+
+pub fn text() -> Style {
+    Style::default().fg(FROST)
+}
+
+pub fn muted() -> Style {
+    Style::default().fg(SMOKE)
+}
+
+pub fn accent() -> Style {
+    Style::default().fg(HONEY)
+}
+
+pub fn highlight() -> Style {
+    Style::default()
+        .fg(COMB)
+        .bg(HONEY)
+        .add_modifier(Modifier::BOLD)
+}
+
+pub fn selected() -> Style {
+    Style::default().fg(GOLD).add_modifier(Modifier::BOLD)
+}
+
+pub fn success() -> Style {
+    Style::default().fg(MINT)
+}
+
+pub fn error() -> Style {
+    Style::default().fg(EMBER)
+}
+
+pub fn agent_color() -> Style {
+    Style::default().fg(ROYAL)
+}
+
+pub fn key_hint() -> Style {
+    Style::default().fg(HONEY).add_modifier(Modifier::BOLD)
+}
+
+pub fn key_desc() -> Style {
+    Style::default().fg(SMOKE)
+}
+
+pub fn border() -> Style {
+    Style::default().fg(WAX)
+}
+
+pub fn border_active() -> Style {
+    Style::default().fg(HONEY)
+}
+
+pub fn tool_name() -> Style {
+    Style::default().fg(ICE).add_modifier(Modifier::BOLD)
+}
+
+pub fn border_neutral() -> Style {
+    Style::default().fg(STEEL)
+}
+
+pub fn input_cursor() -> Style {
+    Style::default().fg(GOLD).add_modifier(Modifier::BOLD)
+}
+
+pub fn status_running() -> Style {
+    Style::default().fg(MINT)
+}
+
+pub fn status_idle() -> Style {
+    Style::default().fg(SMOKE)
+}
+
+pub fn status_done() -> Style {
+    Style::default().fg(POLLEN)
+}
+
+pub fn logo() -> Style {
+    Style::default().fg(HONEY).add_modifier(Modifier::BOLD)
+}
+
+pub fn overlay_bg() -> Style {
+    Style::default().bg(OVERLAY_BG)
+}
+
+pub fn status_waiting() -> Style {
+    Style::default().fg(HONEY)
+}
+
+pub fn status_dead() -> Style {
+    Style::default().fg(EMBER)
+}
+
+pub fn status_pending() -> Style {
+    Style::default().fg(POLLEN)
+}
+
+pub fn severity_critical() -> Style {
+    Style::default().fg(EMBER).add_modifier(Modifier::BOLD)
+}
+
+pub fn severity_warning() -> Style {
+    Style::default().fg(NECTAR)
+}
+
+pub fn severity_info() -> Style {
+    Style::default().fg(SMOKE)
+}
+
+pub fn pr_open() -> Style {
+    Style::default().fg(MINT)
+}
+
+pub fn pr_merged() -> Style {
+    Style::default().fg(ROYAL)
+}
+
+pub fn pr_closed() -> Style {
+    Style::default().fg(EMBER)
+}
+
+pub fn divider() -> Style {
+    Style::default().fg(WAX)
+}
+
+/// Bright sidebar colors for the left bar indicator.
+pub const SIDEBAR_COLORS: &[Color] = &[
+    Color::Rgb(180, 120, 60), // warm brown
+    Color::Rgb(60, 120, 180), // cool blue
+    Color::Rgb(60, 180, 60),  // forest green
+    Color::Rgb(140, 60, 180), // purple
+    Color::Rgb(60, 180, 180), // teal
+    Color::Rgb(180, 150, 60), // amber
+    Color::Rgb(180, 60, 120), // rose
+    Color::Rgb(100, 180, 60), // olive
+];


### PR DESCRIPTION
## Summary

- **Bump ratatui 0.29 → 0.30**: Updated workspace `Cargo.toml`; `unstable-rendered-line-info` feature still exists in 0.30
- **Vendor `apiari-tui`**: Since `apiari-tui@0.2.0` requires `ratatui ^0.29` (semver-incompatible with 0.30), vendored it at `vendor/apiari-tui/` with `ratatui = "0.30"` and patched it in via `[patch.crates-io]`. No source changes needed — the library's basic text rendering API is unchanged in 0.30.
- **OSC 8 hyperlinks**: Added `apply_osc8_hyperlink()` helper that writes OSC 8 escape sequences (`\x1B]8;;url\x07symbol\x1B]8;;\x07`) to buffer cells post-render, making text clickable in terminals supporting OSC 8 (iTerm2, WezTerm, Kitty, etc.)
  - **PR list**: URL lines become clickable after the `Paragraph` renders
  - **Triage sidebar**: Item titles with a `url` field become clickable hyperlinks

## Test plan

- [ ] `cargo build -p apiari` compiles cleanly
- [ ] `cargo clippy -p apiari -- -D warnings` passes
- [ ] `cargo fmt -p apiari` produces no changes
- [ ] In a supporting terminal (iTerm2, WezTerm): PR list URLs and triage item titles are clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)