### PR TITLE
fix: remove OSC 8 hyperlink from triage sidebar title (fixes garbled display)

### DIFF
--- a/crates/apiari/src/ui/render.rs
+++ b/crates/apiari/src/ui/render.rs
@@ -852,11 +852,6 @@ fn draw_triage_view(frame: &mut Frame, ws: &app::WorkspaceState, area: Rect) {
             Span::styled(truncate_to_width(&item.title, title_max), title_style),
         ]);
         frame.render_widget(Paragraph::new(line1).style(row_bg), line1_area);
-        // Apply OSC 8 hyperlink to the title text if the item has a URL.
-        // Skip 4 columns: ▌(1) + selector(1) + dot(1) + space(1)
-        if let Some(ref url) = item.url {
-            apply_osc8_hyperlink(frame.buffer_mut(), line1_area, url, 4);
-        }
 
         // Line 2: ▌   source_label · age
         // Reserve width for " · {age}" so the age is never pushed off-screen.


### PR DESCRIPTION
## Problem

After the ratatui 0.29→0.30 bump (PR #216), the triage sidebar displayed titles as garbled text with spaces between letters:

```
f     t    l         s      w    c            s
```

instead of:

```
feat: task lifecycle system with configurable stages
```

## Root Cause

`apply_osc8_hyperlink` sets each cell's symbol to the full OSC 8 escape sequence including the URL (e.g., `\x1B]8;;https://github.com/...\x07f\x1B]8;;\x07`).

In `unicode-width` 0.1.14, control characters like ESC (`\x1B`) and BEL (`\x07`) changed to have **width 1** (previously 0). This makes `symbol.width()` return ~54 for a typical GitHub URL symbol.

`Buffer::diff()` in ratatui-core uses `to_skip = current.symbol().width() - 1` to skip trailing cells after wide characters (e.g., CJK). With OSC8-tagged cells reporting width ~54, `to_skip` stays at 53 for all subsequent cells. Space characters (left as plain `" "` with width 1) reset `to_skip` to 0 — so only the **first character of each word** is emitted to the terminal, producing the observed garbled display.

## Fix

Remove the `apply_osc8_hyperlink` call for the triage sidebar title line. The title now renders as plain truncated text — correctly diffed, readable, and truncated with `…` when needed.

The `apply_osc8_hyperlink` function is still used by the PR list URL line, which is outside this PR's scope.

## Test

- Triage sidebar titles now display full readable text truncated cleanly with `…`
- `cargo fmt -p apiari` and `cargo clippy -p apiari -- -D warnings` both pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)