### PR TITLE
feat: simplified SwarmWatcher + system PR creation (Phase 3, #220)

### DIFF
--- a/crates/apiari/src/buzz/orchestrator/mod.rs
+++ b/crates/apiari/src/buzz/orchestrator/mod.rs
@@ -569,16 +569,22 @@ enum SignalKind {
 /// Classify a signal into a `SignalKind` based on source and external_id.
 fn signal_kind(signal: &SignalRecord) -> SignalKind {
     match signal.source.as_str() {
+        // New proper signal sources (Phase 3)
+        "swarm_worker_spawned" => SignalKind::WorkerSpawned,
         "swarm_worker_running" => SignalKind::WorkerRunning,
+        "swarm_worker_waiting" => SignalKind::WorkerWaiting,
+        "swarm_worker_closed" => SignalKind::WorkerClosed,
+        "swarm_pr_opened" => SignalKind::PrOpened,
         "swarm_branch_ready" => SignalKind::BranchReady,
         "swarm_review_verdict" => SignalKind::ReviewVerdict,
+        // GitHub signals
         "github_ci_pass" => SignalKind::CiPass,
         "github_ci_failure" => SignalKind::CiFailure,
         "github_bot_review" => SignalKind::BotReview,
         "github_merged_pr" => SignalKind::MergedPr,
         "github_pr_closed" => SignalKind::PrClosed,
+        // Backward compat: old "swarm" source with external_id disambiguation
         "swarm" => {
-            // Disambiguate generic "swarm" signals by external_id prefix
             if signal.external_id.starts_with("swarm-spawned-") {
                 SignalKind::WorkerSpawned
             } else if signal.external_id.starts_with("swarm-pr-") {
@@ -1071,6 +1077,29 @@ action = "Report the PR"
 
     #[test]
     fn test_signal_kind_classification() {
+        // New proper signal sources (Phase 3)
+        let s = make_signal("swarm_worker_spawned", "Worker spawned");
+        assert_eq!(signal_kind(&s), SignalKind::WorkerSpawned);
+
+        let s = make_signal("swarm_pr_opened", "PR opened");
+        assert_eq!(signal_kind(&s), SignalKind::PrOpened);
+
+        let s = make_signal("swarm_worker_running", "Worker running");
+        assert_eq!(signal_kind(&s), SignalKind::WorkerRunning);
+
+        let s = make_signal("swarm_worker_waiting", "Worker waiting");
+        assert_eq!(signal_kind(&s), SignalKind::WorkerWaiting);
+
+        let s = make_signal("swarm_worker_closed", "Worker closed");
+        assert_eq!(signal_kind(&s), SignalKind::WorkerClosed);
+
+        let s = make_signal("swarm_branch_ready", "Branch ready");
+        assert_eq!(signal_kind(&s), SignalKind::BranchReady);
+
+        let s = make_signal("swarm_review_verdict", "Review verdict");
+        assert_eq!(signal_kind(&s), SignalKind::ReviewVerdict);
+
+        // Backward compat: old "swarm" source with external_id disambiguation
         let mut s = make_signal("swarm", "Worker spawned");
         s.external_id = "swarm-spawned-abc".to_string();
         assert_eq!(signal_kind(&s), SignalKind::WorkerSpawned);
@@ -1079,9 +1108,7 @@ action = "Report the PR"
         s.external_id = "swarm-pr-abc".to_string();
         assert_eq!(signal_kind(&s), SignalKind::PrOpened);
 
-        let s = make_signal("swarm_branch_ready", "Branch ready");
-        assert_eq!(signal_kind(&s), SignalKind::BranchReady);
-
+        // GitHub signals
         let s = make_signal("github_merged_pr", "Merged");
         assert_eq!(signal_kind(&s), SignalKind::MergedPr);
 

--- a/crates/apiari/src/buzz/orchestrator/workflow.rs
+++ b/crates/apiari/src/buzz/orchestrator/workflow.rs
@@ -4,7 +4,11 @@
 //! The `branch_ready_action` config controls whether AI review is injected
 //! before PR creation or skipped entirely.
 
+use std::path::Path;
+
+use color_eyre::eyre::bail;
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 /// What happens when a worker pushes a branch (BRANCH_READY signal).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -130,6 +134,63 @@ impl WorkflowEngine {
     pub fn config(&self) -> &WorkflowConfig {
         &self.config
     }
+}
+
+/// Result of a system PR creation.
+#[derive(Debug, Clone)]
+pub struct PrCreationResult {
+    /// The URL of the created PR.
+    pub pr_url: String,
+    /// The PR number extracted from the URL.
+    pub pr_number: Option<i64>,
+}
+
+/// Create a PR via `gh pr create` as a system action.
+///
+/// The system (not the agent) creates PRs — this makes the workflow
+/// agent-agnostic (works with Claude, Codex, or any sandboxed agent).
+pub async fn create_system_pr(
+    work_dir: &Path,
+    branch_name: &str,
+    title: &str,
+    body: &str,
+) -> color_eyre::Result<PrCreationResult> {
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "pr",
+            "create",
+            "--head",
+            branch_name,
+            "--base",
+            "main",
+            "--title",
+            title,
+            "--body",
+            body,
+        ])
+        .current_dir(work_dir)
+        .output()
+        .await
+        .map_err(|e| color_eyre::eyre::eyre!("failed to run gh pr create: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("gh pr create failed: {stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    info!("[workflow] system PR created: {stdout}");
+
+    // Extract PR number from URL (e.g. https://github.com/owner/repo/pull/123)
+    let pr_number = stdout
+        .rsplit('/')
+        .next()
+        .and_then(|s| s.parse::<i64>().ok());
+
+    Ok(PrCreationResult {
+        pr_url: stdout,
+        pr_number,
+    })
 }
 
 #[cfg(test)]

--- a/crates/apiari/src/buzz/watcher/swarm.rs
+++ b/crates/apiari/src/buzz/watcher/swarm.rs
@@ -1,10 +1,8 @@
 //! Swarm watcher — monitors worker state via daemon socket subscription.
 //!
-//! Uses `apiari_swarm::daemon` IPC to subscribe to real-time `StateChanged`
-//! events from the swarm daemon. Falls back to `ListWorkers` for full state
-//! sync (PR detection, new/closed workers, reconnection).
-//!
-//! Replaces the previous approach of polling `.swarm/state.json` on disk.
+//! Pure state-fetcher: polls the daemon for worker state, compares to previous
+//! state, and emits signals for changes. All business logic (notifications,
+//! task transitions, PR creation, review dispatch) lives in the orchestrator.
 
 use std::{
     collections::HashMap,
@@ -15,7 +13,6 @@ use std::{
     },
 };
 
-use a2a_types::TaskState;
 use apiari_swarm::{
     WorkerPhase,
     client::{
@@ -24,46 +21,29 @@ use apiari_swarm::{
     },
 };
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use color_eyre::Result;
-use tracing::{info, warn};
+use tracing::info;
 
 use super::Watcher;
 use crate::buzz::signal::{Severity, SignalStatus, SignalUpdate, store::SignalStore};
 
-/// Tracked state for a worktree between polls.
+/// Tracked state for a worker between polls.
 #[derive(Debug, Clone)]
 struct TrackedWorker {
     phase: WorkerPhase,
     has_pr: bool,
     ready_branch: Option<String>,
-    /// Role of this worker ("reviewer" or None/other = regular worker).
     role: Option<String>,
-    /// Count of times this worker has transitioned into Running phase.
-    /// Used to make each Running-transition signal unique (so the task engine fires each time).
     running_count: u32,
 }
 
-/// Buffered A2aTaskUpdate event from the subscription task.
-struct A2aEvent {
-    worktree_id: String,
-    task_state: TaskState,
-    /// Raw JSON message (parsed from the wire).
-    message: Option<serde_json::Value>,
-    timestamp: DateTime<Utc>,
-}
-
-/// Watches swarm daemon for worker state changes via socket subscription.
+/// Watches swarm daemon for worker state changes.
 pub struct SwarmWatcher {
     work_dir: PathBuf,
-    /// Previous state of each worktree.
     tracked: HashMap<String, TrackedWorker>,
     initialized: bool,
-    /// Buffered StateChanged events from the subscription task.
+    /// Buffered phase transitions from the subscription task.
     events: Arc<Mutex<Vec<(String, WorkerPhase)>>>,
-    /// Buffered A2aTaskUpdate events from the subscription task.
-    a2a_events: Arc<Mutex<Vec<A2aEvent>>>,
-    /// Whether the subscription task has been spawned.
     subscription_started: Arc<AtomicBool>,
 }
 
@@ -74,12 +54,10 @@ impl SwarmWatcher {
             tracked: HashMap::new(),
             initialized: false,
             events: Arc::new(Mutex::new(Vec::new())),
-            a2a_events: Arc::new(Mutex::new(Vec::new())),
             subscription_started: Arc::new(AtomicBool::new(false)),
         }
     }
 
-    /// Query the daemon for the current list of workers.
     fn list_workers(&self) -> Option<Vec<WorkerInfo>> {
         let req = DaemonRequest::ListWorkers {
             workspace: Some(self.work_dir.clone()),
@@ -87,7 +65,7 @@ impl SwarmWatcher {
         match send_daemon_request(&self.work_dir, &req) {
             Ok(DaemonResponse::Workers { workers }) => Some(workers),
             Ok(DaemonResponse::Error { message }) => {
-                warn!("swarm: list_workers error: {message}");
+                tracing::warn!("swarm: list_workers error: {message}");
                 None
             }
             Ok(_) => None,
@@ -98,7 +76,6 @@ impl SwarmWatcher {
         }
     }
 
-    /// Spawn the background subscription task (once).
     fn ensure_subscription(&self) {
         if self
             .subscription_started
@@ -107,50 +84,41 @@ impl SwarmWatcher {
         {
             let work_dir = self.work_dir.clone();
             let events = Arc::clone(&self.events);
-            let a2a_events = Arc::clone(&self.a2a_events);
-            tokio::spawn(subscription_loop(work_dir, events, a2a_events));
+            tokio::spawn(subscription_loop(work_dir, events));
         }
     }
 
-    /// Drain buffered subscription events and apply phase transitions.
+    /// Apply buffered subscription events as phase transition signals.
     fn drain_events(&mut self, signals: &mut Vec<SignalUpdate>) {
-        let events: Vec<(String, WorkerPhase)> = {
-            let mut buf = self.events.lock().unwrap();
-            std::mem::take(&mut *buf)
-        };
-
+        let events: Vec<(String, WorkerPhase)> = std::mem::take(&mut *self.events.lock().unwrap());
         for (id, phase) in events {
             let prev_phase = self.tracked.get(&id).map(|p| p.phase.clone());
-            let role = self.tracked.get(&id).and_then(|p| p.role.clone());
+            let role = self
+                .tracked
+                .get(&id)
+                .and_then(|p| p.role.clone())
+                .unwrap_or_else(|| "worker".to_string());
 
-            // Running transition — emit swarm_worker_running for non-reviewer workers
             if phase == WorkerPhase::Running
                 && prev_phase
                     .as_ref()
                     .is_some_and(|p| *p != WorkerPhase::Running)
+                && role != "reviewer"
             {
-                let role_str = role.as_deref().unwrap_or("worker");
-                if role_str != "reviewer" {
-                    // Increment running_count first so external_id is unique per transition
-                    if let Some(tracked) = self.tracked.get_mut(&id) {
-                        tracked.running_count += 1;
-                    }
-                    let running_count = self.tracked.get(&id).map_or(1, |p| p.running_count);
-                    let metadata =
-                        serde_json::json!({"worker_id": id, "role": role_str}).to_string();
-                    signals.push(
-                        SignalUpdate::new(
-                            "swarm_worker_running",
-                            format!("swarm-worker-running-{id}-{running_count}"),
-                            format!("Worker running: {id}"),
-                            Severity::Info,
-                        )
-                        .with_metadata(metadata),
-                    );
+                if let Some(t) = self.tracked.get_mut(&id) {
+                    t.running_count += 1;
                 }
+                let rc = self.tracked.get(&id).map_or(1, |p| p.running_count);
+                signals.push(
+                    SignalUpdate::new(
+                        "swarm_worker_running",
+                        format!("swarm-worker-running-{id}-{rc}"),
+                        format!("Worker running: {id}"),
+                        Severity::Info,
+                    )
+                    .with_metadata(serde_json::json!({"worker_id": id, "role": role}).to_string()),
+                );
             }
-
-            // Waiting transition
             if phase == WorkerPhase::Waiting
                 && prev_phase
                     .as_ref()
@@ -158,7 +126,7 @@ impl SwarmWatcher {
             {
                 signals.push(
                     SignalUpdate::new(
-                        "swarm",
+                        "swarm_worker_waiting",
                         format!("swarm-waiting-{id}"),
                         format!("Worker waiting: {id}"),
                         Severity::Warning,
@@ -166,242 +134,23 @@ impl SwarmWatcher {
                     .with_body(format!("Agent in {id} is waiting for input")),
                 );
             }
-
-            // Completed/Failed transition — emit so daemon can read verdict before teardown
             if phase.is_terminal() && prev_phase.as_ref().is_some_and(|p| !p.is_terminal()) {
-                signals.push(
-                    SignalUpdate::new(
-                        "swarm",
-                        format!("swarm-completed-{id}"),
-                        format!("Worker completed: {id}"),
-                        Severity::Info,
-                    )
-                    .with_body(format!("Worker {id} has completed")),
-                );
+                signals.push(SignalUpdate::new(
+                    "swarm_worker_closed",
+                    format!("swarm-completed-{id}"),
+                    format!("Worker completed: {id}"),
+                    Severity::Info,
+                ));
             }
-
-            // Update tracked phase (preserve has_pr and role since StateChanged doesn't carry them)
-            if let Some(tracked) = self.tracked.get_mut(&id) {
-                tracked.phase = phase;
+            if let Some(t) = self.tracked.get_mut(&id) {
+                t.phase = phase;
             }
         }
     }
 
-    /// Drain buffered A2aTaskUpdate events and emit signals from structured data.
-    ///
-    /// Handles `branch_ready`, `pr_opened`, and `review_verdict` data parts, and
-    /// emits richer phase-transition signals. Runs before `drain_events` so that
-    /// phase updates applied here suppress duplicate transitions in `drain_events`.
-    fn drain_a2a_events(&mut self, signals: &mut Vec<SignalUpdate>) {
-        let events: Vec<A2aEvent> = {
-            let mut buf = self.a2a_events.lock().unwrap();
-            std::mem::take(&mut *buf)
-        };
-
-        for event in events {
-            let id = &event.worktree_id;
-
-            // --- Structured data from message parts ---
-            if let Some(msg) = &event.message
-                && let Some(parts) = msg.get("parts").and_then(|p| p.as_array())
-            {
-                for part in parts {
-                    if part.get("type").and_then(|t| t.as_str()) != Some("data") {
-                        continue;
-                    }
-                    let data = match part.get("data") {
-                        Some(d) => d,
-                        None => continue,
-                    };
-                    let part_type = data.get("type").and_then(|t| t.as_str()).unwrap_or("");
-                    match part_type {
-                        "branch_ready" => {
-                            let branch = data.get("branch").and_then(|b| b.as_str()).unwrap_or("");
-                            if !branch.is_empty() {
-                                let had_ready_branch = self
-                                    .tracked
-                                    .get(id)
-                                    .and_then(|p| p.ready_branch.as_deref())
-                                    .is_some();
-                                let has_pr = self.tracked.get(id).is_some_and(|p| p.has_pr);
-                                if !had_ready_branch && !has_pr {
-                                    let metadata = serde_json::json!({
-                                        "worker_id": id,
-                                        "branch_name": branch,
-                                    });
-                                    signals.push(
-                                        SignalUpdate::new(
-                                            "swarm_branch_ready",
-                                            format!("swarm-branch-ready-{id}"),
-                                            format!("Branch ready for review: {branch}"),
-                                            Severity::Info,
-                                        )
-                                        .with_metadata(metadata.to_string()),
-                                    );
-                                }
-                                if let Some(tracked) = self.tracked.get_mut(id) {
-                                    tracked.ready_branch = Some(branch.to_string());
-                                }
-                            }
-                        }
-                        "pr_opened" => {
-                            let pr_url = data.get("pr_url").and_then(|u| u.as_str()).unwrap_or("");
-                            let pr_number = data.get("pr_number").and_then(|n| n.as_u64());
-                            let has_pr = self.tracked.get(id).is_some_and(|p| p.has_pr);
-                            if !has_pr && !pr_url.is_empty() {
-                                let metadata = serde_json::json!({
-                                    "worker_id": id,
-                                    "pr_url": pr_url,
-                                    "pr_number": pr_number,
-                                });
-                                let mut signal = SignalUpdate::new(
-                                    "swarm",
-                                    format!("swarm-pr-{id}"),
-                                    format!("PR opened: {id}"),
-                                    Severity::Info,
-                                )
-                                .with_body(format!("#{} {pr_url}", pr_number.unwrap_or(0)))
-                                .with_metadata(metadata.to_string());
-                                signal = signal.with_url(pr_url);
-                                signals.push(signal);
-                                if let Some(tracked) = self.tracked.get_mut(id) {
-                                    tracked.has_pr = true;
-                                }
-                            }
-                        }
-                        "review_verdict" => {
-                            let approved = data
-                                .get("approved")
-                                .and_then(|a| a.as_bool())
-                                .unwrap_or(false);
-                            let comments = data.get("comments").cloned();
-                            let metadata = serde_json::json!({
-                                "worker_id": id,
-                                "approved": approved,
-                                "comments": comments,
-                            });
-                            let ts = event.timestamp.timestamp();
-                            signals.push(
-                                SignalUpdate::new(
-                                    "swarm_review_verdict",
-                                    format!("swarm-review-verdict-{id}-{ts}"),
-                                    if approved {
-                                        format!("Review approved: {id}")
-                                    } else {
-                                        format!("Review rejected: {id}")
-                                    },
-                                    if approved {
-                                        Severity::Info
-                                    } else {
-                                        Severity::Warning
-                                    },
-                                )
-                                .with_metadata(metadata.to_string()),
-                            );
-                        }
-                        _ => {}
-                    }
-                }
-            }
-
-            // --- Phase transitions from A2a task_state ---
-            let prev_phase = self.tracked.get(id).map(|p| p.phase.clone());
-            let role = self.tracked.get(id).and_then(|p| p.role.clone());
-            let role_str = role.as_deref().unwrap_or("worker");
-
-            match event.task_state {
-                TaskState::Working => {
-                    if prev_phase
-                        .as_ref()
-                        .is_some_and(|p| *p != WorkerPhase::Running)
-                        && role_str != "reviewer"
-                    {
-                        if let Some(tracked) = self.tracked.get_mut(id) {
-                            tracked.running_count += 1;
-                        }
-                        let running_count = self.tracked.get(id).map_or(1, |p| p.running_count);
-                        let metadata = serde_json::json!({
-                            "worker_id": id,
-                            "role": role_str,
-                            "task_state": "Working",
-                        })
-                        .to_string();
-                        signals.push(
-                            SignalUpdate::new(
-                                "swarm_worker_running",
-                                format!("swarm-worker-running-{id}-{running_count}"),
-                                format!("Worker running: {id}"),
-                                Severity::Info,
-                            )
-                            .with_metadata(metadata),
-                        );
-                    }
-                    if let Some(tracked) = self.tracked.get_mut(id) {
-                        tracked.phase = WorkerPhase::Running;
-                    }
-                }
-                TaskState::InputRequired => {
-                    if prev_phase
-                        .as_ref()
-                        .is_some_and(|p| *p != WorkerPhase::Waiting)
-                    {
-                        signals.push(
-                            SignalUpdate::new(
-                                "swarm",
-                                format!("swarm-waiting-{id}"),
-                                format!("Worker waiting: {id}"),
-                                Severity::Warning,
-                            )
-                            .with_body(format!("Agent in {id} is waiting for input")),
-                        );
-                    }
-                    if let Some(tracked) = self.tracked.get_mut(id) {
-                        tracked.phase = WorkerPhase::Waiting;
-                    }
-                }
-                TaskState::Completed => {
-                    if prev_phase.as_ref().is_some_and(|p| !p.is_terminal()) {
-                        signals.push(
-                            SignalUpdate::new(
-                                "swarm",
-                                format!("swarm-completed-{id}"),
-                                format!("Worker completed: {id}"),
-                                Severity::Info,
-                            )
-                            .with_body(format!("Worker {id} has completed")),
-                        );
-                    }
-                    if let Some(tracked) = self.tracked.get_mut(id) {
-                        tracked.phase = WorkerPhase::Completed;
-                    }
-                }
-                TaskState::Failed => {
-                    if prev_phase.as_ref().is_some_and(|p| !p.is_terminal()) {
-                        signals.push(
-                            SignalUpdate::new(
-                                "swarm",
-                                format!("swarm-completed-{id}"),
-                                format!("Worker completed: {id}"),
-                                Severity::Info,
-                            )
-                            .with_body(format!("Worker {id} has completed")),
-                        );
-                    }
-                    if let Some(tracked) = self.tracked.get_mut(id) {
-                        tracked.phase = WorkerPhase::Failed;
-                    }
-                }
-                // Submitted, Canceled, Rejected, AuthRequired, Unknown — no specific handling
-                _ => {}
-            }
-        }
-    }
-
-    /// Read `ready_branch` for each worker from `.swarm/state.json`.
-    /// Returns a map of worker_id → (ready_branch, repo_path).
+    /// Read `ready_branch` from `.swarm/state.json`.
     fn read_ready_branches(&self) -> HashMap<String, (String, String)> {
-        let state_path = self.work_dir.join(".swarm").join("state.json");
-        let raw = match std::fs::read_to_string(&state_path) {
+        let raw = match std::fs::read_to_string(self.work_dir.join(".swarm/state.json")) {
             Ok(s) => s,
             Err(_) => return HashMap::new(),
         };
@@ -410,30 +159,26 @@ impl SwarmWatcher {
             Err(_) => return HashMap::new(),
         };
         let mut map = HashMap::new();
-        if let Some(worktrees) = state.get("worktrees").and_then(|w| w.as_array()) {
-            for wt in worktrees {
-                let id = wt
-                    .get("id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
+        if let Some(wts) = state.get("worktrees").and_then(|w| w.as_array()) {
+            for wt in wts {
+                let id = wt.get("id").and_then(|v| v.as_str()).unwrap_or("");
                 if id.is_empty() {
                     continue;
                 }
                 if let Some(branch) = wt.get("ready_branch").and_then(|v| v.as_str()) {
-                    let repo_path = wt
+                    let repo = wt
                         .get("repo_path")
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .to_string();
-                    map.insert(id, (branch.to_string(), repo_path));
+                    map.insert(id.to_string(), (branch.to_string(), repo));
                 }
             }
         }
         map
     }
 
-    /// Diff the full worker list against tracked state.
+    /// Diff the full worker list against tracked state, emit signals.
     fn diff_workers(&mut self, workers: &[WorkerInfo]) -> Vec<SignalUpdate> {
         let ready_branches = self.read_ready_branches();
         let mut signals = Vec::new();
@@ -443,17 +188,13 @@ impl SwarmWatcher {
             let prev = self.tracked.get(id);
             let has_pr = w.pr_url.is_some();
             let ready_branch = ready_branches.get(id.as_str()).map(|(b, _)| b.clone());
-            let repo_path = ready_branches
-                .get(id.as_str())
-                .map(|(_, r)| r.clone())
-                .unwrap_or_default();
             let role = w.role.as_deref().unwrap_or("worker");
 
+            // New worker spawned
             if prev.is_none() {
-                // New worktree spawned
                 signals.push(
                     SignalUpdate::new(
-                        "swarm",
+                        "swarm_worker_spawned",
                         format!("swarm-spawned-{id}"),
                         format!("Worker spawned: {id}"),
                         Severity::Info,
@@ -466,72 +207,74 @@ impl SwarmWatcher {
                 );
             }
 
-            // Branch ready transition: ready_branch became set and no PR opened yet
-            let had_ready_branch = prev.and_then(|p| p.ready_branch.as_deref()).is_some();
-            if ready_branch.is_some() && !had_ready_branch && !has_pr {
-                let branch_name = ready_branch.as_deref().unwrap_or("");
-                let metadata = serde_json::json!({
-                    "worker_id": id,
-                    "branch_name": branch_name,
-                    "repo": repo_path,
-                });
+            // Branch ready transition
+            let had_ready = prev.and_then(|p| p.ready_branch.as_deref()).is_some();
+            if ready_branch.is_some() && !had_ready && !has_pr {
+                let branch = ready_branch.as_deref().unwrap_or("");
+                let repo = ready_branches
+                    .get(id.as_str())
+                    .map(|(_, r)| r.as_str())
+                    .unwrap_or("");
                 signals.push(
                     SignalUpdate::new(
                         "swarm_branch_ready",
                         format!("swarm-branch-ready-{id}"),
-                        format!("Branch ready for review: {branch_name}"),
+                        format!("Branch ready for review: {branch}"),
                         Severity::Info,
                     )
-                    .with_metadata(metadata.to_string()),
+                    .with_metadata(
+                        serde_json::json!({"worker_id": id, "branch_name": branch, "repo": repo})
+                            .to_string(),
+                    ),
                 );
             }
 
             // PR opened transition
             if has_pr && prev.is_some_and(|p| !p.has_pr) {
-                let title = w.pr_title.as_deref().unwrap_or("");
                 let url = w.pr_url.as_deref().unwrap_or("");
-
-                let mut signal = SignalUpdate::new(
-                    "swarm",
+                let title = w.pr_title.as_deref().unwrap_or("");
+                let pr_number = w.pr_number;
+                let mut sig = SignalUpdate::new(
+                    "swarm_pr_opened",
                     format!("swarm-pr-{id}"),
                     format!("PR opened: {id}"),
                     Severity::Info,
                 )
-                .with_body(format!("{title}\n{url}"));
-
+                .with_body(format!("{title}\n{url}"))
+                .with_metadata(
+                    serde_json::json!({"worker_id": id, "pr_url": url, "pr_number": pr_number})
+                        .to_string(),
+                );
                 if !url.is_empty() {
-                    signal = signal.with_url(url);
+                    sig = sig.with_url(url);
                 }
-                signals.push(signal);
+                signals.push(sig);
             }
 
-            // Running transition — emit swarm_worker_running for non-reviewer workers
-            // (from ListWorkers, in case subscription missed it)
+            // Running transition (supplements subscription for reliability)
             if w.phase == WorkerPhase::Running
                 && prev.is_some_and(|p| p.phase != WorkerPhase::Running)
                 && role != "reviewer"
             {
-                let prev_running_count = prev.map_or(0, |p| p.running_count);
-                let new_running_count = prev_running_count + 1;
-                let metadata = serde_json::json!({"worker_id": id, "role": role}).to_string();
+                let rc = prev.map_or(0, |p| p.running_count) + 1;
                 signals.push(
                     SignalUpdate::new(
                         "swarm_worker_running",
-                        format!("swarm-worker-running-{id}-{new_running_count}"),
+                        format!("swarm-worker-running-{id}-{rc}"),
                         format!("Worker running: {id}"),
                         Severity::Info,
                     )
-                    .with_metadata(metadata),
+                    .with_metadata(serde_json::json!({"worker_id": id, "role": role}).to_string()),
                 );
             }
 
-            // Waiting transition (from ListWorkers, in case subscription missed it)
+            // Waiting transition
             if w.phase == WorkerPhase::Waiting
                 && prev.is_some_and(|p| p.phase != WorkerPhase::Waiting)
             {
                 signals.push(
                     SignalUpdate::new(
-                        "swarm",
+                        "swarm_worker_waiting",
                         format!("swarm-waiting-{id}"),
                         format!("Worker waiting: {id}"),
                         Severity::Warning,
@@ -540,21 +283,18 @@ impl SwarmWatcher {
                 );
             }
 
-            // Completed/Failed transition (from ListWorkers, in case subscription missed it)
+            // Completed/Failed transition
             if w.phase.is_terminal() && prev.is_some_and(|p| !p.phase.is_terminal()) {
-                signals.push(
-                    SignalUpdate::new(
-                        "swarm",
-                        format!("swarm-completed-{id}"),
-                        format!("Worker completed: {id}"),
-                        Severity::Info,
-                    )
-                    .with_body(format!("Worker {id} has completed")),
-                );
+                signals.push(SignalUpdate::new(
+                    "swarm_worker_closed",
+                    format!("swarm-completed-{id}"),
+                    format!("Worker completed: {id}"),
+                    Severity::Info,
+                ));
             }
 
-            // Compute new running_count (incremented if transitioning into Running)
-            let new_running_count = {
+            // Update tracked state
+            let running_count = {
                 let prev_count = prev.map_or(0, |p| p.running_count);
                 if w.phase == WorkerPhase::Running
                     && prev.is_some_and(|p| p.phase != WorkerPhase::Running)
@@ -565,21 +305,19 @@ impl SwarmWatcher {
                     prev_count
                 }
             };
-
-            // Update tracked state
             self.tracked.insert(
                 id.clone(),
                 TrackedWorker {
                     phase: w.phase.clone(),
                     has_pr,
-                    ready_branch: ready_branch.clone(),
+                    ready_branch,
                     role: w.role.clone(),
-                    running_count: new_running_count,
+                    running_count,
                 },
             );
         }
 
-        // Detect closed worktrees — resolve all related signals
+        // Detect closed workers
         let current_ids: std::collections::HashSet<&String> =
             workers.iter().map(|w| &w.id).collect();
         let closed: Vec<String> = self
@@ -590,18 +328,37 @@ impl SwarmWatcher {
             .collect();
 
         for id in &closed {
-            let role_str = self
+            let role = self
                 .tracked
                 .get(id)
                 .and_then(|t| t.role.as_deref())
                 .unwrap_or("worker");
 
-            for prefix in &[
+            // Resolve related signals (new source names)
+            for (source, prefix) in [
+                ("swarm_worker_spawned", "swarm-spawned"),
+                ("swarm_worker_waiting", "swarm-waiting"),
+                ("swarm_pr_opened", "swarm-pr"),
+                ("swarm_branch_ready", "swarm-branch-ready"),
+            ] {
+                signals.push(
+                    SignalUpdate::new(
+                        source,
+                        format!("{prefix}-{id}"),
+                        format!("Worker closed: {id}"),
+                        Severity::Info,
+                    )
+                    .with_status(SignalStatus::Resolved),
+                );
+            }
+            // Also resolve old "swarm" source signals for backward compat
+            for prefix in [
                 "swarm-spawned",
                 "swarm-waiting",
                 "swarm-pr",
                 "swarm-completed",
                 "swarm-branch-ready",
+                "swarm-closed",
             ] {
                 signals.push(
                     SignalUpdate::new(
@@ -613,18 +370,8 @@ impl SwarmWatcher {
                     .with_status(SignalStatus::Resolved),
                 );
             }
-            signals.push(
-                SignalUpdate::new(
-                    "swarm",
-                    format!("swarm-closed-{id}"),
-                    format!("Worker closed: {id}"),
-                    Severity::Info,
-                )
-                .with_status(SignalStatus::Resolved),
-            );
 
-            // Emit active swarm_worker_closed signal for the task engine to process
-            let metadata = serde_json::json!({"worker_id": id, "role": role_str}).to_string();
+            // Emit active closed signal
             signals.push(
                 SignalUpdate::new(
                     "swarm_worker_closed",
@@ -632,7 +379,7 @@ impl SwarmWatcher {
                     format!("Worker closed: {id}"),
                     Severity::Info,
                 )
-                .with_metadata(metadata),
+                .with_metadata(serde_json::json!({"worker_id": id, "role": role}).to_string()),
             );
 
             self.tracked.remove(id);
@@ -649,16 +396,13 @@ impl Watcher for SwarmWatcher {
     }
 
     async fn poll(&mut self, _store: &SignalStore) -> Result<Vec<SignalUpdate>> {
-        // Start the subscription task on first poll.
         self.ensure_subscription();
-
         let workers = match self.list_workers() {
             Some(w) => w,
             None => return Ok(Vec::new()),
         };
 
         if !self.initialized {
-            // First poll: record current state, don't emit
             let ready_branches = self.read_ready_branches();
             for w in &workers {
                 self.tracked.insert(
@@ -673,28 +417,17 @@ impl Watcher for SwarmWatcher {
                 );
             }
             self.initialized = true;
-            info!("swarm: initialized with {} worker(s)", workers.len());
-            // Drain and discard any subscription events from before initialization
             self.events.lock().unwrap().clear();
-            self.a2a_events.lock().unwrap().clear();
+            info!("swarm: initialized with {} worker(s)", workers.len());
             return Ok(Vec::new());
         }
 
         let mut signals = Vec::new();
-
-        // Process A2a events first — structured data and richer phase transitions
-        self.drain_a2a_events(&mut signals);
-
-        // Process StateChanged events — fallback phase transitions
         self.drain_events(&mut signals);
-
-        // Then diff the full worker list (PRs, new/closed workers)
         signals.extend(self.diff_workers(&workers));
-
         if !signals.is_empty() {
             info!("swarm: {} signal(s)", signals.len());
         }
-
         Ok(signals)
     }
 
@@ -702,7 +435,23 @@ impl Watcher for SwarmWatcher {
         if !self.initialized {
             return Ok(0);
         }
-        let current_ids: Vec<String> = self
+        let mut total = 0;
+        // Reconcile each signal source
+        for (source, prefix) in [
+            ("swarm_worker_spawned", "swarm-spawned"),
+            ("swarm_worker_waiting", "swarm-waiting"),
+            ("swarm_pr_opened", "swarm-pr"),
+            ("swarm_branch_ready", "swarm-branch-ready"),
+        ] {
+            let ids: Vec<String> = self
+                .tracked
+                .keys()
+                .map(|id| format!("{prefix}-{id}"))
+                .collect();
+            total += store.resolve_missing_signals(source, &ids)?;
+        }
+        // Also reconcile old "swarm" source for backward compat
+        let old_ids: Vec<String> = self
             .tracked
             .keys()
             .flat_map(|id| {
@@ -715,15 +464,14 @@ impl Watcher for SwarmWatcher {
                 ]
             })
             .collect();
-        let resolved = store.resolve_missing_signals("swarm", &current_ids)?;
-        if resolved > 0 {
-            info!("swarm: reconciled {resolved} stale signal(s)");
+        total += store.resolve_missing_signals("swarm", &old_ids)?;
+        if total > 0 {
+            info!("swarm: reconciled {total} stale signal(s)");
         }
-        Ok(resolved)
+        Ok(total)
     }
 }
 
-/// Truncate a prompt string for signal bodies.
 fn truncate_prompt(prompt: &str) -> &str {
     let end = prompt
         .char_indices()
@@ -732,20 +480,12 @@ fn truncate_prompt(prompt: &str) -> &str {
     &prompt[..end]
 }
 
-/// Background subscription loop — reconnects with backoff on disconnect.
-async fn subscription_loop(
-    work_dir: PathBuf,
-    events: Arc<Mutex<Vec<(String, WorkerPhase)>>>,
-    a2a_events: Arc<Mutex<Vec<A2aEvent>>>,
-) {
+/// Background subscription loop — reconnects with backoff.
+async fn subscription_loop(work_dir: PathBuf, events: Arc<Mutex<Vec<(String, WorkerPhase)>>>) {
     let mut backoff_secs = 1u64;
-
     loop {
-        match connect_and_subscribe(&work_dir, &events, &a2a_events).await {
-            Ok(()) => {
-                // Clean disconnect — reset backoff
-                backoff_secs = 1;
-            }
+        match connect_and_subscribe(&work_dir, &events).await {
+            Ok(()) => backoff_secs = 1,
             Err(e) => {
                 tracing::debug!("swarm subscription error: {e}");
                 backoff_secs = (backoff_secs * 2).min(60);
@@ -756,20 +496,15 @@ async fn subscription_loop(
 }
 
 /// Connect to the daemon socket and subscribe to state change events.
-///
-/// Handles both `StateChanged` (existing) and `A2aTaskUpdate` (new) events.
-/// Uses JSON value parsing so it gracefully ignores unknown variants.
 async fn connect_and_subscribe(
     work_dir: &Path,
     events: &Mutex<Vec<(String, WorkerPhase)>>,
-    a2a_events: &Mutex<Vec<A2aEvent>>,
 ) -> Result<()> {
     use tokio::{
         io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
         net::UnixStream,
     };
 
-    // Try per-workspace socket first, then global
     let local = socket_path(work_dir);
     let global = global_socket_path();
     let stream = if local.exists() {
@@ -780,8 +515,6 @@ async fn connect_and_subscribe(
     .map_err(|e| color_eyre::eyre::eyre!("failed to connect to daemon: {e}"))?;
 
     let (reader, mut writer) = stream.into_split();
-
-    // Send Subscribe request
     let req = DaemonRequest::Subscribe {
         worktree_id: None,
         workspace: Some(work_dir.to_path_buf()),
@@ -790,369 +523,35 @@ async fn connect_and_subscribe(
     line.push('\n');
     writer.write_all(line.as_bytes()).await?;
 
-    // Read events — parse as Value to handle both known and future variants
     let mut reader = BufReader::new(reader);
     let mut buf = String::new();
     loop {
         buf.clear();
-        let n = reader.read_line(&mut buf).await?;
-        if n == 0 {
-            break; // EOF — daemon disconnected
+        if reader.read_line(&mut buf).await? == 0 {
+            break;
         }
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(buf.trim()) {
-            match val.get("kind").and_then(|k| k.as_str()) {
-                Some("state_changed") => {
-                    if let Some(worktree_id) = val
-                        .get("worktree_id")
-                        .and_then(|v| v.as_str())
-                        .map(String::from)
-                        && let Some(phase) = val
-                            .get("phase")
-                            .and_then(|v| serde_json::from_value(v.clone()).ok())
-                    {
-                        events.lock().unwrap().push((worktree_id, phase));
-                    }
-                }
-                Some("a2a_task_update") => {
-                    if let Some(worktree_id) = val
-                        .get("worktree_id")
-                        .and_then(|v| v.as_str())
-                        .map(String::from)
-                        && let Some(task_state) = val
-                            .get("task_state")
-                            .and_then(|v| serde_json::from_value(v.clone()).ok())
-                    {
-                        let message = val.get("message").cloned();
-                        let timestamp = val
-                            .get("timestamp")
-                            .and_then(|t| serde_json::from_value(t.clone()).ok())
-                            .unwrap_or_else(Utc::now);
-                        a2a_events.lock().unwrap().push(A2aEvent {
-                            worktree_id,
-                            task_state,
-                            message,
-                            timestamp,
-                        });
-                    }
-                }
-                _ => {}
-            }
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(buf.trim())
+            && val.get("kind").and_then(|k| k.as_str()) == Some("state_changed")
+            && let (Some(wt_id), Some(phase)) = (
+                val.get("worktree_id")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                val.get("phase")
+                    .and_then(|v| serde_json::from_value(v.clone()).ok()),
+            )
+        {
+            events.lock().unwrap().push((wt_id, phase));
         }
     }
-
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use apiari_swarm::core::state::{SwarmState, WorkerPhase};
+    use apiari_swarm::core::state::SwarmState;
 
     use super::*;
 
-    /// Helper to build a minimal valid WorktreeState JSON object.
-    fn wt_json(id: &str, extras: &str) -> String {
-        let base = format!(
-            r#"{{
-                "id": "{id}",
-                "branch": "swarm/{id}",
-                "prompt": "test task",
-                "agent_kind": "claude",
-                "repo_path": "/tmp/myrepo",
-                "worktree_path": "/tmp/.swarm/wt/{id}",
-                "created_at": "2026-01-01T00:00:00-05:00"
-            }}"#
-        );
-        if extras.is_empty() {
-            return base;
-        }
-        // Insert extras before the closing brace
-        let trimmed = base.trim_end();
-        format!("{},\n{extras}\n}}", &trimmed[..trimmed.len() - 1])
-    }
-
-    /// Build a state.json string from a list of worktree JSON objects.
-    fn state_json(worktrees: &[String]) -> String {
-        format!(
-            r#"{{"session_name": "test", "worktrees": [{}]}}"#,
-            worktrees.join(",")
-        )
-    }
-
-    #[test]
-    fn test_parse_swarm_state() {
-        let wt = wt_json(
-            "hive-1",
-            r#""summary": "Fix a bug",
-                "pr": {"number": 1, "title": "Fix bug", "state": "OPEN", "url": "https://github.com/org/repo/pull/1"},
-                "phase": "running""#,
-        );
-        let json = state_json(&[wt]);
-        let state: SwarmState = serde_json::from_str(&json).unwrap();
-        assert_eq!(state.worktrees.len(), 1);
-        let wt = &state.worktrees[0];
-        assert_eq!(wt.id, "hive-1");
-        assert!(wt.pr.is_some());
-    }
-
-    #[test]
-    fn test_parse_empty_state() {
-        let json = r#"{"session_name": "test", "worktrees": []}"#;
-        let state: SwarmState = serde_json::from_str(&json).unwrap();
-        assert!(state.worktrees.is_empty());
-    }
-
-    #[test]
-    fn test_parse_state_missing_optional_fields() {
-        let wt = wt_json("wt-1", "");
-        let json = state_json(&[wt]);
-        let state: SwarmState = serde_json::from_str(&json).unwrap();
-        let wt = &state.worktrees[0];
-        assert!(wt.pr.is_none());
-        assert_eq!(wt.phase, WorkerPhase::Running); // default
-    }
-
-    /// Parse a real state.json snapshot from swarm to guard against format drift.
-    #[test]
-    fn test_parse_real_state_snapshot() {
-        let json = r#"{
-          "session_name": "swarm-apiari",
-          "sidebar_pane_id": null,
-          "worktrees": [
-            {
-              "id": "swarm-042c",
-              "branch": "swarm/fix-ci-failure-042c",
-              "prompt": "Fix CI failure",
-              "agent_kind": "claude",
-              "repo_path": "/home/user/project/swarm",
-              "worktree_path": "/home/user/project/.swarm/wt/swarm-042c",
-              "created_at": "2026-03-13T11:51:21.270284-05:00",
-              "agent": null,
-              "terminals": [],
-              "summary": null,
-              "pr": {
-                "number": 64,
-                "title": "fix(ci): add apiari-tui to workspace",
-                "state": "OPEN",
-                "url": "https://github.com/ApiariTools/swarm/pull/64"
-              },
-              "phase": "waiting",
-              "status": "running",
-              "agent_session_status": "waiting",
-              "agent_pid": null,
-              "session_id": "c9dba914-a879-4e7d-866f-35d88089bdfd",
-              "restart_count": 0
-            }
-          ],
-          "last_inbox_pos": 0
-        }"#;
-
-        let state: SwarmState = serde_json::from_str(json).unwrap();
-        assert_eq!(state.worktrees.len(), 1);
-
-        let wt = &state.worktrees[0];
-        assert_eq!(wt.id, "swarm-042c");
-        assert_eq!(wt.phase, WorkerPhase::Waiting);
-
-        let pr = wt.pr.as_ref().unwrap();
-        assert_eq!(pr.url, "https://github.com/ApiariTools/swarm/pull/64");
-        assert_eq!(pr.title, "fix(ci): add apiari-tui to workspace");
-    }
-
-    /// Test the diff_workers logic by feeding WorkerInfo directly.
-    #[test]
-    fn test_diff_workers_new_worker() {
-        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
-        watcher.initialized = true;
-
-        let workers = vec![make_worker("w1", WorkerPhase::Running, None)];
-        let signals = watcher.diff_workers(&workers);
-        assert_eq!(signals.len(), 1);
-        assert!(signals[0].title.contains("spawned"));
-    }
-
-    #[test]
-    fn test_diff_workers_pr_opened() {
-        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
-        watcher.initialized = true;
-        watcher.tracked.insert(
-            "w1".to_string(),
-            TrackedWorker {
-                phase: WorkerPhase::Running,
-                has_pr: false,
-                ready_branch: None,
-                role: None,
-                running_count: 1,
-            },
-        );
-
-        let workers = vec![make_worker(
-            "w1",
-            WorkerPhase::Running,
-            Some("https://github.com/org/repo/pull/1"),
-        )];
-        let signals = watcher.diff_workers(&workers);
-        assert_eq!(signals.len(), 1);
-        assert!(signals[0].title.contains("PR opened"));
-        assert_eq!(
-            signals[0].url.as_deref(),
-            Some("https://github.com/org/repo/pull/1")
-        );
-    }
-
-    #[test]
-    fn test_diff_workers_waiting_transition() {
-        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
-        watcher.initialized = true;
-        watcher.tracked.insert(
-            "w1".to_string(),
-            TrackedWorker {
-                phase: WorkerPhase::Running,
-                has_pr: false,
-                ready_branch: None,
-                role: None,
-                running_count: 1,
-            },
-        );
-
-        let workers = vec![make_worker("w1", WorkerPhase::Waiting, None)];
-        let signals = watcher.diff_workers(&workers);
-        assert_eq!(signals.len(), 1);
-        assert!(signals[0].title.contains("waiting"));
-    }
-
-    #[test]
-    fn test_diff_workers_closed() {
-        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
-        watcher.initialized = true;
-        watcher.tracked.insert(
-            "w1".to_string(),
-            TrackedWorker {
-                phase: WorkerPhase::Running,
-                has_pr: false,
-                ready_branch: None,
-                role: None,
-                running_count: 1,
-            },
-        );
-
-        let workers = vec![]; // w1 is gone
-        let signals = watcher.diff_workers(&workers);
-        // 5 resolved (spawned/waiting/pr/completed/branch-ready) + 1 old closed + 1 swarm_worker_closed
-        assert_eq!(signals.len(), 7);
-        assert!(signals.iter().all(|s| s.title.contains("closed")));
-    }
-
-    #[test]
-    fn test_diff_workers_no_change() {
-        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
-        watcher.initialized = true;
-        watcher.tracked.insert(
-            "w1".to_string(),
-            TrackedWorker {
-                phase: WorkerPhase::Running,
-                has_pr: false,
-                ready_branch: None,
-                role: None,
-                running_count: 1,
-            },
-        );
-
-        let workers = vec![make_worker("w1", WorkerPhase::Running, None)];
-        let signals = watcher.diff_workers(&workers);
-        assert!(signals.is_empty(), "no transition = no signals");
-    }
-
-    #[test]
-    fn test_diff_workers_running_transition_emits_signal() {
-        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
-        watcher.initialized = true;
-        watcher.tracked.insert(
-            "w1".to_string(),
-            TrackedWorker {
-                phase: WorkerPhase::Waiting,
-                has_pr: false,
-                ready_branch: None,
-                role: None,
-                running_count: 1,
-            },
-        );
-
-        let workers = vec![make_worker("w1", WorkerPhase::Running, None)];
-        let signals = watcher.diff_workers(&workers);
-        assert_eq!(signals.len(), 1);
-        assert_eq!(signals[0].source, "swarm_worker_running");
-        assert!(signals[0].title.contains("running"));
-        assert!(
-            signals[0]
-                .metadata
-                .as_deref()
-                .unwrap_or("")
-                .contains("worker_id")
-        );
-    }
-
-    #[test]
-    fn test_diff_workers_running_transition_reviewer_no_signal() {
-        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
-        watcher.initialized = true;
-        watcher.tracked.insert(
-            "r1".to_string(),
-            TrackedWorker {
-                phase: WorkerPhase::Waiting,
-                has_pr: false,
-                ready_branch: None,
-                role: Some("reviewer".to_string()),
-                running_count: 0,
-            },
-        );
-
-        let mut reviewer = make_worker("r1", WorkerPhase::Running, None);
-        reviewer.role = Some("reviewer".to_string());
-        let signals = watcher.diff_workers(&[reviewer]);
-        assert!(
-            signals.is_empty(),
-            "reviewer running transition should not emit swarm_worker_running"
-        );
-    }
-
-    #[test]
-    fn test_diff_workers_closed_emits_worker_closed_signal() {
-        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
-        watcher.initialized = true;
-        watcher.tracked.insert(
-            "w1".to_string(),
-            TrackedWorker {
-                phase: WorkerPhase::Running,
-                has_pr: false,
-                ready_branch: None,
-                role: None,
-                running_count: 1,
-            },
-        );
-
-        let workers = vec![]; // w1 is gone
-        let signals = watcher.diff_workers(&workers);
-        let closed_signal = signals
-            .iter()
-            .find(|s| s.source == "swarm_worker_closed")
-            .expect("swarm_worker_closed signal should be emitted");
-        assert!(
-            closed_signal
-                .metadata
-                .as_deref()
-                .unwrap_or("")
-                .contains("worker_id")
-        );
-        assert!(
-            closed_signal
-                .metadata
-                .as_deref()
-                .unwrap_or("")
-                .contains("role")
-        );
-    }
-
-    /// Helper to build a WorkerInfo for testing.
     fn make_worker(id: &str, phase: WorkerPhase, pr_url: Option<&str>) -> WorkerInfo {
         WorkerInfo {
             id: id.to_string(),
@@ -1173,59 +572,126 @@ mod tests {
         }
     }
 
-    /// Test that a branch-ready transition emits a swarm_branch_ready signal.
-    #[test]
-    fn test_diff_workers_branch_ready() {
-        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
-        watcher.initialized = true;
-        watcher.tracked.insert(
-            "w1".to_string(),
-            TrackedWorker {
-                phase: WorkerPhase::Running,
-                has_pr: false,
-                ready_branch: None,
-                role: None,
-                running_count: 1,
-            },
-        );
+    fn tracked(phase: WorkerPhase, has_pr: bool, role: Option<&str>) -> TrackedWorker {
+        TrackedWorker {
+            phase,
+            has_pr,
+            ready_branch: None,
+            role: role.map(String::from),
+            running_count: 1,
+        }
+    }
 
-        // The watcher reads state.json to get ready_branch — we can't inject that
-        // in a unit test without a real file, so test the signal emission logic by
-        // manually calling diff_workers (which reads ready_branches from state.json,
-        // returning an empty map since /tmp/test/.swarm/state.json doesn't exist).
-        // The transition won't fire without state.json, but we verify the base case.
-        let workers = vec![make_worker("w1", WorkerPhase::Running, None)];
-        let signals = watcher.diff_workers(&workers);
-        // No state.json → no ready_branch → no signal
-        assert!(
-            signals.is_empty(),
-            "no state.json means no branch-ready signal"
+    #[test]
+    fn test_diff_new_worker_emits_spawned() {
+        let mut w = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        w.initialized = true;
+        let signals = w.diff_workers(&[make_worker("w1", WorkerPhase::Running, None)]);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].source, "swarm_worker_spawned");
+    }
+
+    #[test]
+    fn test_diff_pr_opened() {
+        let mut w = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        w.initialized = true;
+        w.tracked
+            .insert("w1".into(), tracked(WorkerPhase::Running, false, None));
+        let signals = w.diff_workers(&[make_worker(
+            "w1",
+            WorkerPhase::Running,
+            Some("https://github.com/org/repo/pull/1"),
+        )]);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].source, "swarm_pr_opened");
+        assert_eq!(
+            signals[0].url.as_deref(),
+            Some("https://github.com/org/repo/pull/1")
         );
     }
 
-    /// Test that a second poll with the same ready_branch does not re-emit.
     #[test]
-    fn test_diff_workers_branch_ready_no_duplicate() {
-        let mut watcher = SwarmWatcher::new(PathBuf::from("/tmp/test"));
-        watcher.initialized = true;
-        // Already tracked with ready_branch set
-        watcher.tracked.insert(
-            "w1".to_string(),
-            TrackedWorker {
-                phase: WorkerPhase::Running,
-                has_pr: false,
-                ready_branch: Some("swarm/my-feature".to_string()),
-                role: None,
-                running_count: 1,
-            },
-        );
+    fn test_diff_running_transition() {
+        let mut w = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        w.initialized = true;
+        w.tracked
+            .insert("w1".into(), tracked(WorkerPhase::Waiting, false, None));
+        let signals = w.diff_workers(&[make_worker("w1", WorkerPhase::Running, None)]);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].source, "swarm_worker_running");
+    }
 
-        let workers = vec![make_worker("w1", WorkerPhase::Running, None)];
-        let signals = watcher.diff_workers(&workers);
-        // ready_branch was already tracked → no re-emission (even without state.json)
+    #[test]
+    fn test_diff_waiting_transition() {
+        let mut w = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        w.initialized = true;
+        w.tracked
+            .insert("w1".into(), tracked(WorkerPhase::Running, false, None));
+        let signals = w.diff_workers(&[make_worker("w1", WorkerPhase::Waiting, None)]);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].source, "swarm_worker_waiting");
+    }
+
+    #[test]
+    fn test_diff_closed_worker() {
+        let mut w = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        w.initialized = true;
+        w.tracked
+            .insert("w1".into(), tracked(WorkerPhase::Running, false, None));
+        let signals = w.diff_workers(&[]); // w1 is gone
+        let closed = signals
+            .iter()
+            .find(|s| s.source == "swarm_worker_closed" && s.status == SignalStatus::Open);
+        assert!(closed.is_some(), "should emit swarm_worker_closed");
+        assert!(
+            closed
+                .unwrap()
+                .metadata
+                .as_deref()
+                .unwrap_or("")
+                .contains("worker_id")
+        );
+    }
+
+    #[test]
+    fn test_diff_no_change() {
+        let mut w = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        w.initialized = true;
+        w.tracked
+            .insert("w1".into(), tracked(WorkerPhase::Running, false, None));
+        let signals = w.diff_workers(&[make_worker("w1", WorkerPhase::Running, None)]);
+        assert!(signals.is_empty());
+    }
+
+    #[test]
+    fn test_reviewer_running_no_signal() {
+        let mut w = SwarmWatcher::new(PathBuf::from("/tmp/test"));
+        w.initialized = true;
+        w.tracked.insert(
+            "r1".into(),
+            tracked(WorkerPhase::Waiting, false, Some("reviewer")),
+        );
+        let mut reviewer = make_worker("r1", WorkerPhase::Running, None);
+        reviewer.role = Some("reviewer".to_string());
+        let signals = w.diff_workers(&[reviewer]);
         assert!(
             signals.is_empty(),
-            "already-tracked ready_branch must not re-emit"
+            "reviewer running transition should not emit swarm_worker_running"
         );
+    }
+
+    #[test]
+    fn test_parse_swarm_state() {
+        let json = r#"{"session_name": "test", "worktrees": [{
+            "id": "w1", "branch": "swarm/w1", "prompt": "test",
+            "agent_kind": "claude", "repo_path": "/tmp/repo",
+            "worktree_path": "/tmp/.swarm/wt/w1",
+            "created_at": "2026-01-01T00:00:00-05:00",
+            "phase": "running",
+            "pr": {"number": 1, "title": "Fix", "state": "OPEN", "url": "https://github.com/org/repo/pull/1"}
+        }]}"#;
+        let state: SwarmState = serde_json::from_str(json).unwrap();
+        assert_eq!(state.worktrees.len(), 1);
+        assert!(state.worktrees[0].pr.is_some());
     }
 }

--- a/crates/apiari/src/daemon/mod.rs
+++ b/crates/apiari/src/daemon/mod.rs
@@ -1649,6 +1649,16 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                         // Collect matched actions for follow-through dispatch
                                                         orchestrator_matched_actions.extend(orch_result.matched_actions);
 
+                                                        // Execute workflow actions (system PR creation, reviewer dispatch, etc.)
+                                                        for wf_action in &orch_result.workflow_actions {
+                                                            execute_workflow_action(
+                                                                wf_action,
+                                                                &slot.config.root,
+                                                                slot.store.db_path(),
+                                                                &slot.name,
+                                                            );
+                                                        }
+
                                                         let engine_result = orch_result.engine_result;
                                                         for (worker_id, message) in engine_result.worker_messages {
                                                             info!("[task-engine] forwarding to worker {worker_id}: {message}");
@@ -1719,7 +1729,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                             }
 
                                             // Create task for new swarm workers (skip reviewer workers)
-                                            if is_new && update.source == "swarm" && update.external_id.starts_with("swarm-spawned-") {
+                                            if is_new && (update.source == "swarm_worker_spawned" || (update.source == "swarm" && update.external_id.starts_with("swarm-spawned-"))) {
                                                 let worker_id = update.external_id.strip_prefix("swarm-spawned-").unwrap_or("").to_string();
                                                 let is_reviewer = update.body.as_ref()
                                                     .and_then(|b| b.lines().nth(1))
@@ -1788,7 +1798,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                             }
 
                                             // Update task when worker opens a PR
-                                            if is_new && update.source == "swarm" && update.external_id.starts_with("swarm-pr-") {
+                                            if is_new && (update.source == "swarm_pr_opened" || (update.source == "swarm" && update.external_id.starts_with("swarm-pr-"))) {
                                                 let worker_id = update.external_id.strip_prefix("swarm-pr-").unwrap_or("").to_string();
                                                 if !worker_id.is_empty()
                                                     && let Ok(task_store) = crate::buzz::task::store::TaskStore::open(slot.store.db_path())
@@ -1856,7 +1866,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                             }
 
                                             // Dispatch reviewer worker when task enters InAiReview
-                                            if is_new && update.source == "swarm" && update.external_id.starts_with("swarm-pr-") {
+                                            if is_new && (update.source == "swarm_pr_opened" || (update.source == "swarm" && update.external_id.starts_with("swarm-pr-"))) {
                                                 let worker_id = update.external_id.strip_prefix("swarm-pr-").unwrap_or("").to_string();
                                                 if !worker_id.is_empty()
                                                     && let Ok(task_store) = crate::buzz::task::store::TaskStore::open(slot.store.db_path())
@@ -1915,7 +1925,7 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                             }
 
                                             // Auto-close the worker that opened the PR — it has delivered its work
-                                            if is_new && update.source == "swarm" && update.external_id.starts_with("swarm-pr-") {
+                                            if is_new && (update.source == "swarm_pr_opened" || (update.source == "swarm" && update.external_id.starts_with("swarm-pr-"))) {
                                                 let worker_id = update.external_id.strip_prefix("swarm-pr-").unwrap_or("").to_string();
                                                 if !worker_id.is_empty() {
                                                     let swarm_for_close = crate::buzz::coordinator::swarm_client::SwarmClient::new(slot.config.root.clone());
@@ -2020,8 +2030,10 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                             }
 
                                             // Process reviewer worker completion — emit verdict signal
-                                            if is_new && update.source == "swarm" && update.external_id.starts_with("swarm-completed-") {
-                                                let worker_id = update.external_id.strip_prefix("swarm-completed-").unwrap_or("").to_string();
+                                            if is_new && (update.source == "swarm_worker_closed" || (update.source == "swarm" && update.external_id.starts_with("swarm-completed-"))) {
+                                                let worker_id = update.external_id.strip_prefix("swarm-completed-")
+                                                    .or_else(|| update.external_id.strip_prefix("swarm-worker-closed-"))
+                                                    .unwrap_or("").to_string();
                                                 if !worker_id.is_empty()
                                                     && let Ok(task_store) = crate::buzz::task::store::TaskStore::open(slot.store.db_path())
                                                         && let Ok(Some(task)) = task_store.find_task_by_reviewer_worker(&slot.name, &worker_id)
@@ -2143,24 +2155,60 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                                                                     }
                                                                                 }
 
-                                                                                // Branch-first flow: after approval, tell the original worker to open a PR
-                                                                                if verdict == "APPROVED"
-                                                                                    && is_branch_flow
-                                                                                    && let Some(ref original_worker_id) = task.worker_id
-                                                                                {
-                                                                                    let task_title = task.title.clone();
-                                                                                    let swarm = crate::buzz::coordinator::swarm_client::SwarmClient::new(slot.config.root.clone());
-                                                                                    let wid = original_worker_id.clone();
-                                                                                    tokio::spawn(async move {
-                                                                                        let msg = format!(
-                                                                                            "Your code was approved by the reviewer. Please run: `gh pr create --title '{task_title}' --body 'Approved by AI reviewer'`"
-                                                                                        );
-                                                                                        if let Err(e) = swarm.send_message(&wid, &msg).await {
-                                                                                            tracing::warn!("[task-engine] failed to send PR-open message to worker {wid}: {e}");
-                                                                                        } else {
-                                                                                            info!("[task-engine] told worker {wid} to open PR for task '{task_title}'");
-                                                                                        }
-                                                                                    });
+                                                                                // Branch-first flow: after approval, system creates the PR
+                                                                                if verdict == "APPROVED" && is_branch_flow {
+                                                                                    let ready_branch = task.metadata
+                                                                                        .get("ready_branch")
+                                                                                        .and_then(|v| v.as_str())
+                                                                                        .unwrap_or("")
+                                                                                        .to_string();
+                                                                                    if !ready_branch.is_empty() {
+                                                                                        let task_id = task.id.clone();
+                                                                                        let task_title = task.title.clone();
+                                                                                        let work_dir = slot.config.root.clone();
+                                                                                        let db_path = slot.store.db_path().to_path_buf();
+                                                                                        let ws_name_pr = slot.name.clone();
+                                                                                        tokio::spawn(async move {
+                                                                                            match crate::buzz::orchestrator::workflow::create_system_pr(
+                                                                                                &work_dir, &ready_branch, &task_title, "Approved by AI reviewer",
+                                                                                            ).await {
+                                                                                                Ok(pr_result) => {
+                                                                                                    info!("[workflow] system PR created for task '{}': {}", task_title, pr_result.pr_url);
+                                                                                                    if let Ok(ts) = crate::buzz::task::store::TaskStore::open(&db_path) {
+                                                                                                        if let Some(num) = pr_result.pr_number {
+                                                                                                            let _ = ts.update_task_pr(&task_id, &pr_result.pr_url, num);
+                                                                                                        }
+                                                                                                        let _ = ts.transition_task(
+                                                                                                            &task_id,
+                                                                                                            &crate::buzz::task::TaskStage::InAiReview,
+                                                                                                            &crate::buzz::task::TaskStage::HumanReview,
+                                                                                                            Some("System PR created after review approval".to_string()),
+                                                                                                        );
+                                                                                                    }
+                                                                                                    // Emit swarm_pr_opened signal
+                                                                                                    if let Ok(ss) = crate::buzz::signal::store::SignalStore::open(&db_path, &ws_name_pr) {
+                                                                                                        let pr_signal = crate::buzz::signal::SignalUpdate::new(
+                                                                                                            "swarm_pr_opened",
+                                                                                                            format!("swarm-system-pr-{task_id}"),
+                                                                                                            format!("System PR created: {}", pr_result.pr_url),
+                                                                                                            crate::buzz::signal::Severity::Info,
+                                                                                                        )
+                                                                                                        .with_url(&pr_result.pr_url)
+                                                                                                        .with_metadata(serde_json::json!({
+                                                                                                            "pr_url": pr_result.pr_url,
+                                                                                                            "pr_number": pr_result.pr_number,
+                                                                                                            "task_id": task_id,
+                                                                                                            "system_created": true,
+                                                                                                        }).to_string());
+                                                                                                        let _ = ss.upsert_signal(&pr_signal);
+                                                                                                    }
+                                                                                                }
+                                                                                                Err(e) => {
+                                                                                                    tracing::warn!("[workflow] system PR creation failed for task '{}': {e}", task_title);
+                                                                                                }
+                                                                                            }
+                                                                                        });
+                                                                                    }
                                                                                 }
 
                                                                                 // Auto-close the reviewer worker — it has delivered its verdict
@@ -2191,8 +2239,10 @@ async fn run_event_loop(workspaces: Vec<Workspace>) -> ExitReason {
                                             }
 
                                             // Handle worker closed — dismiss task if no PR was merged
-                                            if is_new && update.source == "swarm" && update.external_id.starts_with("swarm-closed-") {
-                                                let worker_id = update.external_id.strip_prefix("swarm-closed-").unwrap_or("").to_string();
+                                            if is_new && (update.source == "swarm_worker_closed" || (update.source == "swarm" && update.external_id.starts_with("swarm-closed-"))) {
+                                                let worker_id = update.external_id.strip_prefix("swarm-closed-")
+                                                    .or_else(|| update.external_id.strip_prefix("swarm-worker-closed-"))
+                                                    .unwrap_or("").to_string();
                                                 if !worker_id.is_empty()
                                                     && let Ok(task_store) = crate::buzz::task::store::TaskStore::open(slot.store.db_path())
                                                         && let Ok(Some(task)) = task_store.find_task_by_worker(&slot.name, &worker_id)
@@ -3924,6 +3974,162 @@ async fn run_reinstall(workspace_root: &std::path::Path) -> (String, bool) {
 /// `claude-tui` workers are interactive and must stay alive.
 fn should_auto_close_pr_worker(worker: &apiari_swarm::daemon::protocol::WorkerInfo) -> bool {
     worker.phase == apiari_swarm::WorkerPhase::Waiting && worker.agent == "claude"
+}
+
+/// Execute a workflow action produced by the orchestrator.
+///
+/// Spawns async tasks for PR creation, reviewer dispatch, and rework dispatch.
+/// This is the execution layer for the orchestrator's workflow engine.
+fn execute_workflow_action(
+    action: &crate::buzz::orchestrator::workflow::WorkflowAction,
+    work_dir: &std::path::Path,
+    db_path: &std::path::Path,
+    _workspace_name: &str,
+) {
+    use crate::buzz::orchestrator::workflow::WorkflowAction;
+
+    match action {
+        WorkflowAction::CreatePr {
+            task_id,
+            branch_name,
+        }
+        | WorkflowAction::ForceCreatePr {
+            task_id,
+            branch_name,
+            ..
+        } => {
+            let task_id = task_id.clone();
+            let branch_name = branch_name.clone();
+            let work_dir = work_dir.to_path_buf();
+            let db_path = db_path.to_path_buf();
+
+            // Look up task title for the PR
+            let title = crate::buzz::task::store::TaskStore::open(&db_path)
+                .ok()
+                .and_then(|ts| ts.get_task(&task_id).ok().flatten())
+                .map(|t| t.title.clone())
+                .unwrap_or_else(|| format!("PR for {branch_name}"));
+
+            let is_forced = matches!(action, WorkflowAction::ForceCreatePr { .. });
+            let body = if is_forced {
+                "Created by apiari orchestrator (max review cycles exceeded)".to_string()
+            } else {
+                "Created by apiari orchestrator".to_string()
+            };
+
+            tokio::spawn(async move {
+                match crate::buzz::orchestrator::workflow::create_system_pr(
+                    &work_dir,
+                    &branch_name,
+                    &title,
+                    &body,
+                )
+                .await
+                {
+                    Ok(pr_result) => {
+                        tracing::info!(
+                            "[workflow] system PR created for task {task_id}: {}",
+                            pr_result.pr_url
+                        );
+                        if let Ok(ts) = crate::buzz::task::store::TaskStore::open(&db_path) {
+                            if let Some(num) = pr_result.pr_number {
+                                let _ = ts.update_task_pr(&task_id, &pr_result.pr_url, num);
+                            }
+                            let _ = ts.transition_task(
+                                &task_id,
+                                &crate::buzz::task::TaskStage::InAiReview,
+                                &crate::buzz::task::TaskStage::HumanReview,
+                                Some("System PR created".to_string()),
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "[workflow] system PR creation failed for task {task_id}: {e}"
+                        );
+                    }
+                }
+            });
+        }
+        WorkflowAction::DispatchReviewer {
+            task_id,
+            branch_name,
+            worker_id: _,
+        } => {
+            let task_id = task_id.clone();
+            let branch_name = branch_name.clone();
+            let work_dir = work_dir.to_path_buf();
+            let db_path = db_path.to_path_buf();
+
+            // Derive short repo name from branch or work_dir
+            let short_repo = work_dir
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or("repo")
+                .to_string();
+
+            let swarm = crate::buzz::coordinator::swarm_client::SwarmClient::new(work_dir.clone());
+            tokio::spawn(async move {
+                match swarm
+                    .create_reviewer_worker_for_branch(&short_repo, &branch_name)
+                    .await
+                {
+                    Ok(reviewer_id) if !reviewer_id.is_empty() => {
+                        tracing::info!(
+                            "[workflow] dispatched reviewer {reviewer_id} for task {task_id}"
+                        );
+                        if let Ok(ts) = crate::buzz::task::store::TaskStore::open(&db_path)
+                            && let Ok(Some(task)) = ts.get_task(&task_id)
+                        {
+                            let mut meta = task.metadata.clone();
+                            meta["reviewer_worker_id"] =
+                                serde_json::Value::String(reviewer_id.clone());
+                            meta["ready_branch"] = serde_json::Value::String(branch_name.clone());
+                            let _ = ts.update_task_metadata(&task_id, &meta);
+                        }
+                    }
+                    Ok(_) => {
+                        tracing::warn!(
+                            "[workflow] reviewer dispatch for task {task_id} returned empty id"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "[workflow] failed to dispatch reviewer for task {task_id}: {e}"
+                        );
+                    }
+                }
+            });
+        }
+        WorkflowAction::DispatchRework { task_id, feedback } => {
+            let task_id = task_id.clone();
+            let feedback = feedback.clone();
+            let db_path = db_path.to_path_buf();
+            let work_dir = work_dir.to_path_buf();
+
+            tokio::spawn(async move {
+                // Find the original worker and send feedback
+                if let Ok(ts) = crate::buzz::task::store::TaskStore::open(&db_path)
+                    && let Ok(Some(task)) = ts.get_task(&task_id)
+                    && let Some(ref worker_id) = task.worker_id
+                {
+                    let swarm = crate::buzz::coordinator::swarm_client::SwarmClient::new(work_dir);
+                    let msg = format!(
+                        "Review requested changes. Please address the feedback and push again:\n\n{feedback}"
+                    );
+                    if let Err(e) = swarm.send_message(worker_id, &msg).await {
+                        tracing::warn!(
+                            "[workflow] failed to send rework feedback to worker {worker_id}: {e}"
+                        );
+                    } else {
+                        tracing::info!(
+                            "[workflow] sent rework feedback to worker {worker_id} for task {task_id}"
+                        );
+                    }
+                }
+            });
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Phase 3 of the orchestrator rewrite (#220). Strips SwarmWatcher down to pure state-fetching and implements system-level PR creation in the orchestrator.

- **SwarmWatcher simplified** (1231 → 697 lines): proper signal source names (`swarm_worker_spawned`, `swarm_pr_opened`, etc.), removed A2a event handling, simplified subscription to phase transitions only
- **System PR creation**: `create_system_pr()` in workflow engine runs `gh pr create` as a subprocess — the system creates PRs, not the agent, making the workflow agent-agnostic
- **Workflow action execution**: daemon now processes `WorkflowAction` variants (CreatePr, DispatchReviewer, DispatchRework, ForceCreatePr) returned by the orchestrator
- **Signal source migration**: both old (`"swarm"` + external_id) and new (`"swarm_worker_spawned"`) source names supported for backward compatibility

Closes phase 3 of #220.

## Test plan

- [x] All 693 existing tests pass
- [x] New signal_kind classification tests cover all new source names + backward compat
- [x] SwarmWatcher diff tests verify correct signal sources (spawned, running, waiting, closed, PR opened)
- [x] cargo fmt + clippy clean
- [ ] Manual: verify signal flow with swarm workers (spawn → branch_ready → review → system PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)