### PR TITLE
fix: reconcile draw_pr_list after merging PRs #214 and #216

### DIFF
--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -3283,8 +3283,11 @@ fn draw_pr_list(frame: &mut Frame, app: &App, area: Rect) {
     // URL line virtual index = 3 + pr_idx * 3 + 1 = 4 + pr_idx * 3.
     // The URL text starts after 4 spaces of indent.
     let header_lines: u16 = 3;
-    for (list_idx, (_, worker)) in prs.iter().enumerate() {
-        let pr = worker.pr.as_ref().unwrap();
+    for (list_idx, task) in tasks.iter().enumerate() {
+        let url = task.pr_url.as_deref().unwrap_or("");
+        if url.is_empty() {
+            continue;
+        }
         let virtual_line = header_lines + list_idx as u16 * 3 + 1;
         if virtual_line < app.content_scroll {
             continue;
@@ -3299,7 +3302,7 @@ fn draw_pr_list(frame: &mut Frame, app: &App, area: Rect) {
             width: area.width,
             height: 1,
         };
-        apply_osc8_hyperlink(frame.buffer_mut(), url_area, &pr.url, 4);
+        apply_osc8_hyperlink(frame.buffer_mut(), url_area, url, 4);
     }
 }
 


### PR DESCRIPTION
## Summary

- PRs #214 and #216 both modified `draw_pr_list()` in `render.rs`
- #214 switched the data source from workers to tasks (`tasks_with_prs()`)
- #216 added OSC 8 hyperlink post-render code referencing the old `prs`/`worker.pr` variables
- After both merged, the post-render loop referenced undefined `prs`, causing compile error E0425

The fix updates the OSC 8 hyperlink loop to iterate over `tasks` and read the URL via `task.pr_url`, preserving the hyperlink behavior from #216 while using the task-based data model from #214.

## Test plan

- [x] `cargo fmt -p apiari` passes
- [x] `cargo clippy -p apiari -- -D warnings` passes (clean compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)